### PR TITLE
[onert] Revisits CompilerOptions

### DIFF
--- a/runtime/onert/api/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/api/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -26,7 +26,7 @@ ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksMode
     _compiler{std::make_shared<compiler::Compiler>(_model, _coptions.get())}
 {
   if (model->allowedToFp16())
-    _coptions->enableToFp16();
+    _coptions->fp16_enable = true;
 }
 
 bool ANeuralNetworksCompilation::finish() noexcept

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -50,7 +50,7 @@ class TrainingInfo;
 namespace compiler
 {
 struct CompilerArtifact;
-class CompilerOptions;
+struct CompilerOptions;
 } // namespace compiler
 namespace odc
 {

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -32,18 +32,15 @@ namespace compiler
 
 struct ManualSchedulerOptions
 {
-public:
   void setBackendMap(const std::string &str);
 
-public:
   std::string backend_for_all;
   std::unordered_map<ir::OpCode, std::string> opcode_to_backend;
   std::unordered_map<ir::OperationIndex, std::string> index_to_backend;
 };
 
-class CompilerOptions
+struct CompilerOptions
 {
-public:
   /**
    * @brief   Set default values for CompilerOptions
    * @return  Generated CompileOption
@@ -52,11 +49,6 @@ public:
    *          when we stop supporting Android NNAPI.
    */
   static std::unique_ptr<CompilerOptions> fromGlobalConfig();
-
-  /**
-   * @brief Allow to compute float32 using float16 data type
-   */
-  void enableToFp16() { fp16_enable = true; }
 
   /**
    * @brief Force default values of CompilerOptions for correct compilations
@@ -71,7 +63,6 @@ public:
    */
   void verboseOptions();
 
-public:
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
   bool minmax_dump; //< Whether minmax dump is enabled or not


### PR DESCRIPTION
This commit updates CompilerOptions to remove meaningless method and public keyword, and change to struct.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>