### PR TITLE
[onert] Remove unused variable in planTensors, genTensors

### DIFF
--- a/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
@@ -44,9 +44,6 @@ template <typename T_BackendContext> void planTensors(const T_BackendContext &ct
   ir::OperandIndexMap<uint32_t> def_map;
   ir::OperandIndexSequence constants;
 
-  auto model_io =
-    (graph.getInputs() + graph.getOutputs()) | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
-
   // Prepare scanning
   graph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
     if (ctx.external_operands().contains(ind))
@@ -194,8 +191,6 @@ template <typename T_BackendContext> ITensorRegistry *genTensors(T_BackendContex
   const ir::Graph &graph = *ctx.graph();
   auto tensor_builder = ctx.tensor_builder;
 
-  auto model_io =
-    (graph.getInputs() + graph.getOutputs()) | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
   graph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
     if (ctx.external_operands().contains(ind))
       return;

--- a/runtime/onert/core/include/backend/basic/train/TrainableBackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/train/TrainableBackendContextHelpers.h
@@ -36,8 +36,6 @@ ITensorRegistry *genTensors(backend::train::TrainableBackendContext &ctx,
 {
   const auto &tgraph = *ctx.trainable_graph();
 
-  auto model_io =
-    (tgraph.getInputs() + tgraph.getOutputs()) | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
   tgraph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
     if (ctx.external_operands().contains(ind))
       return;


### PR DESCRIPTION
This PR removes unused variables in planTensors() and genTensors().

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>