### PR TITLE
[onert] Move updateWeight function to the CircleExporter

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -25,6 +25,7 @@
 #include "loader/ModelLoader.h"
 #include "loader/TFLiteLoader.h"
 #include "loader/TrainInfoLoader.h"
+#include "exporter/CircleExporter.h"
 #include "json/json.h"
 #include "ir/NNPkg.h"
 #include "ir/OpCode.h"
@@ -32,7 +33,6 @@
 #include "util/TracingCtx.h"
 #include "odc/QuantizeManager.h"
 #include "odc/CodegenManager.h"
-#include "circle_schema_generated.h"
 
 #include <fstream>
 #include <iostream>
@@ -41,10 +41,6 @@
 #include <dirent.h>
 #include <misc/string_helpers.h>
 
-#include <fcntl.h>    // O_RDONLY
-#include <sys/mman.h> // mmap, munmap
-#include <sys/stat.h> // fstat
-#include <unistd.h>   // close
 /*
  * API does not accept string argument longer than max length below
  */
@@ -1669,110 +1665,16 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
     return NNFW_STATUS_INVALID_STATE;
   }
 
-  class MMappedFile
-  {
-  public:
-    MMappedFile(const char *filename) { _fd = open(filename, O_RDWR); }
-
-    bool ensure_mmap()
-    {
-      struct stat file_stat;
-      if (fstat(_fd, &file_stat) != 0 || file_stat.st_size < 0 ||
-          static_cast<uint64_t>(file_stat.st_size) > SIZE_MAX)
-        return false;
-
-      _buf_sz = static_cast<size_t>(file_stat.st_size);
-      _buf = mmap(NULL, _buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0);
-      return _buf != MAP_FAILED;
-    }
-
-    bool sync() { return msync(_buf, _buf_sz, MS_SYNC) == 0; }
-
-    bool close()
-    {
-      bool ret = false;
-      if (_buf != MAP_FAILED)
-      {
-        ret = munmap(_buf, _buf_sz) == 0;
-        _buf = MAP_FAILED; // mark as cleaned up
-      }
-      if (_fd != -1)
-      {
-        ::close(_fd);
-        _fd = -1; // mark as cleaned up
-      }
-      return ret;
-    }
-
-    ~MMappedFile() { close(); }
-
-    uint8_t *buf() const { return static_cast<uint8_t *>(_buf); }
-    size_t buf_size() const { return _buf_sz; }
-
-  private:
-    int _fd;
-    void *_buf = MAP_FAILED;
-    size_t _buf_sz = 0;
-  };
-
-  std::ifstream src(_model_path, std::ios::binary);
-  std::ofstream dst(path, std::ios::binary);
-  dst << src.rdbuf();
-
-  MMappedFile mmapfile(path);
-  if (!mmapfile.ensure_mmap())
-    return NNFW_STATUS_ERROR;
-
-  // make sure the architecture is little endian before direct access to flatbuffers
-  assert(FLATBUFFERS_LITTLEENDIAN);
-
   try
   {
-    _execution->iterateTrainableTensors([&](const onert::ir::OperandIndex &idx,
-                                            const onert::backend::train::ITrainableTensor *tensor) {
-      auto model = ::circle::GetModel(mmapfile.buf());
-      if (!model)
-        throw std::runtime_error("Failed to get model from circle");
-
-      auto subgs = model->subgraphs();
-      if (!subgs || subgs->size() != 1)
-        throw std::runtime_error("Circle does not has valid subgraph or has multiple subgraphs");
-
-      auto subg = subgs->Get(0); // Get 1st subgraph
-      if (!idx.valid() || idx.value() >= subg->tensors()->size())
-        throw std::runtime_error("Trainable tensor index is out of range");
-
-      auto buf_idx = subg->tensors()->Get(idx.value())->buffer();
-      const ::circle::Buffer *buffer = (*model->buffers())[buf_idx];
-      if (!buffer || !buffer->data())
-        throw std::runtime_error("Buffer for trainable tensors is invalid");
-
-      const flatbuffers::Vector<uint8_t> *array = buffer->data();
-      if (!array)
-        throw std::runtime_error("Data for trainable tensor's buffer is invalid");
-
-      auto org_buf_sz = array->size();
-      if (org_buf_sz != tensor->total_size())
-        throw std::runtime_error("Trained tensor buffer size does not match original tensor's one");
-
-      uint8_t *org_buf = const_cast<uint8_t *>(array->Data());
-      if (!org_buf)
-        throw std::runtime_error("Data for trainable tensor's buffer is invalid");
-
-      memcpy(const_cast<uint8_t *>(org_buf), tensor->buffer(), org_buf_sz);
-    });
+    onert::exporter::CircleExporter exporter(_model_path, std::string{path});
+    exporter.updateWeight(_execution);
   }
   catch (const std::exception &e)
   {
     std::cerr << "Error during nnfw_session::train_export_circle : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-
-  if (mmapfile.sync() == false)
-    return NNFW_STATUS_ERROR;
-
-  if (mmapfile.close() == false)
-    return NNFW_STATUS_ERROR;
 
   return NNFW_STATUS_NO_ERROR;
 }

--- a/runtime/onert/core/include/exporter/CircleExporter.h
+++ b/runtime/onert/core/include/exporter/CircleExporter.h
@@ -21,6 +21,13 @@ namespace circle
 {
 struct ModelT;
 } // namespace circle
+namespace onert
+{
+namespace exec
+{
+class Execution;
+} // namespace exec
+} // namespace onert
 
 namespace onert
 {
@@ -31,6 +38,8 @@ class CircleExporter
 public:
   CircleExporter(const std::string &source, const std::string &path);
   ~CircleExporter();
+
+  void updateWeight(const std::unique_ptr<onert::exec::Execution> &exec);
 
 private:
   void finish();


### PR DESCRIPTION
This commit moves updateWeight function to the CircleExporter from nnfw_api_internal.cc file. It exports new circle file with updated weight data.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #13014 