### PR TITLE
[onert/test] Add SUCCEED to unittest

### DIFF
--- a/compute/cker/src/train/Conv.test.cc
+++ b/compute/cker/src/train/Conv.test.cc
@@ -384,6 +384,8 @@ TEST(CKer_Operation, ConvGrad)
     ConvVerifier<float>::verifyInputGradExpected(params, incoming_shape, incoming.data(),
                                                  filter_shape, filter.data(), padding_bottom,
                                                  padding_right, input_shape);
+
+    SUCCEED();
   }
 }
 

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Add.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Add.test.cc
@@ -37,6 +37,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Add_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Add_InvalidType)
@@ -58,4 +60,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Add_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/MaxPool2D.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/MaxPool2D.test.cc
@@ -238,6 +238,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_MaxPool2D_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_MaxPool2D_InvalidType)
@@ -259,4 +261,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_MaxPool2D_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Mean.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Mean.test.cc
@@ -78,6 +78,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Mean_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Mean_InvalidType)
@@ -101,4 +103,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Mean_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Mul.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Mul.test.cc
@@ -37,6 +37,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Mul_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Mul_InvalidType)
@@ -58,4 +60,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Mul_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Pad.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Pad.test.cc
@@ -77,6 +77,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Pad_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Pad_InvalidType)
@@ -101,4 +103,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Pad_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Relu.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Relu.test.cc
@@ -80,6 +80,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Relu_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Relu_InvalidType)
@@ -102,4 +104,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Relu_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Relu6.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Relu6.test.cc
@@ -80,6 +80,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Relu6_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Relu6_InvalidType)
@@ -102,4 +104,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Relu6_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Reshape.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Reshape.test.cc
@@ -82,6 +82,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Reshape_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Reshape_InvalidType)
@@ -106,4 +108,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Reshape_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Softmax.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Softmax.test.cc
@@ -76,6 +76,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Softmax_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Softmax_InvalidType)
@@ -99,4 +101,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Softmax_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Sub.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/nontrainable_op_trains/Sub.test.cc
@@ -38,6 +38,8 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Sub_InvalidShape)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTrain, neg_NonTrainableOps_Sub_InvalidType)
@@ -59,4 +61,6 @@ TEST_F(GenModelTrain, neg_NonTrainableOps_Sub_InvalidType)
   _context = std::make_unique<GenModelTrainContext>(cgen.finish());
   _context->setBackends({"train"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
 }


### PR DESCRIPTION
This commit adds SUCCEED() macro to unittest for TC checker workaround.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>