### PR TITLE
[onert] Disable operations trainability by default

### DIFF
--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -42,10 +42,8 @@ public:
   virtual bool isRequiredForBackward() const final { return _required_for_backward; }
 
 private:
-  // TODO: Change _trainable and _required_for_backward to false after merge other parts of
-  // fine-tuning feature
-  bool _trainable = true;
-  bool _required_for_backward = true;
+  bool _trainable = false;
+  bool _required_for_backward = false;
 };
 
 } // namespace train

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -187,6 +187,10 @@ void TrainableExecutor::backwardImpl(const ExecutionObservee &subject, uint32_t 
     for (auto &&index : _backward_order)
     {
       const auto &code = _code_map.at(index);
+      if (!code.op->isRequiredForBackward())
+      {
+        continue;
+      }
 // TODO : Move ruy profiler into ExecutionObserver
 #ifdef RUY_PROFILER
       ruy::profiler::ScopeLabel label(code.op->name());

--- a/tests/nnfw_api/lib/CircleGen.cc
+++ b/tests/nnfw_api/lib/CircleGen.cc
@@ -81,6 +81,11 @@ uint32_t CircleGen::nextSubgraph()
   return ind;
 }
 
+uint32_t CircleGen::getCurrentSubgraphOpsSize() const
+{
+  return _subgraph_contexts.back().operators.size();
+}
+
 CircleBuffer CircleGen::finish()
 {
   std::vector<flatbuffers::Offset<circle::SubGraph>> subgraphs;

--- a/tests/nnfw_api/lib/CircleGen.h
+++ b/tests/nnfw_api/lib/CircleGen.h
@@ -133,6 +133,7 @@ public:
   uint32_t addTensor(const TensorParams &params, const SparsityParams &sp);
   void setInputsAndOutputs(const std::vector<int> &inputs, const std::vector<int> &outputs);
   uint32_t nextSubgraph();
+  uint32_t getCurrentSubgraphOpsSize() const;
   CircleBuffer finish();
 
   // ===== Add Operator methods begin (SORTED IN ALPHABETICAL ORDER) =====

--- a/tests/nnfw_api/lib/CirclePlusGen.cc
+++ b/tests/nnfw_api/lib/CirclePlusGen.cc
@@ -16,6 +16,8 @@
 
 #include "CirclePlusGen.h"
 
+#include <numeric>
+
 CircleBuffers CirclePlusGen::finish()
 {
   CircleBuffers cbufs;
@@ -25,6 +27,12 @@ CircleBuffers CirclePlusGen::finish()
 }
 
 void CirclePlusGen::addTrainInfo(const TrainInfo &info) { _info = info; }
+
+void CirclePlusGen::markAllOpsAsTrainable()
+{
+  _info.trainable_ops.resize(getCurrentSubgraphOpsSize());
+  std::iota(std::begin(_info.trainable_ops), std::end(_info.trainable_ops), 0);
+}
 
 CircleBuffer CirclePlusGen::createModelTraining()
 {

--- a/tests/nnfw_api/lib/CirclePlusGen.h
+++ b/tests/nnfw_api/lib/CirclePlusGen.h
@@ -44,6 +44,8 @@ public:
 public:
   void addTrainInfo(const TrainInfo &info);
 
+  void markAllOpsAsTrainable();
+
   // NOTE: this is overriden from CircleGen::finish()
   CircleBuffers finish();
 

--- a/tests/nnfw_api/src/GenModelTests/one_op_trains/Conv2D.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/one_op_trains/Conv2D.test.cc
@@ -18,7 +18,7 @@
 
 namespace
 {
-CircleBuffers gen_conv2d_test_model(const std::vector<int32_t> &trainable_ops)
+CirclePlusGen gen_conv2d_test_model()
 {
   CirclePlusGen cgen;
 
@@ -34,17 +34,19 @@ CircleBuffers gen_conv2d_test_model(const std::vector<int32_t> &trainable_ops)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo(
-    {circle::Optimizer::Optimizer_SGD, learning_rate, circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size, trainable_ops});
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+                     circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
 
-  return cgen.finish();
+  return cgen;
 }
 } // namespace
 
 TEST_F(GenModelTrain, OneOp_Conv2D_training_enabled)
 {
-  _context = std::make_unique<GenModelTrainContext>(gen_conv2d_test_model({0}));
+  auto cgen = gen_conv2d_test_model();
+  cgen.markAllOpsAsTrainable();
+  _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->addTrainCase(
     uniformTCD<float>({{{4, 0,  -5, 1, 0,  4, -1, 1, -1, -3, 3,  -2, -4,
                          1, -2, 2,  4, -4, 2, 2,  0, 4,  -1, -2, 4}}}, // input dataset
@@ -62,7 +64,8 @@ TEST_F(GenModelTrain, OneOp_Conv2D_training_enabled)
 
 TEST_F(GenModelTrain, OneOp_Conv2D_training_disabled)
 {
-  _context = std::make_unique<GenModelTrainContext>(gen_conv2d_test_model({}));
+  auto cgen = gen_conv2d_test_model();
+  _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->addTrainCase(
     uniformTCD<float>({{{4, 0,  -5, 1, 0,  4, -1, 1, -1, -3, 3,  -2, -4,
                          1, -2, 2,  4, -4, 2, 2,  0, 4,  -1, -2, 4}}}, // input dataset

--- a/tests/nnfw_api/src/GenModelTests/one_op_trains/FullyConnected.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/one_op_trains/FullyConnected.test.cc
@@ -33,9 +33,12 @@ TEST_F(GenModelTrain, OneOp_FullyConnected)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
+                     learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
+                     batch_size,
+                     {0}});
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->addTrainCase(
@@ -64,9 +67,12 @@ TEST_F(GenModelTrain, OneOp_FullyConnected_OptionalBias)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 2;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
+                     learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
+                     batch_size,
+                     {0}});
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->addTrainCase(
@@ -98,9 +104,12 @@ TEST_F(GenModelTrain, neg_OneOp_FullyConnected_FourOperand)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
+                     learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
+                     batch_size,
+                     {0}});
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
@@ -125,9 +134,12 @@ TEST_F(GenModelTrain, neg_OneOp_FullyConnected_InvalidWeightShape)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
+                     learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
+                     batch_size,
+                     {0}});
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
@@ -149,9 +161,12 @@ TEST_F(GenModelTrain, neg_OneOp_FullyConnected_NoBias)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
+                     learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
+                     batch_size,
+                     {0}});
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});

--- a/tests/nnfw_api/src/GenModelTests/one_op_trains/FullyConnected.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/one_op_trains/FullyConnected.test.cc
@@ -33,12 +33,10 @@ TEST_F(GenModelTrain, OneOp_FullyConnected)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
-                     learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
-                     batch_size,
-                     {0}});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+  cgen.markAllOpsAsTrainable();
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->addTrainCase(
@@ -67,12 +65,10 @@ TEST_F(GenModelTrain, OneOp_FullyConnected_OptionalBias)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 2;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
-                     learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
-                     batch_size,
-                     {0}});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+  cgen.markAllOpsAsTrainable();
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->addTrainCase(
@@ -104,12 +100,10 @@ TEST_F(GenModelTrain, neg_OneOp_FullyConnected_FourOperand)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
-                     learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
-                     batch_size,
-                     {0}});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+  cgen.markAllOpsAsTrainable();
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
@@ -134,12 +128,10 @@ TEST_F(GenModelTrain, neg_OneOp_FullyConnected_InvalidWeightShape)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
-                     learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
-                     batch_size,
-                     {0}});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+  cgen.markAllOpsAsTrainable();
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
@@ -161,12 +153,10 @@ TEST_F(GenModelTrain, neg_OneOp_FullyConnected_NoBias)
 
   float learning_rate = 0.01f;
   int32_t batch_size = 1;
-  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD,
-                     learning_rate,
+  cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
                      circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
-                     circle::LossReductionType::LossReductionType_SumOverBatchSize,
-                     batch_size,
-                     {0}});
+                     circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+  cgen.markAllOpsAsTrainable();
 
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});


### PR DESCRIPTION
This commits disables trainability of operations by default. Missing isRequiredForBackward check added to TrainableExecutor::backwardImpl.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>