### PR TITLE
[infra/onert] Disable hdf5 minmax dumper

### DIFF
--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -31,7 +31,7 @@ option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" ON
 option(INSTALL_TEST_SCRIPTS "Install test scripts" ON)
 option(BUILD_NPUD "Build NPU daemon" OFF)
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
-option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" ON)
+option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)
 #
 # Default build configuration for contrib
 #

--- a/infra/nnfw/cmake/options/options_aarch64-android.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-android.cmake
@@ -6,5 +6,3 @@ option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_BOOST "Download boost source" ON)
 option(BUILD_BOOST "Build boost source" ON)
 option(BUILD_LOGGING "Build logging runtime" OFF)
-
-option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)

--- a/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
@@ -14,5 +14,3 @@ option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OF
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
-
-option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)

--- a/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
@@ -14,5 +14,3 @@ option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OF
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
-
-option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)

--- a/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
@@ -14,5 +14,3 @@ option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OF
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
-
-option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)

--- a/infra/nnfw/cmake/options/options_i686-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_i686-tizen.cmake
@@ -15,5 +15,3 @@ option(BUILD_XNNPACK "Build XNNPACK" OFF)
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
-
-option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)

--- a/infra/nnfw/cmake/options/options_riscv64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_riscv64-tizen.cmake
@@ -15,5 +15,3 @@ option(BUILD_XNNPACK "Build XNNPACK" OFF)
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
-
-option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)

--- a/infra/nnfw/cmake/options/options_x86_64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_x86_64-tizen.cmake
@@ -15,5 +15,3 @@ option(BUILD_XNNPACK "Build XNNPACK" OFF)
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
-
-option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)


### PR DESCRIPTION
This commit updates default setting to use raw file format minmax dumper instead of hdf5 minmax dumper.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>