### PR TITLE
[onert] Change ODC input file setting

### DIFF
--- a/runtime/onert/core/include/odc/CodegenManager.h
+++ b/runtime/onert/core/include/odc/CodegenManager.h
@@ -37,7 +37,7 @@ class CodegenManager
 {
 public:
   // Non-copyable
-  CodegenManager(const std::string &model_path) : _model_path(model_path) {}
+  CodegenManager() = default;
   CodegenManager(CodegenManager const &) = delete;
   CodegenManager &operator=(CodegenManager const &) = delete;
 
@@ -59,19 +59,19 @@ public:
   /**
    * @brief Execute code generator
    *
-   * @param target  Target backend name
-   *                This target string will be used to find a backend library.
-   *                The name of target backend library should follow the following rules:
-   *                  'lib' + {backend extension} + '-gen' + {lib extension}
-   *                And the target string should be a name except 'lib' and {lib extension}.
-   *                For example, if the backend extension is 'aaa', the backend library name
-   *                should be 'libaaa-gen.so', and the target string should be 'aaa-gen'.
-   * @param pref    @c CodegenPreference Codegen preference
+   * @param model[in]   Model to be compiled
+   * @param target[in]  Target backend name
+   *                    This target string will be used to find a backend library.
+   *                    The name of target backend library should follow the following rules:
+   *                      'lib' + {backend extension} + '-gen' + {lib extension}
+   *                    And the target string should be a name except 'lib' and {lib extension}.
+   *                    For example, if the backend extension is 'aaa', the backend library name
+   *                    should be 'libaaa-gen.so', and the target string should be 'aaa-gen'.
+   * @param pref        @c CodegenPreference Codegen preference
    */
-  bool codegen(const char *target, CodegenPreference pref);
+  bool codegen(const std::string &model_path, const char *target, CodegenPreference pref);
 
 private:
-  std::string _model_path = "";
   std::string _export_model_path = "";
 };
 

--- a/runtime/onert/core/include/odc/QuantizeManager.h
+++ b/runtime/onert/core/include/odc/QuantizeManager.h
@@ -34,8 +34,7 @@ class QuantizeManager
 {
 public:
   // Non-copyable
-  QuantizeManager() = delete;
-  QuantizeManager(const std::string &model_path) : _model_path(model_path) {}
+  QuantizeManager() = default;
   QuantizeManager(QuantizeManager const &) = delete;
   QuantizeManager &operator=(QuantizeManager const &) = delete;
 
@@ -64,14 +63,13 @@ public:
   void quantizeType(QuantizeType qtype) { _qtype = qtype; }
 
   /**
-   * @brief  Quantize model
-   *
-   * @return  true if success, otherwise false
+   * @brief     Quantize model
+   * @param[in] model_path  Model path to quantize
+   * @return    @c true if success, otherwise @c false
    */
-  bool quantize();
+  bool quantize(const std::string &model_path);
 
 private:
-  std::string _model_path = "";
   std::string _export_model_path = "";
   QuantizeType _qtype = ODC_QTYPE_NOT_SET;
 };

--- a/runtime/onert/core/src/odc/CodegenManager.cc
+++ b/runtime/onert/core/src/odc/CodegenManager.cc
@@ -25,7 +25,8 @@ namespace onert
 namespace odc
 {
 
-bool CodegenManager::codegen(const char *target, CodegenPreference pref)
+bool CodegenManager::codegen(const std::string &model_path, const char *target,
+                             CodegenPreference pref)
 {
   if (target == nullptr)
     throw std::runtime_error("Target string is not set");
@@ -33,7 +34,7 @@ bool CodegenManager::codegen(const char *target, CodegenPreference pref)
   if (_export_model_path.empty())
     throw std::runtime_error("Export model path is not set");
 
-  if (_model_path.empty())
+  if (model_path.empty())
     throw std::runtime_error("Model path does not exist");
 
   // codegen function is thread-unsafe
@@ -45,7 +46,7 @@ bool CodegenManager::codegen(const char *target, CodegenPreference pref)
   const auto code_generator = codegen_loader.get();
   // TODO Use compile preference
   UNUSED_RELEASE(pref);
-  const auto result = code_generator->codegen(_model_path.c_str(), _export_model_path.c_str());
+  const auto result = code_generator->codegen(model_path.c_str(), _export_model_path.c_str());
   codegen_loader.unloadLibrary();
 
   return (result == 0);

--- a/runtime/onert/core/src/odc/QuantizeManager.cc
+++ b/runtime/onert/core/src/odc/QuantizeManager.cc
@@ -25,9 +25,9 @@ namespace onert
 namespace odc
 {
 
-bool QuantizeManager::quantize()
+bool QuantizeManager::quantize(const std::string &model_path)
 {
-  if (_model_path.empty() || _export_model_path.empty())
+  if (model_path.empty() || _export_model_path.empty())
     return false;
 
   // Compile function is thread-unsafe
@@ -39,7 +39,7 @@ bool QuantizeManager::quantize()
     return false;
 
   auto quantizer = quantize_loader.get();
-  auto result = quantizer->quantize(_model_path.c_str(), _export_model_path.c_str(), _qtype);
+  auto result = quantizer->quantize(model_path.c_str(), _export_model_path.c_str(), _qtype);
 
   // TODO Unload quantize library to reduce memory usage
 

--- a/runtime/onert/core/src/odc/QuantizeManager.test.cc
+++ b/runtime/onert/core/src/odc/QuantizeManager.test.cc
@@ -23,16 +23,16 @@ using namespace onert::odc;
 // Test export model path is not set
 TEST(odc_QuantizeManager, neg_export_model_path_not_set)
 {
-  QuantizeManager manager("model_path");
+  QuantizeManager manager;
   manager.quantizeType(ODC_QTYPE_WO_I8_SYM);
-  ASSERT_EQ(manager.quantize(), false);
+  ASSERT_EQ(manager.quantize("model_path"), false);
 }
 
 // Test invalid model path
 TEST(odc_QuantizeManager, neg_invalid_model_path)
 {
-  QuantizeManager manager("invalid_model_path.circle");
+  QuantizeManager manager;
   manager.exportModelPath("export_model_path.circle");
   manager.quantizeType(ODC_QTYPE_WO_I8_SYM);
-  ASSERT_EQ(manager.quantize(), false);
+  ASSERT_EQ(manager.quantize("invalid_model_path.circle"), false);
 }


### PR DESCRIPTION
This commit changes CodegenManager and QuantizeManager input file setting. 
Because input file can be changed by API, CodegenManager and QuantizeManager get input file from running method parameter, not constructor.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>