### PR TITLE
[onert] Change API status condition

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw.h
+++ b/runtime/onert/api/nnfw/include/nnfw.h
@@ -511,7 +511,7 @@ NNFW_STATUS nnfw_query_info_u32(nnfw_session *session, NNFW_INFO_ID id, uint32_t
  * <p>This function sets the directory to be used as a workspace.
  * System should allow read and write access to the directory for the runtime.
  * Default workspace is running directory of the application.
- * This function should be called before {@link nnfw_prepare} is invoked.</p>
+ * This function should be called before {@link nnfw_load_model_from_file} is invoked.</p>
  *
  * @param[in] session session to be queried on.
  * @param[in] dir     workspace directory path

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -898,13 +898,10 @@ NNFW_STATUS nnfw_session::set_workspace(const char *dir)
   if (!dir)
     return NNFW_STATUS_UNEXPECTED_NULL;
 
-  if (isStatePreparedOrFinishedRun())
+  if (!isStateInitialized())
     return NNFW_STATUS_INVALID_STATE;
 
   _coptions->workspace_dir = std::string(dir);
-
-  // TODO Set workspace dir to workspace user (ex. compiler, quantization manager, etc)
-  //      if model is already loaded
 
   return NNFW_STATUS_NO_ERROR;
 }
@@ -1683,7 +1680,7 @@ NNFW_STATUS nnfw_session::set_quantization_type(NNFW_QUANTIZE_TYPE qtype)
   using onert::odc::QuantizeType;
   try
   {
-    if (!isStateModelLoaded())
+    if (isStateInitialized() || isStateRunning())
     {
       std::cerr << "invalid state" << std::endl;
       return NNFW_STATUS_INVALID_STATE;
@@ -1722,7 +1719,7 @@ NNFW_STATUS nnfw_session::set_quantized_model_path(const char *path)
 {
   try
   {
-    if (!isStateModelLoaded())
+    if (isStateInitialized() || isStateRunning())
     {
       std::cerr << "invalid state" << std::endl;
       return NNFW_STATUS_INVALID_STATE;
@@ -1743,7 +1740,7 @@ NNFW_STATUS nnfw_session::quantize()
 {
   try
   {
-    if (!isStateModelLoaded())
+    if (isStateInitialized() || isStateRunning())
     {
       std::cerr << "invalid state" << std::endl;
       return NNFW_STATUS_INVALID_STATE;
@@ -1774,7 +1771,7 @@ NNFW_STATUS nnfw_session::set_codegen_model_path(const char *path)
 {
   try
   {
-    if (!isStateModelLoaded())
+    if (isStateInitialized() || isStateRunning())
     {
       std::cerr << "invalid state" << std::endl;
       return NNFW_STATUS_INVALID_STATE;
@@ -1796,7 +1793,7 @@ NNFW_STATUS nnfw_session::codegen(const char *target, NNFW_CODEGEN_PREF pref)
 {
   try
   {
-    if (!isStateModelLoaded())
+    if (isStateInitialized() || isStateRunning())
     {
       std::cerr << "Error during nnfw_session::codegen : Invalid state" << std::endl;
       return NNFW_STATUS_INVALID_STATE;

--- a/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
@@ -257,15 +257,10 @@ TEST_F(ValidationTestAddModelLoaded, neg_debug_get_config)
   ASSERT_EQ(nnfw_get_config(_session, "BAD_KEY", buf, sizeof(buf)), NNFW_STATUS_ERROR);
 }
 
-TEST_F(ValidationTestAddModelLoaded, set_workspace)
-{
-  NNFW_ENSURE_SUCCESS(nnfw_set_workspace(_session, "."));
-  SUCCEED();
-}
-
 TEST_F(ValidationTestAddModelLoaded, neg_set_workspace)
 {
-  ASSERT_EQ(nnfw_set_workspace(_session, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
+  // Call after prepare
+  EXPECT_EQ(nnfw_set_workspace(_session, "."), NNFW_STATUS_INVALID_STATE);
 }
 
 TEST_F(ValidationTestAddModelLoaded, set_prepare_config)
@@ -282,15 +277,4 @@ TEST_F(ValidationTestAddModelLoaded, neg_set_execute_config)
             NNFW_STATUS_INVALID_STATE);
   EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_PROFILE, nullptr),
             NNFW_STATUS_INVALID_STATE);
-}
-
-TEST_F(ValidationTestAddModelLoaded, neg_set_execute_config_with_no_workspace)
-{
-  NNFW_ENSURE_SUCCESS(nnfw_set_workspace(_session, ""));
-  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
-
-  // Some execution config requires workspace
-  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_DUMP_MINMAX, nullptr),
-            NNFW_STATUS_ERROR);
-  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_TRACE, nullptr), NNFW_STATUS_ERROR);
 }

--- a/tests/nnfw_api/src/NNPackageTests/SessionCreated.test.cc
+++ b/tests/nnfw_api/src/NNPackageTests/SessionCreated.test.cc
@@ -124,3 +124,27 @@ TEST_F(ValidationTestSessionCreated, neg_internal_set_config)
   // All arguments are valid, but the session state is wrong
   ASSERT_EQ(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "0"), NNFW_STATUS_INVALID_STATE);
 }
+
+TEST_F(ValidationTestSessionCreated, set_workspace)
+{
+  NNFW_ENSURE_SUCCESS(nnfw_set_workspace(_session, "."));
+  SUCCEED();
+}
+
+TEST_F(ValidationTestSessionCreated, neg_set_workspace)
+{
+  ASSERT_EQ(nnfw_set_workspace(_session, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
+}
+
+TEST_F(ValidationTestSessionCreated, neg_set_execute_config_with_no_workspace)
+{
+  NNFW_ENSURE_SUCCESS(nnfw_set_workspace(_session, ""));
+  auto cbuf = genAddModel();
+  NNFW_ENSURE_SUCCESS(nnfw_load_circle_from_buffer(_session, cbuf.buffer(), cbuf.size()));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
+
+  // Some execution config requires workspace
+  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_DUMP_MINMAX, nullptr),
+            NNFW_STATUS_ERROR);
+  EXPECT_EQ(nnfw_set_execute_config(_session, NNFW_RUN_CONFIG_TRACE, nullptr), NNFW_STATUS_ERROR);
+}


### PR DESCRIPTION
This commit changes some API status condition
- `nnfw_set_workspace`: should be called before model loading to support cached optimized model auto loading later
- `nnfw_set_quantization_type`, `nnfw_set_quantized_model_path`, `nnfw_quantize`, `nnfw_set_codegen_model_path`, `nnfw_codegen`: allow to be called after prepare to support full quantization with minmax data collection

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>