### PR TITLE
[onert] Add validation test for set_backends_per_operation

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -1209,9 +1209,17 @@ NNFW_STATUS nnfw_session::set_backends_per_operation(const char *backend_setting
     return NNFW_STATUS_ERROR;
   }
 
-  // Backend for all
-  auto &ms_options = _coptions->manual_scheduler_options;
-  ms_options.setBackendMap(std::string{backend_settings});
+  try
+  {
+    // Backend for all
+    auto &ms_options = _coptions->manual_scheduler_options;
+    ms_options.setBackendMap(std::string{backend_settings});
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::set_backends_per_operation" << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
 
   return NNFW_STATUS_NO_ERROR;
 }

--- a/runtime/onert/core/src/compiler/CompilerOptions.cc
+++ b/runtime/onert/core/src/compiler/CompilerOptions.cc
@@ -64,6 +64,9 @@ void ManualSchedulerOptions::setBackendMap(const std::string &str)
     }
 
     auto key_val = nnfw::misc::split(key_val_str, '=');
+    if (key_val.size() != 2)
+      throw std::runtime_error{"Invalid key-value pair"};
+
     const auto &key_str = key_val.at(0);
     const auto &val = key_val.at(1);
     auto key = static_cast<uint32_t>(std::stoi(key_str));

--- a/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
@@ -193,6 +193,19 @@ TEST_F(ValidationTestAddModelLoaded, neg_experimental_output_no_such_name)
   ASSERT_EQ(ind, 999);
 }
 
+TEST_F(ValidationTestAddModelLoaded, set_backends_per_operation)
+{
+  NNFW_ENSURE_SUCCESS(nnfw_set_backends_per_operation(_session, "0=cpu;1=acl_cl"));
+  SUCCEED();
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_set_backends_per_operation)
+{
+  EXPECT_EQ(nnfw_set_backends_per_operation(_session, nullptr), NNFW_STATUS_ERROR);
+  EXPECT_EQ(nnfw_set_backends_per_operation(_session, "0?cpu;1?acl_cl"), NNFW_STATUS_ERROR);
+  EXPECT_EQ(nnfw_set_backends_per_operation(_session, "0=cpu:1=acl_cl"), NNFW_STATUS_ERROR);
+}
+
 TEST_F(ValidationTestAddModelLoaded, debug_set_config)
 {
   // At least one test for all valid keys


### PR DESCRIPTION
This commit adds validation check and unittest for set_backends_per_operation API.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>