### PR TITLE
[onert-micro] Extend OMRuntimeGraph api

### DIFF
--- a/onert-micro/onert-micro/include/core/OMRuntimeGraph.h
+++ b/onert-micro/onert-micro/include/core/OMRuntimeGraph.h
@@ -54,6 +54,9 @@ public:
   void *getInputDataAt(uint32_t position);
   void *getOutputDataAt(uint32_t position);
 
+  size_t getInputDataTypeSize(uint32_t position);
+  size_t getOutputDataTypeSize(uint32_t position);
+
   OMStatus allocateGraphInputs();
 
   OMStatus reset();

--- a/onert-micro/onert-micro/src/core/OMRuntimeGraph.cpp
+++ b/onert-micro/onert-micro/src/core/OMRuntimeGraph.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "core/OMRuntimeGraph.h"
+#include "core/OMDataType.h"
 #include "OMStatus.h"
 
 using namespace onert_micro::core;
@@ -67,6 +68,25 @@ uint32_t OMRuntimeGraph::getOutputSizeAt(uint32_t position)
 
   OMRuntimeShape shape(output_tensor);
   return shape.flatSize();
+}
+
+size_t OMRuntimeGraph::getInputDataTypeSize(uint32_t position)
+{
+  const auto input_index = _context.getGraphInputTensorIndex(position);
+  const circle::Tensor *input_tensor = _context.getTensorByIndex(static_cast<int32_t>(input_index));
+
+  auto type = input_tensor->type();
+  return sizeof(OMDataType(type));
+}
+
+size_t OMRuntimeGraph::getOutputDataTypeSize(uint32_t position)
+{
+  const auto output_index = _context.getGraphOutputTensorIndex(position);
+  const circle::Tensor *output_tensor =
+    _context.getTensorByIndex(static_cast<int32_t>(output_index));
+
+  auto type = output_tensor->type();
+  return sizeof(OMDataType(type));
 }
 
 uint32_t OMRuntimeGraph::getInputSizeAt(uint32_t position)


### PR DESCRIPTION
This pr extends OMRuntimeGraph api with tow new methods - getInputDataTypeSize and getOutputDataTypeSize.

for issue https://github.com/Samsung/ONE/issues/12873
from draft: https://github.com/Samsung/ONE/pull/13107

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>