### PR TITLE
[infra] Cleanup dockerfiles

### DIFF
--- a/infra/docker/android-sdk/Dockerfile
+++ b/infra/docker/android-sdk/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:jammy
 RUN apt-get update && apt-get -qqy install software-properties-common
 
 # Build tool
-RUN apt-get update && apt-get -qqy install build-essential cmake scons git lcov g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
+RUN apt-get update && apt-get -qqy install build-essential cmake scons git
 
 # Additonal tools
 RUN apt-get update && \
@@ -33,9 +33,9 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
 RUN apt-get update && apt-get install -qqy clang-format-16
 
-# Install java for gradle and android sdk
+# Install java for gradle and android sdk (and file for NDK internally used)
 ARG OPENJDK_VERSION=11
-RUN apt-get install -y openjdk-${OPENJDK_VERSION}-jdk
+RUN apt-get install -y openjdk-${OPENJDK_VERSION}-jdk file
 ENV JAVA_HOME /usr/lib/jvm/java-${OPENJDK_VERSION}-openjdk-amd64
 
 # Setup user to match host user, and give superuser permissions
@@ -83,7 +83,7 @@ RUN ${ANDROID_HOME}/cmdline-tools/${CMDTOOLS_VERSION}/bin/sdkmanager --sdk_root=
 # Env variable for android build (ndk, gradle)
 ENV NDK_DIR ${ANDROID_HOME}/ndk/${NDK_VERSION}
 ENV GRADLE_HOME /home/ubuntu/gradle
-ENV PATH ${PATH}:${GRADLE_HOME}/bin:${ANDROID_HOME}/cmdline-tools/10.0/bin:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+ENV PATH ${PATH}:${GRADLE_HOME}/bin:${ANDROID_HOME}/cmdline-tools/${CMDTOOLS_VERSION}/bin:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 
 # setup adb server
 EXPOSE 5037

--- a/infra/docker/focal/Dockerfile
+++ b/infra/docker/focal/Dockerfile
@@ -14,8 +14,6 @@
 
 FROM ubuntu:20.04
 
-ARG UBUNTU_MIRROR
-
 # Install 'add-apt-repository'
 RUN apt-get update && apt-get -qqy install software-properties-common
 
@@ -44,21 +42,9 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
 RUN apt-get update && apt-get install -qqy clang-format-16
 
-# Install google test (source)
-RUN apt-get update && apt-get -qqy install libgtest-dev
-
-# Install gbs & sdb
+# Install gbs
 RUN echo 'deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_20.04/ /' | cat >> /etc/apt/sources.list
 RUN apt-get update && apt-get -qqy install gbs
-RUN wget http://download.tizen.org/sdk/tizenstudio/official/binary/sdb_4.2.25_ubuntu-64.zip -O sdb.zip
-RUN unzip -d tmp sdb.zip && rm sdb.zip
-RUN cp tmp/data/tools/sdb /usr/bin/. && rm -rf tmp/*
-
-# ARM none eabi build tool
-RUN apt-get update && apt-get -qqy install gcc-arm-none-eabi
-
-# Env for ko encoding build
-ENV LC_ALL "C.UTF-8"
 
 # Setup user to match host user, and give superuser permissions
 ARG USER_ID=1000

--- a/infra/docker/jammy/Dockerfile
+++ b/infra/docker/jammy/Dockerfile
@@ -14,8 +14,6 @@
 
 FROM ubuntu:jammy
 
-ARG UBUNTU_MIRROR
-
 # Install 'add-apt-repository'
 RUN apt-get update && apt-get -qqy install software-properties-common
 
@@ -44,15 +42,9 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
 RUN apt-get update && apt-get install -qqy clang-format-16
 
-# Install google test (source)
-RUN apt-get update && apt-get -qqy install libgtest-dev
-
-# TODO: Install gbs & sdb
+# Install gbs
 RUN echo 'deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_22.04/ /' | cat >> /etc/apt/sources.list
 RUN apt-get update && apt-get -qqy install gbs
-RUN wget http://download.tizen.org/sdk/tizenstudio/official/binary/sdb_4.2.25_ubuntu-64.zip -O sdb.zip
-RUN unzip -d tmp sdb.zip && rm sdb.zip
-RUN cp tmp/data/tools/sdb /usr/bin/. && rm -rf tmp/*
 
 # Setup user to match host user, and give superuser permissions
 ARG USER_ID=1000


### PR DESCRIPTION
This commit updates dockerfiles to remove unnecessary packages and setting
- `android-sdk`
  - Remove unused buildtools
  - Fix cmdline-tools version directory
  - Install file package
- `focal` and `jammy`
  - Remove unused buildtools
  - Remove sdb
  - Remove unused UBUNTU_MIRROR argument
  - Remove unused libgtest-dev package

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>