### PR TITLE
[onert-micro] Reduce Math ops code duplication

### DIFF
--- a/onert-micro/onert-micro/include/execute/kernels/MathCommon.h
+++ b/onert-micro/onert-micro/include/execute/kernels/MathCommon.h
@@ -14,41 +14,32 @@
  * limitations under the License.
  */
 
-#ifndef ONERT_MICRO_EXECUTE_PAL_NEG_COMMON_H
-#define ONERT_MICRO_EXECUTE_PAL_NEG_COMMON_H
+#ifndef ONERT_MICRO_EXECUTE_KERNELS_MATH_COMMON_H
+#define ONERT_MICRO_EXECUTE_KERNELS_MATH_COMMON_H
 
-#include "PALSISOOperation.h"
+#include "OMStatus.h"
+
+#include "core/OMUtils.h"
+#include "core/OMKernelData.h"
+#include "core/OMDataType.h"
+
+#include "execute/OMKernelExecutionBuilder.h"
+#include "execute/OMUtils.h"
+#include "execute/OMRuntimeKernel.h"
+#include <functional>
 
 namespace onert_micro
 {
 namespace execute
 {
-namespace pal
-{
 
-template <typename T>
-inline OMStatus Neg(const core::OMRuntimeShape &input_shape, const T *input_data,
-                    const core::OMRuntimeShape &output_shape, T *output_data)
-{
-  const uint32_t flat_size = input_shape.flatSize();
+OMStatus execute_math_common(
+  const OMExecuteArgs &execute_args,
+  const std::function<OMStatus(const core::OMRuntimeShape &input_shape, const float *input_data,
+                               const core::OMRuntimeShape &output_shape, float *output_data)>
+    &f_float);
 
-  if (flat_size == -1)
-    return UnknownError;
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  assert(input_shape == output_shape);
-
-  for (int i = 0; i < flat_size; i++)
-  {
-    output_data[i] = -(input_data[i]);
-  }
-
-  return Ok;
-}
-} // namespace pal
 } // namespace execute
 } // namespace onert_micro
 
-#endif // ONERT_MICRO_EXECUTE_PAL_NEG_COMMON_H
+#endif // ONERT_MICRO_EXECUTE_KERNELS_MATH_COMMON_H

--- a/onert-micro/onert-micro/include/pal/common/PALCosCommon.h
+++ b/onert-micro/onert-micro/include/pal/common/PALCosCommon.h
@@ -34,8 +34,22 @@ template <typename T>
 inline OMStatus Cos(const core::OMRuntimeShape &input_shape, const T *input_data,
                     const core::OMRuntimeShape &output_shape, T *output_data)
 {
-  return SISOOperation<T>(input_shape, input_data, output_shape, output_data,
-                          [](T arg) -> T { return std::cos(arg); });
+  const uint32_t flat_size = input_shape.flatSize();
+
+  if (flat_size == -1)
+    return UnknownError;
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  assert(input_shape == output_shape);
+
+  for (int i = 0; i < flat_size; i++)
+  {
+    output_data[i] = std::cos(input_data[i]);
+  }
+
+  return Ok;
 }
 } // namespace pal
 } // namespace execute

--- a/onert-micro/onert-micro/include/pal/common/PALExpCommon.h
+++ b/onert-micro/onert-micro/include/pal/common/PALExpCommon.h
@@ -34,8 +34,22 @@ template <typename T>
 inline OMStatus Exp(const core::OMRuntimeShape &input_shape, const T *input_data,
                     const core::OMRuntimeShape &output_shape, T *output_data)
 {
-  return SISOOperation<T>(input_shape, input_data, output_shape, output_data,
-                          [](T arg) -> T { return std::exp(arg); });
+  const uint32_t flat_size = input_shape.flatSize();
+
+  if (flat_size == -1)
+    return UnknownError;
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  assert(input_shape == output_shape);
+
+  for (int i = 0; i < flat_size; i++)
+  {
+    output_data[i] = std::exp(input_data[i]);
+  }
+
+  return Ok;
 }
 } // namespace pal
 } // namespace execute

--- a/onert-micro/onert-micro/include/pal/common/PALLogCommon.h
+++ b/onert-micro/onert-micro/include/pal/common/PALLogCommon.h
@@ -34,8 +34,22 @@ template <typename T>
 inline OMStatus Log(const core::OMRuntimeShape &input_shape, const T *input_data,
                     const core::OMRuntimeShape &output_shape, T *output_data)
 {
-  return SISOOperation<T>(input_shape, input_data, output_shape, output_data,
-                          [](T arg) -> T { return std::log(arg); });
+  const uint32_t flat_size = input_shape.flatSize();
+
+  if (flat_size == -1)
+    return UnknownError;
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  assert(input_shape == output_shape);
+
+  for (int i = 0; i < flat_size; i++)
+  {
+    output_data[i] = std::log(input_data[i]);
+  }
+
+  return Ok;
 }
 } // namespace pal
 } // namespace execute

--- a/onert-micro/onert-micro/include/pal/common/PALSinCommon.h
+++ b/onert-micro/onert-micro/include/pal/common/PALSinCommon.h
@@ -35,8 +35,22 @@ template <typename T>
 inline OMStatus Sin(const core::OMRuntimeShape &input_shape, const T *input_data,
                     const core::OMRuntimeShape &output_shape, T *output_data)
 {
-  return SISOOperation<T>(input_shape, input_data, output_shape, output_data,
-                          [](T arg) -> T { return std::sin(arg); });
+  const uint32_t flat_size = input_shape.flatSize();
+
+  if (flat_size == -1)
+    return UnknownError;
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  assert(input_shape == output_shape);
+
+  for (int i = 0; i < flat_size; i++)
+  {
+    output_data[i] = std::sin(input_data[i]);
+  }
+
+  return Ok;
 }
 } // namespace pal
 } // namespace execute

--- a/onert-micro/onert-micro/include/pal/common/PALSqrtCommon.h
+++ b/onert-micro/onert-micro/include/pal/common/PALSqrtCommon.h
@@ -34,8 +34,22 @@ template <typename T>
 inline OMStatus Sqrt(const core::OMRuntimeShape &input_shape, const T *input_data,
                      const core::OMRuntimeShape &output_shape, T *output_data)
 {
-  return SISOOperation<T>(input_shape, input_data, output_shape, output_data,
-                          [](T arg) -> T { return std::sqrt(arg); });
+  const uint32_t flat_size = input_shape.flatSize();
+
+  if (flat_size == -1)
+    return UnknownError;
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  assert(input_shape == output_shape);
+
+  for (int i = 0; i < flat_size; i++)
+  {
+    output_data[i] = std::sqrt(input_data[i]);
+  }
+
+  return Ok;
 }
 } // namespace pal
 } // namespace execute

--- a/onert-micro/onert-micro/include/pal/common/PALSquareCommon.h
+++ b/onert-micro/onert-micro/include/pal/common/PALSquareCommon.h
@@ -34,8 +34,22 @@ template <typename T>
 inline OMStatus Square(const core::OMRuntimeShape &input_shape, const T *input_data,
                        const core::OMRuntimeShape &output_shape, T *output_data)
 {
-  return SISOOperation<T>(input_shape, input_data, output_shape, output_data,
-                          [](T arg) -> T { return arg * arg; });
+  const uint32_t flat_size = input_shape.flatSize();
+
+  if (flat_size == -1)
+    return UnknownError;
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  assert(input_shape == output_shape);
+
+  for (int i = 0; i < flat_size; i++)
+  {
+    output_data[i] = (input_data[i]) * (input_data[i]);
+  }
+
+  return Ok;
 }
 } // namespace pal
 } // namespace execute

--- a/onert-micro/onert-micro/include/pal/common/PALTanhCommon.h
+++ b/onert-micro/onert-micro/include/pal/common/PALTanhCommon.h
@@ -31,7 +31,22 @@ template <typename T>
 inline OMStatus Tanh(const core::OMRuntimeShape &input_shape, const T *input_data,
                      const core::OMRuntimeShape &output_shape, T *output_data)
 {
-  return UnaryOp<T, TanhFunctor<T>>(input_shape, input_data, output_shape, output_data);
+  const uint32_t flat_size = input_shape.flatSize();
+
+  if (flat_size == -1)
+    return UnknownError;
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  assert(input_shape == output_shape);
+
+  for (int i = 0; i < flat_size; i++)
+  {
+    output_data[i] = std::tanh(input_data[i]);
+  }
+
+  return Ok;
 }
 } // namespace pal
 } // namespace execute

--- a/onert-micro/onert-micro/src/execute/CMakeLists.txt
+++ b/onert-micro/onert-micro/src/execute/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
         OMRuntimeKernel.cpp
         OMUtils.cpp
         kernels/ConvolutionCommon.cpp
+        kernels/MathCommon.cpp
         kernels/PoolingCommon.cpp
         kernels/ReadKernelDataCommon.cpp
         kernels/ReshapeCommon.cpp

--- a/onert-micro/onert-micro/src/execute/kernels/Abs.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Abs.cpp
@@ -14,73 +14,20 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALAbs.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleAbs(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto abs_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                             const core::OMRuntimeShape &output_shape, float *output_data) {
+    assert(input_shape == output_shape);
+    return pal::Abs(input_shape, input_data, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-    case circle::TensorType_FLOAT32:
-      status = pal::Abs(core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-                        core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, abs_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Cos.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Cos.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALCos.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleCos(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto cos_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                             const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Cos(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Cos<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, cos_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Exp.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Exp.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALExp.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleExp(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto exp_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                             const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Exp(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Exp<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, exp_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Floor.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Floor.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALFloor.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleFloor(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto floor_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                               const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Floor(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status =
-        pal::Floor(core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-                   core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, floor_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/FloorDiv.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/FloorDiv.cpp
@@ -28,11 +28,6 @@ using namespace onert_micro::core;
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleFloorDiv(const OMExecuteArgs &execute_args)
 {
-
-  const float *cast_input_data1 = nullptr;
-  const float *cast_input_data2 = nullptr;
-  float *cast_output_data = nullptr;
-
   uint8_t *input_data1;
   uint8_t *input_data2;
   uint8_t *output_data;

--- a/onert-micro/onert-micro/src/execute/kernels/Log.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Log.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALLog.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleLog(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto log_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                             const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Log(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Log<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, log_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/MathCommon.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/MathCommon.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "execute/kernels/MathCommon.h"
+
+using namespace onert_micro;
+using namespace onert_micro::execute;
+
+namespace
+{
+
+constexpr uint32_t inputTensorIdx = 0;
+constexpr uint32_t outputTensorIdx = 0;
+
+} // namespace
+
+// NOTE: doesnt currently support dynamic shapes
+OMStatus onert_micro::execute::execute_math_common(
+  const OMExecuteArgs &execute_args,
+  const std::function<OMStatus(const core::OMRuntimeShape &, const float *,
+                               const core::OMRuntimeShape &, float *)> &f_float)
+{
+  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
+  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
+  uint16_t op_index = execute_args.kernel_index;
+
+  const circle::Tensor *input = nullptr;
+  const circle::Tensor *output = nullptr;
+
+  uint8_t *input_data = nullptr;
+  uint8_t *output_data = nullptr;
+
+  OMStatus status = Ok;
+
+  {
+    OMRuntimeKernel runtime_kernel;
+    runtime_kernel.readKernel(op_index, runtime_context);
+
+    input = runtime_kernel.inputs[inputTensorIdx];
+    output = runtime_kernel.outputs[outputTensorIdx];
+
+    assert(input != nullptr);
+    assert(output != nullptr);
+
+    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
+    if (status != Ok)
+      return status;
+
+    input_data = runtime_kernel.inputs_data[inputTensorIdx];
+    output_data = runtime_kernel.outputs_data[outputTensorIdx];
+  }
+
+  assert(input_data != nullptr);
+  assert(output_data != nullptr);
+
+  switch (input->type())
+  {
+#ifndef DIS_FLOAT
+
+    case circle::TensorType_FLOAT32:
+      status =
+        f_float(core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
+                core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
+      break;
+#endif // DIS_FLOAT
+    default:
+    {
+      status = UnsupportedType;
+      assert(false && "Unsupported type.");
+    }
+  }
+
+  return status;
+}

--- a/onert-micro/onert-micro/src/execute/kernels/Neg.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Neg.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALNeg.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleNeg(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto neg_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                             const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Neg(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Neg<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, neg_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Round.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Round.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALRound.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleRound(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto round_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                               const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Round(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Round<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, round_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Rsqrt.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Rsqrt.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALRsqrt.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleRsqrt(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto rsqrt_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                               const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Rsqrt(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Rsqrt<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, rsqrt_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Sin.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Sin.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALSin.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleSin(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto sin_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                             const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Sin(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Sin<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, sin_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Sqrt.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Sqrt.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALSqrt.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleSqrt(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto sqrt_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                              const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Sqrt(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Sqrt<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, sqrt_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Square.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Square.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALSquare.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleSquare(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto square_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                                const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Square(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Square<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, square_float_lambda);
 }

--- a/onert-micro/onert-micro/src/execute/kernels/Tanh.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Tanh.cpp
@@ -14,75 +14,19 @@
  * limitations under the License.
  */
 
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
-#include "core/OMUtils.h"
+#include "execute/kernels/MathCommon.h"
 #include "PALTanh.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
-
-constexpr uint32_t inputTensorIdx = 0;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
 // NOTE: doesnt currently support dynamic shapes
 OMStatus onert_micro::execute::execute_kernel_CircleTanh(const OMExecuteArgs &execute_args)
 {
-  core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
-  core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
+  auto tanh_float_lambda = [](const core::OMRuntimeShape &input_shape, const float *input_data,
+                              const core::OMRuntimeShape &output_shape, float *output_data) {
+    return pal::Tanh(input_shape, input_data, output_shape, output_data);
+  };
 
-  const circle::Tensor *input = nullptr;
-  const circle::Tensor *output = nullptr;
-
-  uint8_t *input_data = nullptr;
-  uint8_t *output_data = nullptr;
-
-  OMStatus status = Ok;
-
-  {
-    OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
-
-    input = runtime_kernel.inputs[inputTensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-
-    assert(input != nullptr);
-    assert(output != nullptr);
-
-    status = runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
-    if (status != Ok)
-      return status;
-
-    input_data = runtime_kernel.inputs_data[inputTensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-  }
-
-  assert(input_data != nullptr);
-  assert(output_data != nullptr);
-
-  switch (input->type())
-  {
-#ifndef DIS_FLOAT
-
-    case circle::TensorType_FLOAT32:
-      status = pal::Tanh<float>(
-        core::OMRuntimeShape(input), core::utils::castInputData<float>(input_data),
-        core::OMRuntimeShape(output), core::utils::castOutputData<float>(output_data));
-      break;
-#endif // DIS_FLOAT
-    default:
-    {
-      status = UnsupportedType;
-      assert(false && "Unsupported type.");
-    }
-  }
-
-  return status;
+  return execute_math_common(execute_args, tanh_float_lambda);
 }


### PR DESCRIPTION
This pr reduces code duplication for Math ops and change pal to remove redundant lambda call.

for #13272

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>