### PR TITLE
[tools/circle_plus_gen] Add operator access methods to CirclePlus 

### DIFF
--- a/tools/circle_plus_gen/lib/circle_plus.py
+++ b/tools/circle_plus_gen/lib/circle_plus.py
@@ -75,7 +75,7 @@ class CirclePlus():
         self._add_metadata(self.TINFO_META_TAG, tparam_buff)
 
     def get_number_of_operators(self, subgraph_idx=0) -> int:
-        '''Return a number of operators in the subgraph'''
+        '''Return the number of operators in the subgraph'''
         subgraphs: typing.List[cir_gen.SubGraphT] = self.model.subgraphs
         _not_none(subgraphs, "subgraphs")
 
@@ -102,7 +102,7 @@ class CirclePlus():
         opcode_in_order = []
         for op in operators:
             op_int = opcodes[op.opcodeIndex].builtinCode
-            if op_int in opcode_dict.keys():
+            if op_int in opcode_dict:
                 op_str = opcode_dict[op_int]
             else:
                 op_str = "UNKNOWN"  # might be custom_op

--- a/tools/circle_plus_gen/lib/circle_plus.py
+++ b/tools/circle_plus_gen/lib/circle_plus.py
@@ -84,15 +84,15 @@ class CirclePlus():
             return 0
         return len(operators)
 
-    def get_operators(self, subgraph_idx=0) -> typing.List[str]:
-        '''Return a list of opcodes according to the order of operations in the subgraph'''
+    def get_operator_names(self, subgraph_idx=0) -> typing.List[str]:
+        '''Return a list of operator names according to the order of operations in the subgraph'''
         subgraphs: typing.List[cir_gen.SubGraphT] = self.model.subgraphs
         opcodes: typing.List[cir_gen.OperatorCodeT] = self.model.operatorCodes
         _not_none(subgraphs, "subgraphs")
         _not_none(opcodes, "operatorCodes")
 
         operators: typing.List[cir_gen.OperatorT] = subgraphs[subgraph_idx].operators
-        _not_none(operators, "Operators")
+        _not_none(operators, "operators")
 
         opcodes_str = cir_gen.BuiltinOperator.__dict__.keys()  # ['GRU', 'BCQ_GATHER' .. ]
         opcodes_int = cir_gen.BuiltinOperator.__dict__.values()  # [-5, -4, -3....]

--- a/tools/circle_plus_gen/test/test_circle_plus.py
+++ b/tools/circle_plus_gen/test/test_circle_plus.py
@@ -1,0 +1,31 @@
+import unittest
+import hashlib
+import os
+
+from lib.circle_plus import CirclePlus
+
+
+def get_md5sum(file: str):
+    with open(file, 'rb') as f:
+        return hashlib.md5(f.read()).hexdigest()
+
+
+class TestCirclePlus(unittest.TestCase):
+    def setUp(self):
+        # sample.circle has a single operator(fully connected)
+        circle_file = "./example/sample.circle"
+        assert get_md5sum(circle_file) == 'df287dea52cf5bf16bc9dc720e8bca04'
+
+        self.circle_model = CirclePlus.from_file(circle_file)
+
+    def test_get_number_of_operators(self):
+        num_op = self.circle_model.get_number_of_operators()
+        self.assertEqual(num_op, 1)
+
+    def test_get_operators(self):
+        ops = self.circle_model.get_operators()
+        self.assertEqual(ops, ['FULLY_CONNECTED'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/circle_plus_gen/test/test_circle_plus.py
+++ b/tools/circle_plus_gen/test/test_circle_plus.py
@@ -22,8 +22,8 @@ class TestCirclePlus(unittest.TestCase):
         num_op = self.circle_model.get_number_of_operators()
         self.assertEqual(num_op, 1)
 
-    def test_get_operators(self):
-        ops = self.circle_model.get_operators()
+    def test_get_operator_names(self):
+        ops = self.circle_model.get_operator_names()
         self.assertEqual(ops, ['FULLY_CONNECTED'])
 
 


### PR DESCRIPTION
This PR add methods to CirclePlus class to acess circle's operator.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

draft : https://github.com/Samsung/ONE/pull/13154 
related : https://github.com/Samsung/ONE/issues/13099 