### PR TITLE
[onert-micro] Introduce Metrics

### DIFF
--- a/onert-micro/onert-micro/include/train/metrics/Accuracy.h
+++ b/onert-micro/onert-micro/include/train/metrics/Accuracy.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_TRAIN_METRICS_ACCURACY_H
+#define ONERT_MICRO_TRAIN_METRICS_ACCURACY_H
+
+#include "OMStatus.h"
+
+#include <cstdint>
+
+namespace onert_micro
+{
+namespace train
+{
+namespace metrics
+{
+
+// Accuracy metric
+struct Accuracy
+{
+  // Calculate accuracy metric between calculated and target data
+  static float calculateValue(const uint32_t flat_size, const float *calculated_data,
+                              const float *target_data);
+};
+
+} // namespace metrics
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_TRAIN_METRICS_ACCURACY_H

--- a/onert-micro/onert-micro/include/train/metrics/CrossEntropy.h
+++ b/onert-micro/onert-micro/include/train/metrics/CrossEntropy.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_TRAIN_METRICS_CROSS_ENTROPY_H
+#define ONERT_MICRO_TRAIN_METRICS_CROSS_ENTROPY_H
+
+#include "OMStatus.h"
+
+#include <cstdint>
+
+namespace onert_micro
+{
+namespace train
+{
+namespace metrics
+{
+
+struct CrossEntropy
+{
+  // Calculate cross entropy metric between calculated and target data
+  static float calculateValue(const uint32_t flat_size, const float *calculated_data,
+                              const float *target_data);
+};
+
+} // namespace metrics
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_TRAIN_METRICS_CROSS_ENTROPY_H

--- a/onert-micro/onert-micro/include/train/metrics/MAE.h
+++ b/onert-micro/onert-micro/include/train/metrics/MAE.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_TRAIN_METRICS_MAE_H
+#define ONERT_MICRO_TRAIN_METRICS_MAE_H
+
+#include "OMStatus.h"
+
+#include <cstdint>
+
+namespace onert_micro
+{
+namespace train
+{
+namespace metrics
+{
+
+struct MAE
+{
+  // Calculate mae metric between calculated and target data
+  static float calculateValue(const uint32_t flat_size, const float *calculated_data,
+                              const float *target_data);
+};
+
+} // namespace metrics
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_TRAIN_METRICS_MAE_H

--- a/onert-micro/onert-micro/include/train/metrics/MSE.h
+++ b/onert-micro/onert-micro/include/train/metrics/MSE.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_TRAIN_METRICS_MSE_H
+#define ONERT_MICRO_TRAIN_METRICS_MSE_H
+
+#include "OMStatus.h"
+
+#include <cstdint>
+
+namespace onert_micro
+{
+namespace train
+{
+namespace metrics
+{
+
+struct MSE
+{
+  // Calculate mse metric between calculated and target data
+  static float calculateValue(const uint32_t flat_size, const float *calculated_data,
+                              const float *target_data);
+};
+
+} // namespace metrics
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_TRAIN_METRICS_MSE_H

--- a/onert-micro/onert-micro/src/train/metrics/Accuracy.cpp
+++ b/onert-micro/onert-micro/src/train/metrics/Accuracy.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "train/metrics/Accuracy.h"
+
+using namespace onert_micro;
+using namespace onert_micro::train;
+using namespace onert_micro::train::metrics;
+
+/*
+ * return 1.0 if predicted class equals to target
+ * return 0.0 otherwise
+ */
+float Accuracy::calculateValue(const uint32_t flat_size, const float *calculated_data,
+                               const float *target_data)
+{
+  // Find target class
+  float target_class = 0.f;
+  float target_max_val = target_data[0];
+  for (uint32_t i = 0; i < flat_size; ++i)
+  {
+    if (target_max_val < target_data[i])
+    {
+      target_max_val = target_data[i];
+      target_class = static_cast<float>(i);
+    }
+  }
+  // Find predicted class
+  float pred_class = 0.f;
+  float pred_max_val = calculated_data[0];
+  for (uint32_t i = 0; i < flat_size; ++i)
+  {
+    if (pred_max_val < calculated_data[i])
+    {
+      pred_max_val = calculated_data[i];
+      pred_class = static_cast<float>(i);
+    }
+  }
+
+  return pred_class == target_class ? 1.0f : 0.0f;
+}

--- a/onert-micro/onert-micro/src/train/metrics/CrossEntropy.cpp
+++ b/onert-micro/onert-micro/src/train/metrics/CrossEntropy.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "train/metrics/CrossEntropy.h"
+
+#include <cmath>
+
+using namespace onert_micro;
+using namespace onert_micro::train;
+using namespace onert_micro::train::metrics;
+
+/*
+ * Y - calculated value
+ * Y_t - target value
+ * E(Y, Y_t) = -SUM(Y_t_i * log(Y_i))
+ * SUM - sum among i = (0 ... N - 1), N - flat_size
+ */
+float CrossEntropy::calculateValue(const uint32_t flat_size, const float *calculated_data,
+                                   const float *target_data)
+{
+  float result_value = 0.f;
+
+  for (uint32_t i = 0; i < flat_size; ++i)
+  {
+    result_value += target_data[i] * std::log(calculated_data[i] + float(10.0e-32));
+  }
+
+  return -result_value;
+}

--- a/onert-micro/onert-micro/src/train/metrics/MAE.cpp
+++ b/onert-micro/onert-micro/src/train/metrics/MAE.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "train/metrics/MAE.h"
+
+#include <cmath>
+#include <cassert>
+
+using namespace onert_micro;
+using namespace onert_micro::train;
+using namespace onert_micro::train::metrics;
+
+/*
+ * E(Y, Y_t) = SUM(|Y_i - Y_t_i|) / N
+ * SUM - sum among i = (0 ... N - 1)
+ */
+float MAE::calculateValue(const uint32_t flat_size, const float *calculated_data,
+                          const float *target_data)
+{
+  float result_value = 0.f;
+
+  for (uint32_t i = 0; i < flat_size; ++i)
+  {
+    result_value += std::fabs(calculated_data[i] - target_data[i]);
+  }
+
+  assert(flat_size != 0);
+
+  return result_value / static_cast<float>(flat_size);
+}

--- a/onert-micro/onert-micro/src/train/metrics/MSE.cpp
+++ b/onert-micro/onert-micro/src/train/metrics/MSE.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "train/metrics/MSE.h"
+
+#include <cmath>
+#include <cassert>
+
+using namespace onert_micro;
+using namespace onert_micro::train;
+using namespace onert_micro::train::metrics;
+
+/*
+ * E(Y, Y_t) = (SUM(Y_i - Y_t_i)^2) / N
+ * SUM - sum among i = (0 ... N - 1)
+ */
+float MSE::calculateValue(const uint32_t flat_size, const float *calculated_data,
+                          const float *target_data)
+{
+  float result_value = 0.f;
+
+  for (uint32_t i = 0; i < flat_size; ++i)
+  {
+    const auto cur_val = calculated_data[i] - target_data[i];
+    result_value += cur_val * cur_val;
+  }
+
+  assert(flat_size != 0);
+
+  return result_value / static_cast<float>(flat_size);
+}


### PR DESCRIPTION
This pr introduces metrics entities: accuracy, corssentropy, mea, mse.

for issue https://github.com/Samsung/ONE/issues/12873
from draft: https://github.com/Samsung/ONE/pull/13107

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>