### PR TITLE
[onert-micro] Reduce Reshape and ExpandDims code duplication

### DIFF
--- a/onert-micro/onert-micro/include/execute/kernels/ReshapeCommon.h
+++ b/onert-micro/onert-micro/include/execute/kernels/ReshapeCommon.h
@@ -14,21 +14,28 @@
  * limitations under the License.
  */
 
-#include "execute/kernels/ReshapeCommon.h"
+#ifndef ONERT_MICRO_EXECUTE_KERNELS_RESHAPE_COMMON_H
+#define ONERT_MICRO_EXECUTE_KERNELS_RESHAPE_COMMON_H
 
-using namespace onert_micro;
-using namespace onert_micro::execute;
+#include "OMStatus.h"
 
-namespace
+#include "core/OMUtils.h"
+#include "core/OMKernelData.h"
+#include "core/OMDataType.h"
+
+#include "execute/OMKernelExecutionBuilder.h"
+#include "execute/OMUtils.h"
+#include "execute/OMRuntimeKernel.h"
+#include <functional>
+
+namespace onert_micro
+{
+namespace execute
 {
 
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
+OMStatus execute_reshape_common(const OMExecuteArgs &execute_args);
 
-} // namespace
+} // namespace execute
+} // namespace onert_micro
 
-// NOTE: doesnt currently support dynamic shapes
-OMStatus onert_micro::execute::execute_kernel_CircleReshape(const OMExecuteArgs &execute_args)
-{
-  return execute_reshape_common(execute_args);
-}
+#endif // ONERT_MICRO_EXECUTE_KERNELS_RESHAPE_COMMON_H

--- a/onert-micro/onert-micro/src/execute/CMakeLists.txt
+++ b/onert-micro/onert-micro/src/execute/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
         OMUtils.cpp
         kernels/ConvolutionCommon.cpp
         kernels/PoolingCommon.cpp
+        kernels/ReshapeCommon.cpp
         )
 
 # Add configure kernels

--- a/onert-micro/onert-micro/src/execute/kernels/ExpandDims.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/ExpandDims.cpp
@@ -14,63 +14,13 @@
  * limitations under the License.
  */
 
-#include "OMStatus.h"
-
-#include "core/OMUtils.h"
-#include "core/OMDataType.h"
-
-#include "execute/OMKernelExecutionBuilder.h"
-#include "execute/OMRuntimeKernel.h"
+#include "execute/kernels/ReshapeCommon.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleExpandDims(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
-
-  OMRuntimeKernel runtime_kernel;
-  runtime_kernel.readKernel(op_index, runtime_context);
-
-  const circle::Tensor *input = runtime_kernel.inputs[inputTensorIdx];
-  const circle::Tensor *output = runtime_kernel.outputs[outputTensorIdx];
-
-  assert(input != nullptr);
-  assert(output != nullptr);
-
-  OMStatus status = Ok;
-
-  status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-  if (status != Ok)
-    return status;
-
-  uint8_t *input_data = runtime_kernel.inputs_data[inputTensorIdx];
-  uint8_t *output_data = runtime_kernel.outputs_data[outputTensorIdx];
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  // Check is it inplace kernel
-  if (input_data == output_data)
-    return Ok;
-
-  const core::OMRuntimeShape shape(input);
-
-  const size_t element_size =
-    static_cast<uint32_t>(getOMDataTypeSize(core::onertMicroDatatype(input->type())));
-  const int32_t num_elements = shape.flatSize();
-  std::memcpy(output_data, input_data, num_elements * element_size);
-
-  return status;
+  return execute_reshape_common(execute_args);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/ReshapeCommon.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/ReshapeCommon.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "execute/kernels/ReshapeCommon.h"
+
+using namespace onert_micro;
+using namespace onert_micro::execute;
+
+namespace
+{
+
+constexpr uint32_t inputTensorIdx = 0;
+constexpr uint32_t outputTensorIdx = 0;
+
+} // namespace
+
+// NOTE: doesnt currently support dynamic shapes
+OMStatus onert_micro::execute::execute_reshape_common(const OMExecuteArgs &execute_args)
+{
+  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
+  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
+  uint16_t op_index = execute_args.kernel_index;
+
+  OMRuntimeKernel runtime_kernel;
+  runtime_kernel.readKernel(op_index, runtime_context);
+
+  const circle::Tensor *input = runtime_kernel.inputs[inputTensorIdx];
+  const circle::Tensor *output = runtime_kernel.outputs[outputTensorIdx];
+
+  assert(input != nullptr);
+  assert(output != nullptr);
+
+  OMStatus status = Ok;
+
+  status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
+  if (status != Ok)
+    return status;
+
+  uint8_t *input_data = runtime_kernel.inputs_data[inputTensorIdx];
+  uint8_t *output_data = runtime_kernel.outputs_data[outputTensorIdx];
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  // Check is it inplace kernel
+  if (input_data == output_data)
+    return Ok;
+
+  const core::OMRuntimeShape shape(input);
+
+  const size_t element_size =
+    static_cast<uint32_t>(getOMDataTypeSize(core::onertMicroDatatype(input->type())));
+  const int32_t num_elements = shape.flatSize();
+  std::memcpy(output_data, input_data, num_elements * element_size);
+
+  return status;
+}


### PR DESCRIPTION
This pr reduces code duplication for Reshape and ExpandDims.

for https://github.com/Samsung/ONE/issues/13272

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>