### PR TITLE
[onert] Revist trainability in TrainableExecutor

### DIFF
--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -136,7 +136,7 @@ void TrainableExecutor::forwardImpl(const ExecutionObservee &subject, bool train
       ruy::profiler::ScopeLabel label(code.op->name());
 #endif
       auto &tn_seq = code.tn_seq;
-      tn_seq->forward(training);
+      tn_seq->forward(training && code.op->isRequiredForBackward());
     }
   }
 }


### PR DESCRIPTION
This commits adds additional check if operation is trainable for forward step.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>