### PR TITLE
[onert] Remove deprecated compiler option

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -927,11 +927,7 @@ NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
 
   const std::string skey = key;
 
-  if (skey == config::TRACING_MODE)
-  {
-    _coptions->tracing_mode = toBool(value);
-  }
-  else if (skey == config::GRAPH_DOT_DUMP)
+  if (skey == config::GRAPH_DOT_DUMP)
   {
     _coptions->graph_dump_level = toInt(value);
   }

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -65,10 +65,8 @@ struct CompilerOptions
 
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
-  bool minmax_dump; //< Whether minmax dump is enabled or not
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
-  bool tracing_mode;    //< Whether tracing mode ON/OFF
   int graph_dump_level; //< Graph dump level, values between 0 and 2 are valid
   std::string executor; //< Executor name to use
   ManualSchedulerOptions manual_scheduler_options; //< Options for ManualScheduler

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -70,12 +70,6 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
       throw std::runtime_error("Profiling mode works only with 'Dataflow' executor");
   }
 
-  if (_options->minmax_dump)
-  {
-    if (_options->executor != "Linear")
-      throw std::runtime_error("Recording minmax works only with Linear executor");
-  }
-
   if (!_model->hasOnly<ir::Graph>())
   {
     throw std::runtime_error("Compiler can only compile models for inference.");

--- a/runtime/onert/core/src/compiler/CompilerOptions.cc
+++ b/runtime/onert/core/src/compiler/CompilerOptions.cc
@@ -78,8 +78,6 @@ std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig()
 {
   auto o = std::make_unique<CompilerOptions>();
   o->backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
-  o->minmax_dump = util::getConfigBool(util::config::MINMAX_DUMP);
-  o->tracing_mode = util::getConfigBool(util::config::TRACING_MODE);
   o->graph_dump_level = util::getConfigInt(util::config::GRAPH_DOT_DUMP);
   o->executor = util::getConfigString(util::config::EXECUTOR);
   o->he_scheduler = util::getConfigBool(util::config::USE_SCHEDULER);
@@ -133,7 +131,6 @@ void CompilerOptions::verboseOptions()
   VERBOSE(Compiler) << std::boolalpha << "==== Compiler Options ====" << std::endl;
   VERBOSE(Compiler) << "backend_list             : "
                     << nnfw::misc::join(backend_list.begin(), backend_list.end(), "/") << std::endl;
-  VERBOSE(Compiler) << "tracing_mode             : " << tracing_mode << std::endl;
   VERBOSE(Compiler) << "graph_dump_level         : " << graph_dump_level << std::endl;
   VERBOSE(Compiler) << "executor                 : " << executor << std::endl;
   VERBOSE(Compiler) << "manual backend_for_all   : " << manual_scheduler_options.backend_for_all

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -59,9 +59,6 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
     if (_options->he_profiling_mode)
       throw std::runtime_error("NYI: Profiling mode for multiple model is not supported yet");
 
-    if (_options->minmax_dump)
-      throw std::runtime_error("Recording minmax is not supported for multiple models");
-
     _options->forceInternalOptions();
     _options->verboseOptions();
   }

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -75,12 +75,6 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
       throw std::runtime_error("Profiling mode works only with 'Dataflow' executor");
   }
 
-  if (_options->minmax_dump)
-  {
-    if (_options->executor != "Linear")
-      throw std::runtime_error("Recording minmax works only with Linear executor");
-  }
-
   _options->forceInternalOptions();
   _options->verboseOptions();
 

--- a/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
@@ -209,7 +209,6 @@ TEST_F(ValidationTestAddModelLoaded, neg_set_backends_per_operation)
 TEST_F(ValidationTestAddModelLoaded, debug_set_config)
 {
   // At least one test for all valid keys
-  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "TRACING_MODE", "0"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "0"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "1"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "2"));

--- a/tests/nnfw_api/src/NNPackageTests/AddSessionPrepared.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/AddSessionPrepared.test.cc
@@ -194,7 +194,6 @@ TEST_F(ValidationTestAddSessionPrepared, neg_run_without_set_output)
 TEST_F(ValidationTestAddSessionPrepared, neg_internal_set_config)
 {
   // All arguments are valid, but the session state is wrong
-  ASSERT_EQ(nnfw_set_config(_session, "TRACING_MODE", "0"), NNFW_STATUS_INVALID_STATE);
   ASSERT_EQ(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "0"), NNFW_STATUS_INVALID_STATE);
 }
 

--- a/tests/nnfw_api/src/NNPackageTests/SessionCreated.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/SessionCreated.test.cc
@@ -122,6 +122,5 @@ TEST_F(ValidationTestSessionCreated, neg_output_tensorinfo)
 TEST_F(ValidationTestSessionCreated, neg_internal_set_config)
 {
   // All arguments are valid, but the session state is wrong
-  ASSERT_EQ(nnfw_set_config(_session, "TRACING_MODE", "0"), NNFW_STATUS_INVALID_STATE);
   ASSERT_EQ(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "0"), NNFW_STATUS_INVALID_STATE);
 }

--- a/tests/nnfw_api/src/NNPackageTests/SingleSession.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/SingleSession.test.cc
@@ -126,7 +126,6 @@ TEST_F(ValidationTestSingleSession, neg_experimental_output_tensorindex_session_
 
 TEST_F(ValidationTestSingleSession, neg_internal_set_config)
 {
-  ASSERT_EQ(nnfw_set_config(nullptr, "TRACING_MODE", "0"), NNFW_STATUS_UNEXPECTED_NULL);
   ASSERT_EQ(nnfw_set_config(nullptr, "GRAPH_DOT_DUMP", "0"), NNFW_STATUS_UNEXPECTED_NULL);
 }
 


### PR DESCRIPTION
This commit removes deprecated compiler option.
Deprecated compiler options are handled on execution option.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13039
Draft: #13013 