### PR TITLE
[onert] Create minmax dump file in handleSubgraphEnd

### DIFF
--- a/runtime/onert/core/src/exec/MinMaxRecorder.h
+++ b/runtime/onert/core/src/exec/MinMaxRecorder.h
@@ -20,13 +20,8 @@
 #include "ExecutionObservers.h"
 #include "ir/Index.h"
 #include "exec/MinMaxMap.h"
-#if MINMAX_H5DUMPER
-#include "../dumper/h5/MinMaxDumper.h"
-#else
-#include "MinMaxData.h"
-#endif
 
-#include <memory>
+#include <string>
 
 namespace onert
 {
@@ -51,11 +46,7 @@ public:
 private:
   const ir::Graph &_graph;
   const backend::BackendContexts &_backend_contexts;
-#if MINMAX_H5DUMPER
-  dumper::h5::MinMaxDumper _h5dumper;
-#else
-  RawMinMaxDumper _raw_dumper;
-#endif
+  std::string _workspace_dir;
   OpMinMaxMap _op_minmax;
   IOMinMaxMap _input_minmax;
 };


### PR DESCRIPTION
This commit updates MinMaxRecorder to create dump file in handleSubgraphEnd method, not in constructor.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #12904 #13039
Draft: #13013