### PR TITLE
[onert-micro] Add MaxPool2D training kernel

### DIFF
--- a/onert-micro/onert-micro/include/pal/common/PALMaxPool2DInputGrad.h
+++ b/onert-micro/onert-micro/include/pal/common/PALMaxPool2DInputGrad.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_EXECUTE_PAL_COMMON_MAX_POOL_2D_INPUT_GRAD_H
+#define ONERT_MICRO_EXECUTE_PAL_COMMON_MAX_POOL_2D_INPUT_GRAD_H
+
+#include "OMStatus.h"
+#include "PALUtils.h"
+
+#include <cmath>
+
+namespace onert_micro
+{
+namespace train
+{
+namespace pal
+{
+
+void inline MaxPool2D(const core::Pool2DParams &params, const core::OMRuntimeShape &input_shape,
+                      const float *input_data, const core::OMRuntimeShape &dloss_doutput_shape,
+                      const float *dloss_doutput_data, float *dloss_dinput_data)
+{
+  const int32_t batches = input_shape.dims(0);
+  const int32_t depth = dloss_doutput_shape.dims(3);
+  const int32_t input_height = input_shape.dims(1);
+  const int32_t input_width = input_shape.dims(2);
+  const int32_t output_height = dloss_doutput_shape.dims(1);
+  const int32_t output_width = dloss_doutput_shape.dims(2);
+  const int32_t stride_height = params.stride_h;
+  const int32_t stride_width = params.stride_w;
+  for (int batch = 0; batch < batches; ++batch)
+  {
+    for (int out_y = 0; out_y < output_height; ++out_y)
+    {
+      for (int out_x = 0; out_x < output_width; ++out_x)
+      {
+        for (int channel = 0; channel < depth; ++channel)
+        {
+          const int in_x_origin = (out_x * stride_width) - params.pad_w;
+          const int in_y_origin = (out_y * stride_height) - params.pad_h;
+          // Compute the boundaries of the filter region clamped so as to
+          // ensure that the filter window fits in the input array.
+          const int filter_x_start = std::max(0, -in_x_origin);
+          const int filter_x_end = std::min(params.filter_w, input_width - in_x_origin);
+          const int filter_y_start = std::max(0, -in_y_origin);
+          const int filter_y_end = std::min(params.filter_h, input_height - in_y_origin);
+
+          const int output_data_offset =
+            ((batch * output_height + out_y) * output_width + out_x) * depth + channel;
+
+          float max = std::numeric_limits<float>::lowest();
+          int max_index = 0;
+
+          for (int filter_y = filter_y_start; filter_y < filter_y_end; ++filter_y)
+          {
+            for (int filter_x = filter_x_start; filter_x < filter_x_end; ++filter_x)
+            {
+              const int in_x = in_x_origin + filter_x;
+              const int in_y = in_y_origin + filter_y;
+
+              const int input_data_offset =
+                ((batch * input_height + in_y) * input_width + in_x) * depth + channel;
+
+              if (input_data[input_data_offset] > max)
+              {
+                max = input_data[input_data_offset];
+                max_index = input_data_offset;
+              }
+            }
+          }
+          dloss_dinput_data[max_index] = dloss_doutput_data[output_data_offset];
+        }
+      }
+    }
+  }
+}
+
+} // namespace pal
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_EXECUTE_PAL_COMMON_MAX_POOL_2D_INPUT_GRAD_H

--- a/onert-micro/onert-micro/src/train/kernels/MaxPool2D.cpp
+++ b/onert-micro/onert-micro/src/train/kernels/MaxPool2D.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OMStatus.h"
+#include "core/OMUtils.h"
+#include "core/OMKernelData.h"
+#include "core/OMDataType.h"
+#include "train/OMBackpropExecutionBuilder.h"
+#include "execute/OMRuntimeKernel.h"
+#include "execute/OMUtils.h"
+#include "core/memory/OMMemoryManager.h"
+#include "PALMaxPool2DInputGrad.h"
+
+using namespace onert_micro;
+using namespace onert_micro::core;
+using namespace onert_micro::train;
+
+namespace
+{
+
+constexpr uint32_t inputTensorIdx = 0;
+constexpr uint32_t outputTensorIdx = 0;
+
+} // namespace
+
+/*
+ * - Calculate input gradient - Optional (not required if it is last op)
+ */
+OMStatus onert_micro::train::train_kernel_CircleMaxPool2D(const OMBackpropExecuteArgs &args)
+{
+  // Check is it last layer for training
+  if (args.is_last_layer)
+  {
+    return Ok;
+  }
+
+  core::OMRuntimeStorage &forward_storage = args.forward_storage;
+  core::OMRuntimeStorage &backward_storage = args.backward_storage;
+  core::OMRuntimeContext &context = args.backward_context;
+  uint16_t op_index = args.kernel_index;
+
+  const circle::Tensor *input;
+  const circle::Tensor *output;
+
+  uint8_t *input_data;
+  uint8_t *dloss_dinput_data;
+
+  uint8_t *dloss_doutput_data;
+
+  const circle::Pool2DOptions *options;
+  // Read kernel
+  {
+    execute::OMRuntimeKernel runtime_kernel;
+    runtime_kernel.readKernel(op_index, context);
+
+    input = runtime_kernel.inputs[inputTensorIdx];
+    output = runtime_kernel.outputs[outputTensorIdx];
+    assert(input != nullptr);
+    assert(output != nullptr);
+
+    // Read forward storage
+    {
+      runtime_kernel.getDataFromStorage(op_index, forward_storage, context);
+
+      input_data = runtime_kernel.inputs_data[inputTensorIdx];
+      assert(input_data != nullptr);
+    }
+
+    // Read backward storage
+    {
+      runtime_kernel.getDataFromStorage(op_index, backward_storage, context);
+
+      dloss_dinput_data = runtime_kernel.inputs_data[inputTensorIdx];
+      dloss_doutput_data = runtime_kernel.outputs_data[outputTensorIdx];
+
+      assert(dloss_dinput_data != nullptr);
+      assert(dloss_doutput_data != nullptr);
+    }
+
+    options = runtime_kernel.first_operator->builtin_options_as_Pool2DOptions();
+  }
+
+  assert(options->fused_activation_function() == circle::ActivationFunctionType_NONE);
+  if (options->fused_activation_function() != circle::ActivationFunctionType_NONE)
+    return UnsupportedType;
+
+  OMRuntimeShape input_shape(input);
+  OMRuntimeShape output_shape(output);
+
+  int32_t padding_h = 0;
+  int32_t padding_w = 0;
+
+  const int input_width = input_shape.dims(2);
+  const int input_height = input_shape.dims(1);
+  execute::computePaddingHeightWidth(
+    options->stride_h(), options->stride_w(), 1 /* dilation_rate_height */,
+    1 /* dilation_rate_width */, input_height, input_width, options->filter_height(),
+    options->filter_width(), options->padding(), &padding_h, &padding_w);
+
+  core::Pool2DParams params{};
+  params.pad_h = padding_h;
+  params.pad_w = padding_w;
+  params.stride_h = options->stride_h();
+  params.stride_w = options->stride_w();
+  params.filter_h = options->filter_height();
+  params.filter_w = options->filter_width();
+
+  // Set input grad to zero
+  std::memset(dloss_dinput_data, 0, sizeof(OMDataType(output->type())) * input_shape.flatSize());
+
+  // Calculate input grad
+  pal::MaxPool2D(params, input_shape, core::utils::castInputData<float>(input_data), output_shape,
+                 core::utils::castInputData<float>(dloss_doutput_data),
+                 core::utils::castOutputData<float>(dloss_dinput_data));
+
+  return Ok;
+}


### PR DESCRIPTION
This pr adds MaxPool2D training kernel.

for issue https://github.com/Samsung/ONE/issues/12873
from draft: https://github.com/Samsung/ONE/pull/13107

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>