### PR TITLE
[tools/onert_train] Print trainable ops

### DIFF
--- a/tests/tools/onert_train/src/nnfw_util.cc
+++ b/tests/tools/onert_train/src/nnfw_util.cc
@@ -109,6 +109,16 @@ std::ostream &operator<<(std::ostream &os, const nnfw_train_info &info)
   os << "- batch_size      = " << info.batch_size << "\n";
   os << "- loss_info       = " << info.loss_info << "\n";
   os << "- optimizer       = " << info.opt << "\n";
+  os << "- trainalbe_ops   = [";
+  auto const size = info.trainble_ops_size;
+  if (size > 0)
+  {
+    for (int i = 0; i < size - 1; ++i)
+      os << info.trainble_ops_idx[i] << ", ";
+    os << info.trainble_ops_idx[size - 1];
+  }
+  os << "]\n";
+
   return os;
 }
 


### PR DESCRIPTION
This PR make onert_train prints trainable_ops as log.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>