### PR TITLE
[onert] Remove noexcept specifier from ANeuralNetworksCompilation constructor

### DIFF
--- a/runtime/onert/api/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/api/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -21,7 +21,7 @@
 using namespace onert;
 
 // TODO Support multiple subgraphs
-ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept
+ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model)
   : _model{model->getModel()}, _coptions{compiler::CompilerOptions::fromGlobalConfig()},
     _compiler{std::make_shared<compiler::Compiler>(_model, _coptions.get())}
 {

--- a/runtime/onert/api/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/api/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -28,7 +28,7 @@
 struct ANeuralNetworksCompilation
 {
 public:
-  ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept;
+  ANeuralNetworksCompilation(const ANeuralNetworksModel *model);
 
 public:
   bool finish() noexcept;


### PR DESCRIPTION
This commit removes noexcept specifier from ANeuralNetworksCompilation constructor to not call terminate() when an exception occurs.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>