### PR TITLE
[onert-micro] Fix wrong negative suffix

### DIFF
--- a/onert-micro/onert-micro/src/train/tests/BostonHousingTask.test.cpp
+++ b/onert-micro/onert-micro/src/train/tests/BostonHousingTask.test.cpp
@@ -105,7 +105,7 @@ TEST_F(BostonHousingTaskTest, ADAM_MSE_P)
   EXPECT_LE(mae_metric_after_training, golden_mae_metric);
 }
 
-TEST_F(BostonHousingTaskTest, Wrong_Loss_N)
+TEST_F(BostonHousingTaskTest, Wrong_Loss_NEG)
 {
   // Create BostonHousing data handler
   BostonHousingTask<float> bostonTask;

--- a/onert-micro/onert-micro/src/train/tests/CheckpointsHandler.test.cpp
+++ b/onert-micro/onert-micro/src/train/tests/CheckpointsHandler.test.cpp
@@ -84,7 +84,7 @@ TEST_F(CheckpointsHandlerTest, Load_check_P)
 }
 
 // Check load functionality
-TEST_F(CheckpointsHandlerTest, Wrong_magic_num_N)
+TEST_F(CheckpointsHandlerTest, Wrong_magic_num_NEG)
 {
   // Create BostonHousing data handler
   config.model_ptr = reinterpret_cast<char *>(models::checkpoint_simple_example_model_data);


### PR DESCRIPTION
- Wrong_Loss_t to Wrong_Loss_NEG
- Wrong_magic_num_N -> Wrong_magic_num_NEG

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>