### PR TITLE
[onert] Use RTLD_DEEPBIND for dlopen

### DIFF
--- a/runtime/onert/core/src/compiler/BackendManager.cc
+++ b/runtime/onert/core/src/compiler/BackendManager.cc
@@ -65,7 +65,11 @@ void BackendManager::loadBackend(const std::string &backend)
   }
 
   const std::string backend_so = "libbackend_" + backend + SHARED_LIB_EXT;
+#ifdef __ANDROID__
   void *handle = dlopen(backend_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
+#else
+  void *handle = dlopen(backend_so.c_str(), RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+#endif
 
   if (handle == nullptr)
   {

--- a/runtime/onert/core/src/loader/ModelLoader.cc
+++ b/runtime/onert/core/src/loader/ModelLoader.cc
@@ -31,7 +31,11 @@ std::unique_ptr<ir::Model> loadModel(const std::string &filename, const std::str
   std::string libname = "lib" + type + "_loader.so";
 
   // Open custom loader library
-  void *handle = dlopen(libname.c_str(), RTLD_LAZY);
+#ifdef __ANDROID__
+  void *handle = dlopen(libname.c_str(), RTLD_LAZY | RTLD_LOCAL);
+#else
+  void *handle = dlopen(libname.c_str(), RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+#endif
   if (!handle)
     throw std::runtime_error("Failed to open " + type + " loader");
 

--- a/runtime/onert/core/src/odc/CodegenLoader.cc
+++ b/runtime/onert/core/src/odc/CodegenLoader.cc
@@ -44,7 +44,11 @@ void CodegenLoader::loadLibrary(const char *target)
     return;
 
   const std::string codegen_so = "lib" + std::string{target} + SHARED_LIB_EXT;
+#ifdef __ANDROID__
   void *handle = dlopen(codegen_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
+#else
+  void *handle = dlopen(codegen_so.c_str(), RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+#endif
   if (handle == nullptr)
   {
     throw std::runtime_error("CodegenLoader: " + std::string{dlerror()});

--- a/runtime/onert/core/src/odc/QuantizerLoader.cc
+++ b/runtime/onert/core/src/odc/QuantizerLoader.cc
@@ -44,7 +44,11 @@ int32_t QuantizerLoader::loadLibrary()
     return 0;
 
   const std::string quantize_so = std::string("libonert_odc") + SHARED_LIB_EXT;
+#ifdef __ANDROID__
   void *handle = dlopen(quantize_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
+#else
+  void *handle = dlopen(quantize_so.c_str(), RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+#endif
   auto dlerror_msg = dlerror();
 
   if (handle == nullptr)

--- a/tests/libs/nnapi/include/NeuralNetworksLoadHelpers.h
+++ b/tests/libs/nnapi/include/NeuralNetworksLoadHelpers.h
@@ -76,12 +76,15 @@ inline void* loadLibrary(const char* name) {
   // TODO: change RTLD_LOCAL? Assumes there can be multiple instances of nn
   // api RT
   void* handle = nullptr;
-#if 1 //#ifdef __ANDROID__
+#ifdef __ANDROID__
   handle = dlopen(name, RTLD_LAZY | RTLD_LOCAL);
+#else
+  handle = dlopen(name, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+#endif
   if (handle == nullptr) {
     NNAPI_LOG("nnapi error: unable to open library %s", name);
   }
-#endif
+//#endif
   return handle;
 }
 


### PR DESCRIPTION
This commit adds RTLD_DEEPBIND flag to dlopen().
It can help to find internally static linked library version first in dynamic library.
It is not used in android because android dlfcn.h does not intepret RTLD_DEEPBIND flag.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>