### PR TITLE
[luci] Use auto & instead of auto

### DIFF
--- a/compiler/luci/export/src/CircleExporterImpl.cpp
+++ b/compiler/luci/export/src/CircleExporterImpl.cpp
@@ -76,7 +76,7 @@ Offset<Vector<Offset<OperatorCode>>>
 encodeOperatorCodes(FlatBufferBuilder &builder, std::unordered_map<luci::OpCode, uint32_t> &opcodes)
 {
   std::vector<Offset<OperatorCode>> operator_codes_vec(opcodes.size());
-  for (auto it : opcodes)
+  for (const auto &it : opcodes)
   {
     uint32_t idx = it.second;
     int8_t dep_code = 127; // BuiltinOperator_PLACEHOLDER_FOR_GREATER_OP_CODES

--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -506,7 +506,7 @@ encodeSparsityParameters(FlatBufferBuilder &builder, luci::SparsityParam *sparsi
 
   std::vector<flatbuffers::Offset<circle::DimensionMetadata>> dim_metadata_vec;
   auto luci_dim_metadata = sparsityparam->dim_metadata;
-  for (auto it : luci_dim_metadata)
+  for (const auto &it : luci_dim_metadata)
   {
     // array_segments
     auto circle_array_segments = to_circle_sparse_index_vector(builder, it.array_segments());

--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -444,7 +444,7 @@ void CircleQuantizer::quantize(loco::Graph *g) const
     }
 
     // Clear existing quantparams before doing fake quantization
-    for (auto node : loco::active_nodes(loco::output_nodes(g)))
+    for (auto &node : loco::active_nodes(loco::output_nodes(g)))
     {
       auto circle_node = loco::must_cast<luci::CircleNode *>(node);
       if (circle_node->quantparam() != nullptr)


### PR DESCRIPTION
This commit uses auto & to resolve static analysis warning.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>