### PR TITLE
[one-cmds] Fix one-profile_005 test

### DIFF
--- a/compiler/one-cmds/tests/one-profile_005.test
+++ b/compiler/one-cmds/tests/one-profile_005.test
@@ -23,7 +23,7 @@ This test assumes below directories.
     one
     ├── backends
     │   └── command
-    │       └── codegen
+    │       └── profile
     ├── bin
     ├── doc
     ├── include
@@ -62,6 +62,11 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 rm -f ${filename}.log
+
+if [ ! -d "../target/" ]; then
+  mkdir -p ../target/
+  TARGET_ALREADY_EXIST=false
+fi
 
 # copy dummy-profile to bin folder
 cp dummy-profile ../bin/dummy-profile


### PR DESCRIPTION
This commit fixes one-profile_005 test.

Related: https://github.com/Samsung/ONE/issues/13138#issuecomment-2172464177
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>