### PR TITLE
[onert] Apply ConstantInsertionPass to the last remaining operand

### DIFF
--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -39,9 +39,10 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::I
   {
     auto &object = _graph.operands().at(input);
 
-    if (object.isConstant() && object.getUses().size() >= 2)
+    const auto key = ReplaceKey{input, factor};
+    if (object.isConstant() && (object.getUses().size() >= 2 ||
+                                _replace_operands_map.find(key) != _replace_operands_map.end()))
     {
-      const auto key = ReplaceKey{input, factor};
       if (_replace_operands_map.count(key) == 0)
       {
         ir::Operand new_object(object);


### PR DESCRIPTION
This commit modifies the code to check if the Replace Key is present in `_replace_operands_map` and allows ConstantInsertionPass to be applied even to the last remaining operand.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>