### PR TITLE
[onert] Implement config APIs

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -490,3 +490,31 @@ NNFW_STATUS nnfw_codegen(nnfw_session *session, const char *target, NNFW_CODEGEN
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->codegen(target, pref);
 }
+
+// Configuration
+
+NNFW_STATUS nnfw_set_prepare_config(nnfw_session *session, const NNFW_PREPARE_CONFIG key,
+                                    const char *value)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_prepare_config(key, value);
+}
+
+NNFW_STATUS nnfw_reset_prepare_config(nnfw_session *session)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->reset_prepare_config();
+}
+
+NNFW_STATUS nnfw_set_execute_config(nnfw_session *session, const NNFW_RUN_CONFIG key,
+                                    const char *value)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_execute_config(key, value);
+}
+
+NNFW_STATUS nnfw_reset_execute_config(nnfw_session *session)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->reset_execute_config();
+}

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -36,6 +36,7 @@ class CustomKernelRegistry;
 namespace exec
 {
 class Execution;
+struct ExecutionOptions;
 } // namespace exec
 namespace ir
 {
@@ -191,6 +192,11 @@ public:
   NNFW_STATUS set_codegen_model_path(const char *path);
   NNFW_STATUS codegen(const char *target, NNFW_CODEGEN_PREF pref);
 
+  NNFW_STATUS set_prepare_config(const NNFW_PREPARE_CONFIG key, const char *value);
+  NNFW_STATUS reset_prepare_config();
+  NNFW_STATUS set_execute_config(const NNFW_RUN_CONFIG key, const char *value);
+  NNFW_STATUS reset_execute_config();
+
 private:
   const onert::ir::IGraph *primary_subgraph();
   uint32_t getInputSize();
@@ -212,6 +218,7 @@ private:
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
   std::shared_ptr<onert::compiler::CompilerArtifact> _compiler_artifact;
   std::unique_ptr<onert::exec::Execution> _execution;
+  std::unique_ptr<onert::exec::ExecutionOptions> _exec_options;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;
   std::vector<std::thread> _threads;
   std::unique_ptr<onert::ir::train::TrainingInfo> _train_info;

--- a/runtime/onert/core/include/exec/ExecutionContext.h
+++ b/runtime/onert/core/include/exec/ExecutionContext.h
@@ -68,6 +68,8 @@ struct ExecutionOptions
   bool dump_minmax = false;
   bool trace = false;
   bool profile = false;
+
+  static std::unique_ptr<ExecutionOptions> fromGlobalConfig();
 };
 
 struct ExecutionContext

--- a/runtime/onert/core/src/exec/ExecutionContext.cc
+++ b/runtime/onert/core/src/exec/ExecutionContext.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/ExecutionContext.h"
+
+#include "util/ConfigSource.h"
+
+namespace onert
+{
+namespace exec
+{
+
+std::unique_ptr<ExecutionOptions> ExecutionOptions::fromGlobalConfig()
+{
+  auto options = std::make_unique<ExecutionOptions>();
+  options->dump_minmax = util::getConfigBool(util::config::MINMAX_DUMP);
+  options->trace = util::getConfigBool(util::config::TRACING_MODE);
+  options->profile = util::getConfigBool(util::config::PROFILING_MODE);
+
+  return options;
+}
+
+} // namespace exec
+} // namespace onert

--- a/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
@@ -268,3 +268,30 @@ TEST_F(ValidationTestAddModelLoaded, neg_set_workspace)
 {
   ASSERT_EQ(nnfw_set_workspace(_session, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
 }
+
+TEST_F(ValidationTestAddModelLoaded, set_prepare_config)
+{
+  NNFW_ENSURE_SUCCESS(nnfw_set_prepare_config(_session, NNFW_PREPARE_CONFIG_PROFILE, nullptr));
+  SUCCEED();
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_set_execute_config)
+{
+  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_DUMP_MINMAX, nullptr),
+            NNFW_STATUS_INVALID_STATE);
+  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_TRACE, nullptr),
+            NNFW_STATUS_INVALID_STATE);
+  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_PROFILE, nullptr),
+            NNFW_STATUS_INVALID_STATE);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_set_execute_config_with_no_workspace)
+{
+  NNFW_ENSURE_SUCCESS(nnfw_set_workspace(_session, ""));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
+
+  // Some execution config requires workspace
+  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_DUMP_MINMAX, nullptr),
+            NNFW_STATUS_ERROR);
+  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_TRACE, nullptr), NNFW_STATUS_ERROR);
+}

--- a/tests/nnfw_api/src/NNPackageTests/AddSessionPrepared.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/AddSessionPrepared.test.cc
@@ -204,4 +204,19 @@ TEST_F(ValidationTestAddSessionPrepared, neg_set_workspace)
   EXPECT_EQ(nnfw_set_workspace(_session, "."), NNFW_STATUS_INVALID_STATE);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, neg_set_prepare_config)
+{
+  EXPECT_EQ(nnfw_set_prepare_config(_session, NNFW_PREPARE_CONFIG_PROFILE, nullptr),
+            NNFW_STATUS_INVALID_STATE);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, set_execute_config)
+{
+  // Execution config should set after nnfw_prepare
+  NNFW_ENSURE_SUCCESS(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_DUMP_MINMAX, nullptr));
+  NNFW_ENSURE_SUCCESS(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_TRACE, nullptr));
+  NNFW_ENSURE_SUCCESS(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_PROFILE, nullptr));
+  SUCCEED();
+}
+
 // TODO Validation check when "nnfw_run" is called without input & output tensor setting


### PR DESCRIPTION
This commit implements config APIs in nnfw_session. 
Session stores compile config in CompilerOptions and execution configurations in ExecutionOptions. 
ExecutionOptions is initialized from environment variable, otherwise default setting.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #12903