### PR TITLE
Remove test_models for onert-micro coverage

### DIFF
--- a/infra/command/gen-coverage-report
+++ b/infra/command/gen-coverage-report
@@ -69,7 +69,7 @@ done
 # Exclude test files from coverage report
 # Exclude flatbuffer generated files from coverage report
 "${LCOV_PATH}" -r "${EXTRACTED_COVERAGE_INFO_PATH}" -o "${EXCLUDED_COVERAGE_INFO_PATH}" \
-  '*.test.cpp' '*.test.cc' '*/test/*' '*/tests/*' '*_generated.h' '.test.h'
+  '*.test.cpp' '*.test.cc' '*/test/*' '*/tests/*' '*_generated.h' '.test.h' '*/test_models/*'
 
 # Final coverage data
 cp -v ${EXCLUDED_COVERAGE_INFO_PATH} ${COVERAGE_INFO_PATH}


### PR DESCRIPTION
- Remove */test_models/* from coverage report for onert-micro coverage

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>