### PR TITLE
[tools/onert_train] Introduce export_circleplus option

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -181,7 +181,10 @@ void Args::Initialize(void)
     }
   };
 
-  auto process_export_path = [&](const std::string &path) { _export_model_filename = path; };
+  auto process_export_circle = [&](const std::string &path) { _export_circle_filename = path; };
+  auto process_export_circleplus = [&](const std::string &path) {
+    _export_circleplus_filename = path;
+  };
 
   auto process_load_raw_inputfile = [&](const std::string &input_filename) {
     _load_raw_input_filename = input_filename;
@@ -278,7 +281,8 @@ void Args::Initialize(void)
     ("nnpackage", po::value<std::string>()->notifier(process_nnpackage), "NN Package file(directory) name")
     ("modelfile", po::value<std::string>()->notifier(process_modelfile), "NN Model filename")
     ("path", po::value<std::string>()->notifier(process_path), "NN Package or NN Modelfile path")
-    ("export_path", po::value<std::string>()->notifier(process_export_path), "Path to export circle")
+    ("export_circle", po::value<std::string>()->notifier(process_export_circle), "Path to export circle")
+    ("export_circleplus", po::value<std::string>()->notifier(process_export_circleplus), "Path to export circle+")
     ("load_input:raw", po::value<std::string>()->notifier(process_load_raw_inputfile),
          "NN Model Raw Input data file\n"
          "The datafile must have data for each input number.\n"

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -51,7 +51,8 @@ public:
 
   const std::string &getPackageFilename(void) const { return _package_filename; }
   const std::string &getModelFilename(void) const { return _model_filename; }
-  const std::string &getExportModelFilename(void) const { return _export_model_filename; }
+  const std::string &getExportCircleFilename(void) const { return _export_circle_filename; }
+  const std::string &getExportCirclePlusFilename(void) const { return _export_circleplus_filename; }
   const bool useSingleModel(void) const { return _use_single_model; }
   const std::string &getLoadRawInputFilename(void) const { return _load_raw_input_filename; }
   const std::string &getLoadRawExpectedFilename(void) const { return _load_raw_expected_filename; }
@@ -101,7 +102,8 @@ private:
 
   std::string _package_filename;
   std::string _model_filename;
-  std::string _export_model_filename;
+  std::string _export_circle_filename;
+  std::string _export_circleplus_filename;
   bool _use_single_model = false;
   std::string _load_raw_input_filename;
   std::string _load_raw_expected_filename;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -377,8 +377,11 @@ int main(const int argc, char **argv)
       }
     });
 
-    if (args.getExportModelFilename() != "")
-      NNPR_ENSURE_STATUS(nnfw_train_export_circle(session, args.getExportModelFilename().c_str()));
+    if (auto name = args.getExportCircleFilename(); name != "")
+      NNPR_ENSURE_STATUS(nnfw_train_export_circle(session, name.c_str()));
+
+    if (auto name = args.getExportCirclePlusFilename(); name != "")
+      NNPR_ENSURE_STATUS(nnfw_train_export_circleplus(session, name.c_str()));
 
     NNPR_ENSURE_STATUS(nnfw_close_session(session));
 


### PR DESCRIPTION
This commit introduces `export_circleplus` option and rename `export_path` to `export_circle` option.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #13014 