### PR TITLE
[onert] Use dlmopen for codegen lib

### DIFF
--- a/runtime/onert/core/src/odc/CodegenLoader.cc
+++ b/runtime/onert/core/src/odc/CodegenLoader.cc
@@ -44,7 +44,11 @@ void CodegenLoader::loadLibrary(const char *target)
     return;
 
   const std::string codegen_so = "lib" + std::string{target} + SHARED_LIB_EXT;
+#ifdef __ANDROID__
   void *handle = dlopen(codegen_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
+#else
+  void *handle = dlmopen(LM_ID_NEWLM, codegen_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
+#endif
   if (handle == nullptr)
   {
     throw std::runtime_error("CodegenLoader: " + std::string{dlerror()});


### PR DESCRIPTION
This commit changes dlopen() to dlmopen() for codegen library. 
It's hard to control dependent library version with runtime's core. 
It can help to find internally linked static library version first in dynamic library. 
This feature is not supported on android.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>