### PR TITLE
[onert-micro] Skip findInplaceOpPass during training

### DIFF
--- a/onert-micro/onert-micro/src/optimize/pass/FindInplaceOpPass.cpp
+++ b/onert-micro/onert-micro/src/optimize/pass/FindInplaceOpPass.cpp
@@ -246,6 +246,12 @@ optimize::OMGraphStatus optimize::onert_micro_FindInplaceOpPass(core::OMRuntimeS
   bool changed = false;
 
   OMGraphStatus graph_status = {Unchanged, Ok};
+
+  // If it is train mode, skip inplace optimization
+  // We need all tensors
+  if (configs.train_mode)
+    return graph_status;
+
   do
   {
     changed = false;


### PR DESCRIPTION
This pr adds skipping FindInplaceOpPass during training.

for issue https://github.com/Samsung/ONE/issues/12873
from draft: https://github.com/Samsung/ONE/pull/13107

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>