### PR TITLE
[onert] Remove nnfw_set_op_backend implementation

### DIFF
--- a/docs/howto/how-to-use-nnfw-api.md
+++ b/docs/howto/how-to-use-nnfw-api.md
@@ -21,11 +21,11 @@ nnfw_create_session(&session);
 ``` c
 nnfw_load_model_from_file(session, nnpackage_path);
 ```
-3) (Optional) Assign a specific backend to operations
+3) (Optional) Assign a specific backend
 ``` c
-  // Use 'acl_neon' backend for CONV_2D and 'cpu' for otherwise.
+  // Use 'acl_neon' backend only
   // Note that defalut backend is 'cpu'.
-  nnfw_set_op_backend(session, "CONV_2D", "acl_neon");
+  nnfw_set_available_backends(session, "acl_neon");
 ```
 
 4) Compilation

--- a/docs/howto/how-to-use-specific-backend.md
+++ b/docs/howto/how-to-use-specific-backend.md
@@ -9,9 +9,6 @@ ONE runtime has many ways to use specific backend during inference
 - For each backend string, `libbackend_{backend}.so` will be dynamically loaded during nnfw_prepare.
 - Among the multiple backends, the 1st element is used as the default backend.
 
-### [nnfw_set_op_backend](https://github.com/Samsung/ONE/blob/c46ddc04abdb58323fbd38389e6927f003bfaea1/runtime/onert/api/include/nnfw.h#L476)
-- The backend for op has higher priority than available backends specified by nnfw_set_available_backends.
-
 ## Using Environment Variable
 
 ### 1. BACKENDS
@@ -22,7 +19,6 @@ BACKENDS=cpu ./Product/out/bin/onert_run ...
 ```
 
 ### 2. OP_BACKEND_[OP_TYPE]
-- Same as `nnfw_set_op_backend`
 - Set backend for specific operator type
 - Example
   - Execute `Conv2D` operator on ruy backend and others on cpu backend

--- a/runtime/onert/api/nnfw/include/nnfw.h
+++ b/runtime/onert/api/nnfw/include/nnfw.h
@@ -38,7 +38,7 @@ extern "C" {
  *
  * <p>After loading, prepare inference by calling {@link nnfw_prepare}.
  * Application can set runtime environment before prepare by calling
- * {@link nnfw_set_available_backends} and {@link nnfw_set_op_backend}, and it is optional.
+ * {@link nnfw_set_available_backends}, and it is optional.
  *
  * <p>Application can inference by calling {@link nnfw_run}.
  * Before inference, application has responsibility to set input tensor to set input data by calling

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -292,7 +292,7 @@ NNFW_STATUS nnfw_set_available_backends(nnfw_session *session, const char *backe
   return session->set_available_backends(backends);
 }
 
-/*
+/**
  * Set the operation's backend
  *
  * @param[in] session session to be modified
@@ -301,10 +301,9 @@ NNFW_STATUS nnfw_set_available_backends(nnfw_session *session, const char *backe
  *
  * @return NNFW_STATUS_NO_ERROR if successful
  */
-NNFW_STATUS nnfw_set_op_backend(nnfw_session *session, const char *op, const char *backend)
+NNFW_STATUS nnfw_set_op_backend(nnfw_session *, const char *, const char *)
 {
-  NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_op_backend(op, backend);
+  return nnfw_session::deprecated("nnfw_set_op_backend: Deprecated");
 }
 
 /*

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -867,29 +867,6 @@ NNFW_STATUS nnfw_session::register_custom_operation(const std::string &id,
   return NNFW_STATUS_NO_ERROR;
 }
 
-static std::string get_op_backend_string(std::string op)
-{
-#define MAP_MACRO(CircleName, OneRTName) {#CircleName, #OneRTName},
-
-  static std::unordered_map<std::string, std::string> operation_map = {
-#include "OpMap.lst"
-  };
-
-#undef MAP_MACRO
-
-  auto n = operation_map.find(op);
-
-  if (n == operation_map.end())
-  {
-    // this return value is handled by a caller to return error code
-    return std::string("");
-  }
-  else
-  {
-    return n->second;
-  }
-}
-
 NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
 {
   if (!isStateModelLoaded())
@@ -909,37 +886,6 @@ NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
   catch (const std::exception &e)
   {
     std::cerr << "Error during nnfw_session::set_available_backends : " << e.what() << std::endl;
-    return NNFW_STATUS_ERROR;
-  }
-  return NNFW_STATUS_NO_ERROR;
-}
-
-NNFW_STATUS nnfw_session::set_op_backend(const char *op, const char *backend)
-{
-  if (!isStateModelLoaded())
-    return NNFW_STATUS_INVALID_STATE;
-
-  try
-  {
-    if (!op || !backend)
-      return NNFW_STATUS_UNEXPECTED_NULL;
-    if (!null_terminating(op, MAX_OP_NAME_LENGTH) ||
-        !null_terminating(backend, MAX_BACKEND_NAME_LENGTH))
-      return NNFW_STATUS_ERROR;
-
-    auto key = get_op_backend_string(op);
-
-    if (key.empty())
-    {
-      return NNFW_STATUS_ERROR;
-    }
-
-    auto &opcode_to_backend = _coptions->manual_scheduler_options.opcode_to_backend;
-    opcode_to_backend.emplace(onert::ir::toOpCode(key), backend);
-  }
-  catch (const std::exception &e)
-  {
-    std::cerr << "Error during nnfw_session::set_op_backend : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -143,7 +143,6 @@ public:
   NNFW_STATUS output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);
 
   NNFW_STATUS set_available_backends(const char *backends);
-  NNFW_STATUS set_op_backend(const char *op, const char *backend);
 
   NNFW_STATUS set_workspace(const char *dir);
 

--- a/runtime/onert/api/python/src/nnfw_api_wrapper.cc
+++ b/runtime/onert/api/python/src/nnfw_api_wrapper.cc
@@ -163,14 +163,6 @@ NNFW_SESSION::NNFW_SESSION(const char *package_file_path, const char *backends)
   ensure_status(nnfw_set_available_backends(this->session, backends));
   ensure_status(nnfw_prepare(this->session));
 }
-NNFW_SESSION::NNFW_SESSION(const char *package_file_path, const char *op, const char *backend)
-{
-  this->session = nullptr;
-  ensure_status(nnfw_create_session(&(this->session)));
-  ensure_status(nnfw_load_model_from_file(this->session, package_file_path));
-  ensure_status(nnfw_set_op_backend(this->session, op, backend));
-  ensure_status(nnfw_prepare(this->session));
-}
 NNFW_SESSION::~NNFW_SESSION()
 {
   if (session)

--- a/tests/nnfw_api/src/NNPackageTests/SingleSession.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/SingleSession.test.cc
@@ -136,4 +136,5 @@ TEST_F(ValidationTestSessionCreated, neg_deprecated_api)
   EXPECT_EQ(nnfw_prepare_pipeline(nullptr, nullptr), NNFW_STATUS_DEPRECATED_API);
   EXPECT_EQ(nnfw_push_pipeline_input(nullptr, nullptr, nullptr), NNFW_STATUS_DEPRECATED_API);
   EXPECT_EQ(nnfw_pop_pipeline_output(nullptr, nullptr), NNFW_STATUS_DEPRECATED_API);
+  EXPECT_EQ(nnfw_set_op_backend(nullptr, nullptr, nullptr), NNFW_STATUS_DEPRECATED_API);
 }


### PR DESCRIPTION
This commit removes deprecated nnfw_set_op_backend API implementation. 
This feature can be used by environment variable only.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>