### PR TITLE
[tools/onert_train] Add trainable ops support

### DIFF
--- a/tests/tools/onert_train/README.md
+++ b/tests/tools/onert_train/README.md
@@ -31,6 +31,7 @@ onert_train \
 --learning_rate 0.01 \   
 --loss 2 \                  # cateogrical crossentropy
 --loss_reduction_type 1     # sum over batch size
+--trainable_ops_idx 0-30    # indexes of operations which should be trained
 ```
 
 `onert_train --help` would help you to set each parameter.
@@ -79,6 +80,7 @@ If you start with tensorflow code, you could first save it as saved format and t
 Now you're ready to run `onert_train`. <br/>
 Please pass your model file to `--modelfile` and data files to `--load_input:raw` and `--load_expected:raw`. <br/>
 Also, you could set training parameter using options like `--batch_size`, `--epoch`.. etc.
+Please pay special attention for `trainable_ops_idx` to determine operations which should be trained.
 
 ```bash 
 $ onert_train \
@@ -91,4 +93,5 @@ $ onert_train \
 --learning_rate 0.001 \
 --loss 2 \               # cateogrical crossentropy
 --loss_reduction_type 1  # sum over batch size
+--trainable_ops_idx 0-10
 ```

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <set>
 #include <boost/program_options.hpp>
 
 #include "nnfw_experimental.h"
@@ -69,6 +70,7 @@ public:
   const bool printVersion(void) const { return _print_version; }
   const int getVerboseLevel(void) const { return _verbose_level; }
   std::unordered_map<uint32_t, uint32_t> getOutputSizes(void) const { return _output_sizes; }
+  std::set<uint32_t> getTrainableOpsIdx(void) const { return _trainable_ops_idx; }
 
 private:
   void Initialize();
@@ -115,6 +117,7 @@ private:
   bool _print_version = false;
   int _verbose_level;
   std::unordered_map<uint32_t, uint32_t> _output_sizes;
+  std::set<uint32_t> _trainable_ops_idx;
 };
 
 } // end of namespace onert_train

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -145,6 +145,13 @@ int main(const int argc, char **argv)
       args.getLossReductionType().value_or(tri.loss_info.reduction_type);
     tri.opt = args.getOptimizerType().value_or(tri.opt);
 
+    size_t pos = 0;
+    tri.trainble_ops_size = args.getTrainableOpsIdx().size();
+    for (auto const &idx : args.getTrainableOpsIdx())
+    {
+      tri.trainble_ops_idx[pos++] = idx;
+    }
+
     std::cout << "== training parameter ==" << std::endl;
     std::cout << tri;
     std::cout << "========================" << std::endl;


### PR DESCRIPTION
This commits adds new flags of onert_train - trainable_ops_idx. It allows to pass trainable ops indexes nnfw training.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Issue: https://github.com/Samsung/ONE/issues/12386