### PR TITLE
[one-cmds] Expand interface of the dummy tools for test

### DIFF
--- a/compiler/one-cmds/dummy-driver/src/dummy-compile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummy-compile.cpp
@@ -18,6 +18,7 @@
  * dummy-compile only tests its interface rather than its functionality.
  *
  * ./dummy-compile -o ${OUTPUT_NAME} ${INPUT_NAME}
+ * ./dummy-compile --target {TARGET_NAME} -o ${OUTPUT_NAME} ${INPUT_NAME}
  *
  * NOTE argv[3](INPUT_NAME) is not used here.
  */
@@ -28,21 +29,39 @@
 
 int main(int argc, char **argv)
 {
-  if (argc != 4)
+  if (argc != 4 and argc != 6)
     return EXIT_FAILURE;
 
-  std::string opt_o{"-o"};
-  std::string argv_1{argv[1]};
+  if (argc == 4)
+  {
+    std::string opt_o{"-o"};
+    std::string argv_1{argv[1]};
+    if (opt_o != argv_1)
+      return EXIT_FAILURE;
 
-  if (opt_o != argv_1)
-    return EXIT_FAILURE;
+    std::string output_name{argv[2]};
+    std::ofstream outfile(output_name);
+    outfile << "dummy-compile dummy output!!" << std::endl;
+    outfile.close();
+  }
+  if (argc == 6)
+  {
+    std::string opt_T{"--target"};
+    std::string argv_1{argv[1]};
+    if (opt_T != argv_1)
+      return EXIT_FAILURE;
+    std::string target_name{argv[2]};
 
-  std::string output_name{argv[2]};
-  std::ofstream outfile(output_name);
+    std::string opt_o{"-o"};
+    std::string argv_3{argv[3]};
+    if (opt_o != argv_3)
+      return EXIT_FAILURE;
 
-  outfile << "dummy-compile dummy output!!" << std::endl;
-
-  outfile.close();
+    std::string output_name{argv[4]};
+    std::ofstream outfile(output_name);
+    outfile << "dummy-compile with " << target_name << " target" << std::endl;
+    outfile.close();
+  }
 
   return EXIT_SUCCESS;
 }

--- a/compiler/one-cmds/dummy-driver/src/dummy-profile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummy-profile.cpp
@@ -18,7 +18,7 @@
  * dummy-profile only tests its interface rather than its functionality.
  *
  * ./dummy-profile ${INPUT_NAME}
- * dummy-profile dummy output!!!
+ * ./dummy-profile --target ${TARGET_NAME} ${INPUT_NAME}
  */
 
 #include <iostream>
@@ -27,10 +27,23 @@
 
 int main(int argc, char **argv)
 {
-  if (argc != 2)
+  if (argc != 2 and argc != 4)
     return EXIT_FAILURE;
 
-  std::cout << "dummy-profile dummy output!!!" << std::endl;
+  if (argc == 2)
+  {
+    std::cout << "dummy-profile dummy output!!!" << std::endl;
+  }
+  if (argc == 4)
+  {
+    std::string opt_T{"--target"};
+    std::string argv_1{argv[1]};
+    if (opt_T != argv_1)
+      return EXIT_FAILURE;
+    std::string target_name{argv[2]};
+
+    std::cout << "dummy-profile with " << target_name << " target" << std::endl;
+  }
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This commit expands the interfae of the dummy tools for test.

This will be for the target configuration test.

Draft: https://github.com/Samsung/ONE/pull/13161
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>