### PR TITLE
[onert/odc] Fix quantization bug

### DIFF
--- a/runtime/onert/odc/MinMaxReader.cc
+++ b/runtime/onert/odc/MinMaxReader.cc
@@ -22,7 +22,7 @@
 namespace
 {
 
-void inline readMMFile(void *ptr, size_t size, size_t count, FILE *fp, const std::string &err_msg)
+void readMMFile(void *ptr, size_t size, size_t count, FILE *fp, const std::string &err_msg)
 {
   if (fread(ptr, size, count, fp) != count)
   {
@@ -31,7 +31,7 @@ void inline readMMFile(void *ptr, size_t size, size_t count, FILE *fp, const std
   }
 }
 
-void inline checkHeader(FILE *file)
+void checkHeader(FILE *file)
 {
   // Check magic code and version
   // Match with runtime/onert/core/src/exec/MinMaxData.cc
@@ -41,13 +41,18 @@ void inline checkHeader(FILE *file)
   {
     uint32_t read_magic_code = 0;
     uint32_t read_version = 0;
-    if (std::fread(&read_magic_code, sizeof(uint32_t), 1, file) != 1 ||
-        read_magic_code != MAGIC_CODE)
+
+    readMMFile(&read_magic_code, sizeof(uint32_t), 1, file,
+               "MinMaxReader: Failed to read magic code");
+    readMMFile(&read_version, sizeof(uint32_t), 1, file, "MinMaxReader: Failed to read version");
+
+    if (read_magic_code != MAGIC_CODE)
     {
       std::fclose(file);
       throw std::runtime_error{"MinMaxReader: Invalid magic code"};
     }
-    if (std::fread(&read_version, sizeof(uint32_t), 1, file) != 1 || read_version != VERSION)
+
+    if (read_version != VERSION)
     {
       std::fclose(file);
       throw std::runtime_error{"MinMaxReader: Invalid version"};

--- a/runtime/onert/odc/Quantizer.cc
+++ b/runtime/onert/odc/Quantizer.cc
@@ -93,17 +93,13 @@ int Quantizer::quantize(const char *in, const char *out, QuantizeType qtype)
   if (module.get() == nullptr)
     return 1;
 
-  luci::CircleQuantizer quantizer;
-  auto options = quantizer.options();
-  if (options == nullptr)
-    return 1;
-
-  // Fill quantization type param
-  fillQuantizeOptionParam(options, qtype);
-
   // Additional phase for full quantization
   if (full_quantize)
   {
+    luci::CircleQuantizer quantizer;
+    auto options = quantizer.options();
+    fillQuantizeOptionParam(options, qtype);
+
     // Fake quantization
     options->enable(QuantizerOptions::Algorithm::QuantizeDequantizeWeights);
     for (size_t idx = 0; idx < module->size(); ++idx)
@@ -119,6 +115,10 @@ int Quantizer::quantize(const char *in, const char *out, QuantizeType qtype)
     auto minmax_path = util::getConfigString(util::config::WORKSPACE_DIR) + "/minmax.bin";
     Embedder().embed(module.get(), minmax_path, {1.f, 99.f});
   }
+
+  luci::CircleQuantizer quantizer;
+  auto options = quantizer.options();
+  fillQuantizeOptionParam(options, qtype);
 
   if (full_quantize)
     options->enable(QuantizerOptions::Algorithm::QuantizeWithMinMax);
@@ -150,7 +150,6 @@ int Quantizer::quantize(const char *in, const char *out, QuantizeType qtype)
   if (!exporter.invoke(&contract))
     return 1;
 
-  // Return 0 when luci::CircleQuantizer::Options::Algorithm::QuantizeWeights is ready
   return 0;
 }
 


### PR DESCRIPTION
This commit fixes quantization bugs.
- Read minmax file header in readInput() mehtod
- Use individual quantizer for fake quantization because minmax-embedder modify model between fake quantizer and quantize-with-minmax.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>