### PR TITLE
[onert] Introduce `export_circleplus` internal API

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_internal.h
+++ b/runtime/onert/api/nnfw/include/nnfw_internal.h
@@ -44,4 +44,15 @@ NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer,
  */
 NNFW_STATUS nnfw_load_model_from_modelfile(nnfw_session *session, const char *file_path);
 
+/**
+ * @brief Export circle+ model
+ * @note  This function should be called on training mode
+ *        This function should be called before or after {@link nnfw_train}
+ *
+ * @param[in] session     The session to export training model
+ * @param[in] file_path   The path to export training model
+ * @return @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_train_export_circleplus(nnfw_session *session, const char *file_path);
+
 #endif // __NNFW_INTERNAL_H__

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -458,6 +458,12 @@ NNFW_STATUS nnfw_train_export_circle(nnfw_session *session, const char *path)
   return session->train_export_circle(path);
 }
 
+NNFW_STATUS nnfw_train_export_circleplus(nnfw_session *session, const char *path)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->train_export_circleplus(path);
+}
+
 // Quantization
 
 NNFW_STATUS nnfw_set_quantization_type(nnfw_session *session, NNFW_QUANTIZE_TYPE qtype)

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -1625,6 +1625,35 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
   return NNFW_STATUS_NO_ERROR;
 }
 
+NNFW_STATUS nnfw_session::train_export_circleplus(const char *path)
+{
+  if (path == nullptr)
+  {
+    std::cerr << "Error during nnfw_session::train_export_circleplus : path is null" << std::endl;
+    return NNFW_STATUS_UNEXPECTED_NULL;
+  }
+
+  if (!isStatePreparedOrFinishedTraining())
+  {
+    std::cerr << "Error during nnfw_session::train_export_circleplus : invalid state" << std::endl;
+    return NNFW_STATUS_INVALID_STATE;
+  }
+
+  try
+  {
+    onert::exporter::CircleExporter exporter(_model_path, std::string{path});
+    exporter.updateWeight(_execution);
+    exporter.updateMetadata(_train_info);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::train_export_circleplus : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  return NNFW_STATUS_NO_ERROR;
+}
+
 bool nnfw_session::isStatePreparedTraining()
 {
   if (_state == State::PREPARED_TRAINING)

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -183,6 +183,7 @@ public:
   NNFW_STATUS train_run(bool update_weights);
   NNFW_STATUS train_get_loss(uint32_t index, float *loss);
   NNFW_STATUS train_export_circle(const char *path);
+  NNFW_STATUS train_export_circleplus(const char *path);
 
   NNFW_STATUS set_quantization_type(NNFW_QUANTIZE_TYPE qtype);
   NNFW_STATUS set_quantized_model_path(const char *path);


### PR DESCRIPTION
This commit introduces `nnfw_train_export_circleplus` api to export circle+ file. This api is an internal API.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #13014 