### PR TITLE
[onert-micro] Add Conv2D training kernel

### DIFF
--- a/onert-micro/onert-micro/include/pal/common/PALConv2DInputGrad.h
+++ b/onert-micro/onert-micro/include/pal/common/PALConv2DInputGrad.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_PAL_COMMON_CONV2D_INPUT_GRAD_H
+#define ONERT_MICRO_PAL_COMMON_CONV2D_INPUT_GRAD_H
+
+#include "PALUtils.h"
+#include "core/OMKernelData.h"
+#include "OMStatus.h"
+
+namespace onert_micro
+{
+namespace train
+{
+namespace pal
+{
+
+namespace
+{
+
+/*
+ * Rotate square 2D weights by 180 degrees
+ */
+void rotate_180(float *weights, uint32_t num_rows, uint32_t num_cols, uint32_t oc, uint32_t ic,
+                uint32_t num_input_channels)
+{
+  for (int row = 0; row < num_rows; ++row)
+  {
+    for (int col = 0; col < num_cols / 2; ++col)
+    {
+      uint32_t offset = ic + col * num_input_channels + row * num_cols * num_input_channels +
+                        oc * num_cols * num_input_channels * num_rows;
+      uint32_t rotated_offset = ic + (num_cols - col - 1) * num_input_channels +
+                                row * num_cols * num_input_channels +
+                                oc * num_cols * num_input_channels * num_rows;
+
+      float tmp_value = weights[offset];
+      weights[offset] = weights[rotated_offset];
+      weights[rotated_offset] = tmp_value;
+    }
+  }
+}
+
+} // namespace
+
+void Conv2DInputGrad(const core::FloatConv2D &params, const core::OMRuntimeShape &weight_shape,
+                     const float *weight_data, const core::OMRuntimeShape &dloss_doutput_shape,
+                     const float *dloss_doutput_data,
+                     const core::OMRuntimeShape &dloss_dinput_shape, float *dloss_dinput_data)
+{
+  const int stride_width = params.stride_w;
+  const int stride_height = params.stride_h;
+  const int dilation_width_factor = params.dilation_width_factor;
+  const int dilation_height_factor = params.dilation_height_factor;
+  const int pad_width = 0;
+  const int pad_height = 0;
+
+  const int weight_h = weight_shape.dims(1);
+  const int weight_w = weight_shape.dims(2);
+  const int weight_d = weight_shape.dims(3);
+  const int dloss_doutput_h = dloss_doutput_shape.dims(1);
+  const int dloss_doutput_w = dloss_doutput_shape.dims(2);
+  const int dloss_doutput_d = dloss_doutput_shape.dims(3);
+  const int dloss_dinput_h = dloss_dinput_shape.dims(1);
+  const int dloss_dinput_w = dloss_dinput_shape.dims(2);
+  const int dloss_dinput_d = dloss_dinput_shape.dims(3);
+
+  auto *n_c_weight_data = const_cast<float *>(weight_data);
+
+  for (uint32_t oc = 0; oc < dloss_dinput_d; ++oc)
+  {
+    for (uint32_t ic = 0; ic < dloss_doutput_d; ++ic)
+    {
+      rotate_180(n_c_weight_data, weight_h, weight_w, ic, oc, dloss_dinput_d);
+      for (int out_y = 0; out_y < dloss_dinput_h; ++out_y)
+      {
+        for (int out_x = 0; out_x < dloss_dinput_w; ++out_x)
+        {
+          const int in_x_origin = (out_x * stride_width) - pad_width;
+          const int in_y_origin = (out_y * stride_height) - pad_height;
+          float total = 0.f;
+
+          for (int filter_y = 0; filter_y < weight_h; ++filter_y)
+          {
+            for (int filter_x = 0; filter_x < weight_w; ++filter_x)
+            {
+              const int in_x = in_x_origin + dilation_width_factor * filter_x;
+              const int in_y = in_y_origin + dilation_height_factor * filter_y;
+              // If the location is outside the bounds of the input image,
+              // use zero as a default value.
+              if ((in_x >= 0) && (in_x < dloss_doutput_w) && (in_y >= 0) &&
+                  (in_y < dloss_doutput_h))
+              {
+                uint32_t input_offset =
+                  in_x * dloss_doutput_d + in_y * dloss_doutput_w * dloss_doutput_d + ic;
+                uint32_t filter_offset = oc + filter_x * dloss_dinput_d +
+                                         filter_y * weight_w * dloss_dinput_d +
+                                         ic * weight_w * dloss_dinput_d * weight_h;
+                assert(input_offset < dloss_doutput_shape.flatSize());
+                assert(filter_offset < weight_shape.flatSize());
+                float input_value = dloss_doutput_data[input_offset];
+                float filter_value = n_c_weight_data[filter_offset];
+                total += (input_value * filter_value);
+              }
+            }
+          }
+          uint32_t output_offset =
+            oc + dloss_dinput_d * out_x + out_y * dloss_dinput_d * dloss_dinput_w;
+          assert(output_offset < dloss_dinput_shape.flatSize());
+          dloss_dinput_data[output_offset] = total;
+        }
+      }
+      // Rotate back
+      rotate_180(n_c_weight_data, weight_h, weight_w, ic, oc, dloss_dinput_d);
+    }
+  }
+}
+
+} // namespace pal
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_PAL_COMMON_CONV2D_INPUT_GRAD_H

--- a/onert-micro/onert-micro/include/pal/common/PALConv2DWeightGrad.h
+++ b/onert-micro/onert-micro/include/pal/common/PALConv2DWeightGrad.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_PAL_COMMON_CONV2D_WEIGHT_GRAD_H
+#define ONERT_MICRO_PAL_COMMON_CONV2D_WEIGHT_GRAD_H
+
+#include "PALUtils.h"
+#include "core/OMKernelData.h"
+#include "OMStatus.h"
+
+namespace onert_micro
+{
+namespace train
+{
+namespace pal
+{
+void Conv2DBiasGrad(const core::OMRuntimeShape &dloss_doutput_shape,
+                    const float *dloss_doutput_data, float *dloss_dbias_data)
+{
+  assert(dloss_doutput_shape.dimensionsCount() == 4);
+  assert(dloss_doutput_shape.dims(0) == 1);
+  const int dloss_doutput_h = dloss_doutput_shape.dims(1);
+  const int dloss_doutput_w = dloss_doutput_shape.dims(2);
+  const int dloss_doutput_d = dloss_doutput_shape.dims(3);
+
+  // Reduce sum over last dim
+  for (uint32_t oc = 0; oc < dloss_doutput_d; ++oc)
+  {
+    float total = 0.f;
+    for (uint32_t h = 0; h < dloss_doutput_h; ++h)
+    {
+      for (uint32_t w = 0; w < dloss_doutput_w; ++w)
+      {
+        uint32_t offset = oc + w * dloss_doutput_d + h * dloss_doutput_w * dloss_doutput_d;
+        assert(offset < dloss_doutput_shape.flatSize());
+        total +=
+          dloss_doutput_data[oc + w * dloss_doutput_d + h * dloss_doutput_w * dloss_doutput_d];
+      }
+    }
+    dloss_dbias_data[oc] = total;
+  }
+}
+
+void Conv2DWeightGrad(const core::FloatConv2D &params, const core::OMRuntimeShape &input_shape,
+                      const float *input_data, const core::OMRuntimeShape &dloss_doutput_shape,
+                      const float *dloss_doutput_data,
+                      const core::OMRuntimeShape &dloss_dweight_shape, float *dloss_dweight_data)
+{
+  const int stride_width = params.stride_w;
+  const int stride_height = params.stride_h;
+  const int dilation_width_factor = params.dilation_width_factor;
+  const int dilation_height_factor = params.dilation_height_factor;
+  const int pad_width = 0;
+  const int pad_height = 0;
+
+  const int batches = dloss_doutput_shape.dims(0);
+  const int input_h = input_shape.dims(1);
+  const int input_w = input_shape.dims(2);
+  const int input_d = input_shape.dims(3);
+  const int dloss_doutput_h = dloss_doutput_shape.dims(1);
+  const int dloss_doutput_w = dloss_doutput_shape.dims(2);
+  const int dloss_doutput_d = dloss_doutput_shape.dims(3);
+  const int dloss_dweight_h = dloss_dweight_shape.dims(1);
+  const int dloss_dweight_w = dloss_dweight_shape.dims(2);
+  const int dloss_dweight_d = dloss_dweight_shape.dims(3);
+
+  for (uint32_t oc = 0; oc < dloss_doutput_d; ++oc)
+  {
+    for (uint32_t ic = 0; ic < input_d; ++ic)
+    {
+      for (int out_y = 0; out_y < dloss_dweight_h; ++out_y)
+      {
+        for (int out_x = 0; out_x < dloss_dweight_w; ++out_x)
+        {
+          const int in_x_origin = (out_x * stride_width) - pad_width;
+          const int in_y_origin = (out_y * stride_height) - pad_height;
+          float total = 0.f;
+
+          for (int filter_y = 0; filter_y < dloss_doutput_h; ++filter_y)
+          {
+            for (int filter_x = 0; filter_x < dloss_doutput_w; ++filter_x)
+            {
+              const int in_x = in_x_origin + dilation_width_factor * filter_x;
+              const int in_y = in_y_origin + dilation_height_factor * filter_y;
+              // If the location is outside the bounds of the input image,
+              // use zero as a default value.
+              if ((in_x >= 0) && (in_x < input_w) && (in_y >= 0) && (in_y < input_h))
+              {
+                uint32_t input_offset = in_x * input_d + in_y * input_w * input_d + ic;
+                uint32_t filter_offset =
+                  oc + filter_x * dloss_doutput_d + filter_y * dloss_doutput_w * dloss_doutput_d;
+                assert(input_offset < input_shape.flatSize());
+                assert(filter_offset < dloss_doutput_shape.flatSize());
+                float input_value = input_data[input_offset];
+                float filter_value = dloss_doutput_data[filter_offset];
+                total += (input_value * filter_value);
+              }
+            }
+          }
+          uint32_t output_offset = ic + input_d * out_x + input_d * dloss_dweight_w * out_y +
+                                   input_d * dloss_dweight_w * dloss_dweight_h * oc;
+          assert(output_offset < dloss_dweight_shape.flatSize());
+          dloss_dweight_data[output_offset] = total;
+        }
+      }
+    }
+  }
+}
+
+} // namespace pal
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_PAL_COMMON_CONV2D_WEIGHT_GRAD_H

--- a/onert-micro/onert-micro/src/train/kernels/Conv2D.cpp
+++ b/onert-micro/onert-micro/src/train/kernels/Conv2D.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OMStatus.h"
+#include "core/OMUtils.h"
+#include "train/OMBackpropExecutionBuilder.h"
+#include "execute/OMRuntimeKernel.h"
+#include "PALConv2DWeightGrad.h"
+#include "PALReluInputGrad.h"
+#include "PALConv2DInputGrad.h"
+
+using namespace onert_micro;
+using namespace onert_micro::core;
+using namespace onert_micro::train;
+
+namespace
+{
+
+constexpr uint32_t inputTensorIdx = 0;
+constexpr uint32_t weightTensorIdx = 1;
+constexpr uint32_t biasTensorIdx = 2;
+
+constexpr uint32_t outputTensorIdx = 0;
+
+} // namespace
+
+/*
+ * - Calculate weight gradient (with bias)
+ * - Calculate input gradient - Optional (not required if it is last op)
+ */
+OMStatus onert_micro::train::train_kernel_CircleConv2D(const OMBackpropExecuteArgs &args)
+{
+  core::OMRuntimeStorage &forward_storage = args.forward_storage;
+  core::OMRuntimeStorage &backward_storage = args.backward_storage;
+  core::OMRuntimeContext &context = args.backward_context;
+  uint16_t op_index = args.kernel_index;
+
+  const circle::Tensor *input;
+  const circle::Tensor *weight;
+  const circle::Tensor *output;
+
+  uint8_t *input_data;
+  uint8_t *dloss_dinput_data;
+
+  uint8_t *weight_data;
+  uint8_t *dloss_dweight_data;
+
+  uint8_t *bias_data;
+  uint8_t *dloss_dbias_data;
+
+  uint8_t *output_data;
+  uint8_t *dloss_doutput_data;
+
+  const circle::Conv2DOptions *options;
+  // Read kernel
+  {
+    execute::OMRuntimeKernel runtime_kernel;
+    runtime_kernel.readKernel(op_index, context);
+
+    input = runtime_kernel.inputs[inputTensorIdx];
+    weight = runtime_kernel.inputs[weightTensorIdx];
+    output = runtime_kernel.outputs[outputTensorIdx];
+    assert(input != nullptr);
+    assert(weight != nullptr);
+    // Bias can be nullptr
+    assert(output != nullptr);
+
+    // Read forward storage
+    {
+      runtime_kernel.getDataFromStorage(op_index, forward_storage, context);
+
+      input_data = runtime_kernel.inputs_data[inputTensorIdx];
+      weight_data = runtime_kernel.inputs_data[weightTensorIdx];
+      bias_data = runtime_kernel.inputs_data[biasTensorIdx];
+      output_data = runtime_kernel.outputs_data[outputTensorIdx];
+      // Bias_data can be nullptr
+      // Output_data can be nullptr
+      assert(input_data != nullptr);
+      assert(weight_data != nullptr);
+    }
+
+    // Read backward storage
+    {
+      runtime_kernel.getDataFromStorage(op_index, backward_storage, context);
+
+      dloss_dinput_data = runtime_kernel.inputs_data[inputTensorIdx];
+      dloss_dweight_data = runtime_kernel.inputs_data[weightTensorIdx];
+      dloss_dbias_data = runtime_kernel.inputs_data[biasTensorIdx];
+      dloss_doutput_data = runtime_kernel.outputs_data[outputTensorIdx];
+      // Bias_data and dloss_dinput_data can be nullptr
+      // Note: dloss_dinput_data can be nullptr due to it can be last trainable node
+      assert(dloss_dweight_data != nullptr);
+      assert(dloss_doutput_data != nullptr);
+    }
+
+    options = runtime_kernel.first_operator->builtin_options_as_Conv2DOptions();
+  }
+
+  OMRuntimeShape input_shape(input);
+  OMRuntimeShape output_shape(output);
+  OMRuntimeShape weight_shape(weight);
+
+  // 1. Handle activation functions
+  switch (options->fused_activation_function())
+  {
+    case circle::ActivationFunctionType_NONE:
+      // Do nothing
+      break;
+    case circle::ActivationFunctionType_RELU:
+    {
+      assert(output_data != nullptr);
+      pal::ReluInputGrad(utils::castInputData<float>(output_data),
+                         utils::castOutputData<float>(dloss_doutput_data), output_shape);
+      break;
+    }
+    default:
+    {
+      assert(false && "Unsupported activation type");
+      return UnsupportedType;
+    }
+  }
+
+  const int input_width = input_shape.dims(3);
+  const int input_height = input_shape.dims(2);
+  const int weight_width = output_shape.dims(3);
+  const int weight_height = output_shape.dims(2);
+
+  FloatConv2D params{};
+
+  params.stride_w = options->stride_w();
+  params.stride_h = options->stride_h();
+  params.dilation_width_factor = options->dilation_w_factor();
+  params.dilation_height_factor = options->dilation_h_factor();
+  params.pad_h = 0;
+  params.pad_w = 0;
+
+  // 2. Calculate weight gradient
+  pal::Conv2DWeightGrad(params, input_shape, utils::castInputData<float>(input_data), output_shape,
+                        utils::castInputData<float>(dloss_doutput_data), weight_shape,
+                        utils::castOutputData<float>(dloss_dweight_data));
+
+  // 3. Calculate bias gradient
+  if (dloss_dbias_data)
+  {
+    assert(bias_data != nullptr);
+    if (bias_data == nullptr)
+      return UnknownError;
+
+    pal::Conv2DBiasGrad(output_shape, utils::castInputData<float>(dloss_doutput_data),
+                        utils::castOutputData<float>(dloss_dbias_data));
+  }
+
+  // 4. Calculate (if needed) input grad
+  if (args.is_last_layer == false)
+  {
+    assert(dloss_dinput_data != nullptr);
+    pal::Conv2DInputGrad(params, weight_shape, utils::castInputData<float>(weight_data),
+                         output_shape, utils::castInputData<float>(dloss_doutput_data), input_shape,
+                         utils::castOutputData<float>(dloss_dinput_data));
+  }
+
+  return Ok;
+}


### PR DESCRIPTION
This pr adds Conv2D training kernel.

for issue https://github.com/Samsung/ONE/issues/12873
from draft: https://github.com/Samsung/ONE/pull/13107

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>