### PR TITLE
[onert] Fix value error when training MaxPool2D

### DIFF
--- a/runtime/onert/backend/train/ops/PoolLayer.cc
+++ b/runtime/onert/backend/train/ops/PoolLayer.cc
@@ -45,7 +45,7 @@ private:
   std::unique_ptr<Tensor> _arg_max_index;
 
 public:
-  MaxPool2D(const uint32_t paddingLeft, const uint32_t, const uint32_t, const uint32_t paddingTop,
+  MaxPool2D(const uint32_t paddingLeft, const uint32_t, const uint32_t paddingTop, const uint32_t,
             const uint32_t strideWidth, const uint32_t strideHeight, const uint32_t kernelWidth,
             const uint32_t kernelHeight, const ir::Activation activation,
             const IPortableTensor *output)

--- a/tests/nnfw_api/lib/CircleGen.cc
+++ b/tests/nnfw_api/lib/CircleGen.cc
@@ -329,6 +329,17 @@ uint32_t CircleGen::addOperatorLogSoftmax(const OperatorParams &params)
                                 circle::BuiltinOptions_LogSoftmaxOptions, options);
 }
 
+uint32_t CircleGen::addOperatorMaxPool2D(const OperatorParams &params, circle::Padding padding,
+                                         int stride_w, int stride_h, int filter_w, int filter_h,
+                                         circle::ActivationFunctionType actfn)
+{
+  auto options =
+    circle::CreatePool2DOptions(_fbb, padding, stride_w, stride_h, filter_w, filter_h, actfn)
+      .Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_MAX_POOL_2D,
+                                circle::BuiltinOptions_Pool2DOptions, options);
+}
+
 uint32_t CircleGen::addOperatorMean(const OperatorParams &params, bool keep_dims)
 {
   auto options = circle::CreateReducerOptions(_fbb, keep_dims).Union();

--- a/tests/nnfw_api/lib/CircleGen.h
+++ b/tests/nnfw_api/lib/CircleGen.h
@@ -187,6 +187,9 @@ public:
   uint32_t addOperatorLessEqual(const OperatorParams &params);
   uint32_t addOperatorLogSoftmax(const OperatorParams &params);
   uint32_t addOperatorMul(const OperatorParams &params, circle::ActivationFunctionType actfn);
+  uint32_t addOperatorMaxPool2D(const OperatorParams &params, circle::Padding padding, int stride_w,
+                                int stride_h, int filter_w, int filter_h,
+                                circle::ActivationFunctionType actfn);
   uint32_t addOperatorMean(const OperatorParams &params, bool keep_dims);
   uint32_t addOperatorNeg(const OperatorParams &params);
   uint32_t addOperatorNotEqual(const OperatorParams &params);

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/MaxPool2D.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/MaxPool2D.test.cc
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTrain.h"
+
+namespace
+{
+
+auto getDefaultPool2DOptions()
+{
+  return std::tuple<circle::Padding, int, int, int, int, circle::ActivationFunctionType>(
+    circle::Padding_SAME, 1, 1, 1, 1, circle::ActivationFunctionType_NONE);
+}
+
+} // namespace
+
+TEST_F(GenModelTrain, NonTrainableOps_Conv2D_MaxPool2D)
+{
+  // (( Input 0 )) -> [ Conv2D ] -> [ MaxPool2D ] -> (( Output 0 ))
+  // Padding : Same
+  // stride height : 1, stride width : 1
+  // filter height : 1, filter hight : 1
+  // Activation : None
+  {
+    CirclePlusGen cgen;
+    uint32_t weight_buf = cgen.addBuffer(std::vector<float>(2 * 3 * 3, 0.f));
+    uint32_t bias_buf = cgen.addBuffer(std::vector<float>(2, 0.f));
+    int input = cgen.addTensor({{1, 5, 5, 1}, circle::TensorType::TensorType_FLOAT32});
+    int weight = cgen.addTensor({{2, 3, 3, 1}, circle::TensorType::TensorType_FLOAT32, weight_buf});
+    int bias = cgen.addTensor({{2}, circle::TensorType::TensorType_FLOAT32, bias_buf});
+    int conv_output = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+    int output = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+    const auto [padding, stride_w, stride_h, filter_w, filter_h, actfn] = getDefaultPool2DOptions();
+
+    cgen.addOperatorConv2D({{input, weight, bias}, {conv_output}}, circle::Padding_VALID, 1, 1,
+                           circle::ActivationFunctionType_NONE, 1, 1);
+    cgen.addOperatorMaxPool2D({{conv_output}, {output}}, padding, stride_w, stride_h, filter_w,
+                              filter_h, actfn);
+    cgen.setInputsAndOutputs({input}, {output});
+
+    float learning_rate = 0.01f;
+    int32_t batch_size = 1;
+    cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+                       circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
+                       circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+    cgen.markAllOpsAsTrainable();
+    _context = std::make_unique<GenModelTrainContext>(cgen.finish());
+    _context->addTrainCase(
+      uniformTCD<float>({{{4, 0,  -5, 1, 0,  4, -1, 1, -1, -3, 3,  -2, -4,
+                           1, -2, 2,  4, -4, 2, 2,  0, 4,  -1, -2, 4}}},            // inputs
+                        {{{1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 8, 7, 6, 5, 4, 3, 2, 1}}}, // expected
+                        {24.0089f}                                                  // loss
+                        ));
+
+    _context->setBackends({"train"});
+    _context->setEpoch(4);
+
+    SUCCEED();
+  }
+}
+
+TEST_F(GenModelTrain, NonTrainableOps_Conv2D_MaxPool2D_Depth1_Filter2)
+{
+  // (( Input 0 )) -> [ Conv2D ] -> [ MaxPool2D ] -> (( Output 0 ))
+  // Padding : Same
+  // stride height : 1, stride width : 1
+  // filter height : 2, filter hight : 2
+  // Activation : None
+  {
+    CirclePlusGen cgen;
+    uint32_t weight_buf = cgen.addBuffer(std::vector<float>(1 * 3 * 3, 0.f));
+    uint32_t bias_buf = cgen.addBuffer(std::vector<float>(1, 0.f));
+    int input = cgen.addTensor({{1, 5, 5, 1}, circle::TensorType::TensorType_FLOAT32});
+    int weight = cgen.addTensor({{1, 3, 3, 1}, circle::TensorType::TensorType_FLOAT32, weight_buf});
+    int bias = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, bias_buf});
+    int conv_output = cgen.addTensor({{1, 3, 3, 1}, circle::TensorType::TensorType_FLOAT32});
+    int output = cgen.addTensor({{1, 3, 3, 1}, circle::TensorType::TensorType_FLOAT32});
+    auto [padding, stride_w, stride_h, filter_w, filter_h, actfn] = getDefaultPool2DOptions();
+    // padding = circle::Padding_VALID;
+    filter_w = 2;
+    filter_h = 2;
+
+    cgen.addOperatorConv2D({{input, weight, bias}, {conv_output}}, circle::Padding_VALID, 1, 1,
+                           circle::ActivationFunctionType_NONE, 1, 1);
+    cgen.addOperatorMaxPool2D({{conv_output}, {output}}, padding, stride_w, stride_h, filter_w,
+                              filter_h, actfn);
+    cgen.setInputsAndOutputs({input}, {output});
+
+    float learning_rate = 0.01f;
+    int32_t batch_size = 1;
+    cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+                       circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
+                       circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+    cgen.markAllOpsAsTrainable();
+    _context = std::make_unique<GenModelTrainContext>(cgen.finish());
+    _context->addTrainCase(
+      uniformTCD<float>({{{4, 0,  -5, 1, 0,  4, -1, 1, -1, -3, 3,  -2, -4,
+                           1, -2, 2,  4, -4, 2, 2,  0, 4,  -1, -2, 4}}}, // inputs
+                        {{{1, 2, 3, 4, 5, 6, 7, 8, 9}}},                 // expected
+                        {8.4666}                                         // loss
+                        ));
+
+    _context->setBackends({"train"});
+    _context->setEpoch(4);
+
+    SUCCEED();
+  }
+}
+
+TEST_F(GenModelTrain, NonTrainableOps_Conv2D_MaxPool2D_Depth2_Filter2)
+{
+  // (( Input 0 )) -> [ Conv2D ] -> [ MaxPool2D ] -> (( Output 0 ))
+  // Padding : Same
+  // stride height : 1, stride width : 1
+  // filter height : 2, filter hight : 2
+  // Activation : None
+  {
+    CirclePlusGen cgen;
+    uint32_t weight_buf = cgen.addBuffer(std::vector<float>(2 * 3 * 3, 0.f));
+    uint32_t bias_buf = cgen.addBuffer(std::vector<float>(2, 0.f));
+    int input = cgen.addTensor({{1, 5, 5, 1}, circle::TensorType::TensorType_FLOAT32});
+    int weight = cgen.addTensor({{2, 3, 3, 1}, circle::TensorType::TensorType_FLOAT32, weight_buf});
+    int bias = cgen.addTensor({{2}, circle::TensorType::TensorType_FLOAT32, bias_buf});
+    int conv_output = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+    int output = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+    auto [padding, stride_w, stride_h, filter_w, filter_h, actfn] = getDefaultPool2DOptions();
+    // padding = circle::Padding_VALID;
+    filter_w = 2;
+    filter_h = 2;
+
+    cgen.addOperatorConv2D({{input, weight, bias}, {conv_output}}, circle::Padding_VALID, 1, 1,
+                           circle::ActivationFunctionType_NONE, 1, 1);
+    cgen.addOperatorMaxPool2D({{conv_output}, {output}}, padding, stride_w, stride_h, filter_w,
+                              filter_h, actfn);
+    cgen.setInputsAndOutputs({input}, {output});
+
+    float learning_rate = 0.01f;
+    int32_t batch_size = 1;
+    cgen.addTrainInfo({circle::Optimizer::Optimizer_SGD, learning_rate,
+                       circle::LossFn::LossFn_MEAN_SQUARED_ERROR,
+                       circle::LossReductionType::LossReductionType_SumOverBatchSize, batch_size});
+    cgen.markAllOpsAsTrainable();
+    _context = std::make_unique<GenModelTrainContext>(cgen.finish());
+    _context->addTrainCase(
+      uniformTCD<float>({{{4, 0,  -5, 1, 0,  4, -1, 1, -1, -3, 3,  -2, -4,
+                           1, -2, 2,  4, -4, 2, 2,  0, 4,  -1, -2, 4}}},            // inputs
+                        {{{1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 8, 7, 6, 5, 4, 3, 2, 1}}}, // expected
+                        {9.3556f}                                                   // loss
+                        ));
+
+    _context->setBackends({"train"});
+    _context->setEpoch(4);
+
+    SUCCEED();
+  }
+}
+
+// TODO : Add test case to check stride supporting
+// TODO : Add more negative test cases


### PR DESCRIPTION
This fixes value error when training a model with MaxPool2D.
It fixs a error in arguments passing order when configuring MaxPool layer.
This PR also adds related test cases to gurantee that this fix is correct.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>
Co-authored-by: ragmani <ragmani0216@gmail.com>