### PR TITLE
[onert] Bump up to 1.28.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2020, Samsung Research & contributors'
 author = 'Samsung Research & contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '1.27.0'
+release = '1.28.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -1,6 +1,6 @@
 Name:    nnfw
 Summary: nnfw
-Version: 1.27.0
+Version: 1.28.0
 Release: 1
 Group:   Development
 License: Apache-2.0 and MIT and BSD-2-Clause and MPL-2.0

--- a/runtime/contrib/android/api/build.gradle
+++ b/runtime/contrib/android/api/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 26
         targetSdkVersion 29
         versionCode 1
-        versionName "1.27.0"
+        versionName "1.28.0"
 
         externalNativeBuild {
             ndkBuild {

--- a/runtime/onert/api/nnfw/include/nnfw_version.h
+++ b/runtime/onert/api/nnfw/include/nnfw_version.h
@@ -21,6 +21,6 @@
  * NNFW_VERSION is a uint32 value representing nnfw runtime version
  * in 0xMMmmmmPP, where MM = major, mmmm = minor, PP = patch
  */
-#define NNFW_VERSION 0x01001b00
+#define NNFW_VERSION 0x01001C00
 
 #endif // __NNFW_VERSION_H__


### PR DESCRIPTION
This commit bumps up to 1.28.0.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related: https://github.com/Samsung/ONE/issues/13283