### PR TITLE
[one-cmds] Fix one-import-onnx

### DIFF
--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -248,7 +248,7 @@ def _check_ext(args):
     if oneutils.is_valid_attr(args, 'disable_ext'):
         return None
     env_disable_ext = os.getenv('ONE_IMPORT_ONNX_EXT_DISABLE')
-    if env_disable_ext == '1' or env_disable_ext.upper() == 'Y':
+    if env_disable_ext == '1' or env_disable_ext == 'Y':
         return None
     dir_path = os.path.dirname(os.path.realpath(__file__))
     ext_path = os.path.join(dir_path, 'one-import-onnx-ext')


### PR DESCRIPTION
This will fix one-import-onnx as env. var can be None.

