### PR TITLE
Draft: Revisit Tensor struct and Executor I/O setting

### DIFF
--- a/runtime/onert/backend/train/optimizer/Optimizers.test.cc
+++ b/runtime/onert/backend/train/optimizer/Optimizers.test.cc
@@ -44,34 +44,6 @@ public:
     std::copy(data.begin(), data.end(), _data.begin());
   }
 
-  size_t total_size() const override
-  {
-    size_t total_size = _info.shape().num_elements();
-    total_size *= sizeOfDataType(data_type());
-    return total_size;
-  }
-
-  size_t calcOffset(const ir::Coordinates &coords) const override
-  {
-    const auto &shape = _info.shape();
-    std::vector<size_t> strides(shape.rank());
-
-    size_t stride = 1;
-    for (int32_t i = shape.rank() - 1; i >= 0; --i)
-    {
-      strides.at(i) = stride;
-      stride = stride * shape.dim(i);
-    }
-
-    size_t offset = 0;
-    for (int32_t i = 0; i < shape.rank(); ++i)
-    {
-      offset += (strides[i] * coords[i]);
-    }
-    offset *= sizeOfDataType(data_type());
-    return offset;
-  }
-
   uint8_t *buffer() const override
   {
     if (_data.size() != total_size())
@@ -83,10 +55,6 @@ public:
   template <typename T> const std::vector<T> &data() const { return _data; }
 
   ir::Layout layout() const override { return ir::Layout::NHWC; }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-
-  bool is_dynamic() const override { return false; }
-  Shape getShape() const override { return _info.shape(); }
 
 private:
   using ITensor::setShape;
@@ -113,34 +81,6 @@ public:
     std::copy(data.begin(), data.end(), _data.begin());
   }
 
-  size_t total_size() const override
-  {
-    size_t total_size = _info.shape().num_elements();
-    total_size *= sizeOfDataType(data_type());
-    return total_size;
-  }
-
-  size_t calcOffset(const ir::Coordinates &coords) const override
-  {
-    const auto &shape = _info.shape();
-    std::vector<size_t> strides(shape.rank());
-
-    size_t stride = 1;
-    for (int32_t i = shape.rank() - 1; i >= 0; --i)
-    {
-      strides.at(i) = stride;
-      stride = stride * shape.dim(i);
-    }
-
-    size_t offset = 0;
-    for (int32_t i = 0; i < shape.rank(); ++i)
-    {
-      offset += (strides[i] * coords[i]);
-    }
-    offset *= sizeOfDataType(data_type());
-    return offset;
-  }
-
   uint8_t *buffer() const override
   {
     if (_data.size() != total_size())
@@ -150,10 +90,6 @@ public:
   }
 
   ir::Layout layout() const override { return ir::Layout::NHWC; }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-
-  bool is_dynamic() const override { return false; }
-  Shape getShape() const override { return _info.shape(); }
 
 public:
   std::vector<ITensor *> optVars() override

--- a/runtime/onert/core/include/backend/IPortableTensor.h
+++ b/runtime/onert/core/include/backend/IPortableTensor.h
@@ -42,7 +42,7 @@ public:
 
   virtual ~IPortableTensor();
   virtual const ir::Sparsity *sparsity() const { return nullptr; }
-  const ir::OperandInfo &get_info() const { return _info; }
+  virtual const ir::OperandInfo &get_info() const { return _info; }
   float data_scale() const override { return _info.typeInfo().scale(); }
   int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
   const std::vector<float> &data_scales() const override { return _info.typeInfo().scales(); }

--- a/runtime/onert/core/include/backend/IPortableTensor.h
+++ b/runtime/onert/core/include/backend/IPortableTensor.h
@@ -41,17 +41,31 @@ public:
   IPortableTensor(const ir::OperandInfo &info) : _info(info) {}
 
   virtual ~IPortableTensor();
-  virtual const ir::Sparsity *sparsity() const { return nullptr; }
-  virtual const ir::OperandInfo &get_info() const { return _info; }
-  float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
-  const std::vector<float> &data_scales() const override { return _info.typeInfo().scales(); }
-  const std::vector<int32_t> &data_zero_points() const override
+
+public:
+  // It is introduced to reduce virtual method call overhead on inference
+  // So derived class should maintain actual OperandInfo to "_info" field
+  // Ex. CPU backend getShape() in OperationUtils.h is called frequently on inference
+  //     and it calls get_info()
+  const ir::OperandInfo &get_info() const { return _info; }
+  const ir::Sparsity *sparsity() const { return _info.typeInfo().sparsity(); }
+
+  // Finailized methods for IPortableTensor by "_info" field read
+  size_t total_size() const override final { return _info.total_size(); }
+  size_t calcOffset(const ir::Coordinates &coords) const override final;
+  ir::DataType data_type() const override final { return _info.typeInfo().type(); }
+  float data_scale() const override final { return _info.typeInfo().scale(); }
+  int32_t data_zero_point() const override final { return _info.typeInfo().zero_point(); }
+  const std::vector<float> &data_scales() const override final { return _info.typeInfo().scales(); }
+  const std::vector<int32_t> &data_zero_points() const override final
   {
     return _info.typeInfo().zero_points();
   }
+  bool is_constant() const override final { return _info.isConstant(); }
+  bool is_dynamic() const override final { return _info.isDynamic(); }
+  ir::Shape getShape() const override final { return _info.shape(); }
 
-public:
+  // Finailized methods for IPortableTensor by no padding
   bool has_padding() const final { return false; }
   void access(const std::function<void(ITensor &tensor)> &fn) final { fn(*this); }
 

--- a/runtime/onert/core/include/backend/basic/Tensor.h
+++ b/runtime/onert/core/include/backend/basic/Tensor.h
@@ -81,15 +81,9 @@ public:
    *       W : dimension(2)
    *       C : dimension(3)
    */
-  size_t total_size() const override { return _info.total_size(); }
-  size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return _layout; }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  bool is_constant() const override { return _info.isConstant(); }
-  bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }
   bool applyShape(const ir::Shape &new_shape) override;
-  const ir::Sparsity *sparsity() const override { return _info.typeInfo().sparsity(); }
 
   virtual void increase_ref()
   {
@@ -140,7 +134,6 @@ public:
   virtual int32_t num_references() { return _num_references; }
 
   void setShape(const ir::Shape &new_shape) override;
-  ir::Shape getShape() const override;
 
 protected:
   ir::Layout _layout;
@@ -199,8 +192,6 @@ public:
 public:
   uint8_t *buffer() const override { return _buffer; }
 
-  bool is_constant() const override { return true; }
-  bool is_dynamic() const override { return false; }
   void set_dynamic() override
   {
     throw std::runtime_error("This tensor does not support changing dynamic");

--- a/runtime/onert/core/include/backend/basic/train/TrainableTensor.h
+++ b/runtime/onert/core/include/backend/basic/train/TrainableTensor.h
@@ -61,17 +61,7 @@ public:
    *       W : dimension(2)
    *       C : dimension(3)
    */
-  size_t total_size() const override { return _tensor.total_size(); }
-  size_t calcOffset(const ir::Coordinates &coords) const override
-  {
-    return _tensor.calcOffset(coords);
-  }
   ir::Layout layout() const override { return _tensor.layout(); }
-  ir::DataType data_type() const override { return _tensor.data_type(); }
-  bool is_constant() const override { return _tensor.is_constant(); }
-  bool is_dynamic() const override { return _tensor.is_dynamic(); }
-  ir::Shape getShape() const override { return _tensor.getShape(); };
-  const ir::OperandInfo &get_info() { return _tensor.get_info(); }
 
 public:
   std::vector<ITensor *> optVars() override;

--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -21,9 +21,10 @@
 #ifndef __ONERT_EXEC_I_EXECUTOR_H__
 #define __ONERT_EXEC_I_EXECUTOR_H__
 
-#include "ir/Graph.h"
 #include "IFunction.h"
 #include "ExecutionContext.h"
+#include "backend/IPortableTensor.h"
+#include "ir/Graph.h"
 #include "ir/Index.h"
 #include "ir/OperationIndexMap.h"
 
@@ -31,17 +32,6 @@
 #include <memory>
 #include <unordered_map>
 
-namespace onert
-{
-namespace backend
-{
-class IPortableTensor;
-namespace builtin
-{
-class IOTensor;
-}
-} // namespace backend
-} // namespace onert
 namespace onert
 {
 namespace exec
@@ -85,19 +75,17 @@ struct IExecutor
                        const std::vector<backend::IPortableTensor *> &outputs,
                        const ExecutionOptions &options) = 0;
 
-  /**
-   * @brief Get input tensor objects
-   *
-   * @return Vector of @c IOTensor
-   */
-  virtual const std::vector<backend::builtin::IOTensor *> &getInputTensors() const = 0;
+  virtual uint32_t inputSize() const = 0;
 
-  /**
-   * @brief Get output tensor objects
-   *
-   * @return Vector of @c IOTensor
-   */
-  virtual const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const = 0;
+  virtual uint32_t outputSize() const = 0;
+
+  virtual const ir::OperandInfo &inputInfo(uint32_t index) const = 0;
+
+  virtual const ir::OperandInfo &outputInfo(uint32_t index) const = 0;
+
+  virtual ir::Layout inputLayout(uint32_t index) const = 0;
+
+  virtual ir::Layout outputLayout(uint32_t index) const = 0;
 
   /**
    * @brief   Return current execution configuration

--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -74,13 +74,6 @@ struct IExecutor
   virtual void setIndexedRanks(std::shared_ptr<ir::OperationIndexMap<int64_t>>) = 0;
 
   /**
-   * @brief     Execute with user-given input/output description (for primary subgraph)
-   * @param[in] ctx Execution context
-   * @note      This method should be thread-safe
-   */
-  virtual void execute(const ExecutionContext &ctx) = 0;
-
-  /**
    * @brief Execute with given input/output tensors
    *
    * For non-primary subgraphs, input and output tensors must be given.

--- a/runtime/onert/core/src/backend/IPortableTensor.cc
+++ b/runtime/onert/core/src/backend/IPortableTensor.cc
@@ -25,5 +25,20 @@ namespace backend
 // With this as a key function, `dynamic_cast` works across dl
 IPortableTensor::~IPortableTensor() {}
 
+size_t IPortableTensor::calcOffset(const ir::Coordinates &coords) const
+{
+  auto shape = getShape();
+  size_t rank = shape.rank();
+  rank = rank == 0 ? 1 : rank;
+  size_t offset = 0;
+  for (size_t i = 0; i < rank; ++i)
+  {
+    auto dim = shape.rank() == 0 ? 1 : shape.dim(i);
+    offset = offset * dim + coords[i];
+  }
+  offset *= sizeOfDataType(data_type());
+  return offset;
+}
+
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/basic/Tensor.cc
+++ b/runtime/onert/core/src/backend/basic/Tensor.cc
@@ -28,21 +28,6 @@ namespace basic
 
 Tensor::~Tensor() {}
 
-size_t Tensor::calcOffset(const ir::Coordinates &coords) const
-{
-  auto shape = getShape();
-  size_t rank = shape.rank();
-  rank = rank == 0 ? 1 : rank;
-  size_t offset = 0;
-  for (size_t i = 0; i < rank; ++i)
-  {
-    auto dim = shape.rank() == 0 ? 1 : shape.dim(i);
-    offset = offset * dim + coords[i];
-  }
-  offset *= sizeOfDataType(data_type());
-  return offset;
-}
-
 void Tensor::setShape(const ir::Shape &new_shape) { _info.shape(new_shape); }
 
 bool Tensor::applyShape(const ir::Shape &new_shape)
@@ -83,8 +68,6 @@ bool Tensor::applyShape(const ir::Shape &new_shape)
   }
   return true;
 }
-
-ir::Shape Tensor::getShape() const { return _info.shape(); }
 
 void Tensor::deallocBuffer()
 {

--- a/runtime/onert/core/src/backend/builtin/EdgeTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/EdgeTensor.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "EdgeTensor.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace builtin
+{
+
+bool EdgeTensor::applyShape(const ir::Shape &new_shape)
+{
+  bool previously_dynamic = is_dynamic();
+  if (!previously_dynamic || _buffer == nullptr)
+  {
+    // Always set shape - when buffer with same size was already allocated, shape could differ
+    setShape(new_shape);
+    set_dynamic();
+    const auto total_size = get_info().total_size();
+    _buffer = std::make_unique<uint8_t[]>(total_size);
+  }
+  else
+  {
+    auto previous_size = total_size();
+    auto new_size = new_shape.num_elements() * ir::sizeOfDataType(data_type());
+    if (previous_size != new_size)
+    {
+      setShape(new_shape);
+      set_dynamic();
+      const auto total_size = get_info().total_size();
+      _buffer = std::make_unique<uint8_t[]>(total_size);
+    }
+    else
+    { // when buffer with same size was already allocated, shape could differ
+      setShape(new_shape);
+    }
+  }
+  return true;
+}
+
+} // namespace builtin
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/core/src/backend/builtin/EdgeTensor.h
+++ b/runtime/onert/core/src/backend/builtin/EdgeTensor.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_BUILTIN_EDGE_TENSOR_H__
+#define __ONERT_BACKEND_BUILTIN_EDGE_TENSOR_H__
+
+#include "backend/IPortableTensor.h"
+
+#include <memory>
+
+namespace onert
+{
+namespace backend
+{
+namespace builtin
+{
+
+class EdgeTensor : public IPortableTensor
+{
+public:
+  EdgeTensor(const ir::OperandInfo &info, ir::Layout layout)
+    : IPortableTensor(info), _layout{layout}, _buffer{nullptr}, _ref_count{0}
+  {
+  }
+  ~EdgeTensor() = default;
+
+  uint8_t *buffer() const override { return _buffer.get(); }
+  ir::Layout layout() const override { return _layout; }
+  void set_dynamic() override { _info.setDynamic(); }
+  bool applyShape(const ir::Shape &new_shape) override;
+
+  void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
+
+  void allocate_buffer()
+  {
+    const auto total_size = _info.total_size();
+    _buffer = std::make_unique<uint8_t[]>(total_size);
+    _ref_count = 1;
+  }
+
+  void increase_ref() { _ref_count++; }
+
+  void decrease_ref()
+  {
+    assert(_ref_count > 0);
+    _ref_count--;
+    if (_ref_count == 0)
+    {
+      _buffer.reset();
+    }
+  }
+
+private:
+  ir::Layout _layout;
+  std::unique_ptr<uint8_t[]> _buffer;
+  int32_t _ref_count;
+};
+
+} // namespace builtin
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_BUILTIN_EDGE_TENSOR_H__

--- a/runtime/onert/core/src/backend/builtin/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/builtin/TensorRegistry.h
@@ -17,10 +17,11 @@
 #ifndef __ONERT_BACKEND_BUILTIN_TENSOR_REGISTRY_H__
 #define __ONERT_BACKEND_BUILTIN_TENSOR_REGISTRY_H__
 
-#include "backend/basic/TensorRegistry.h"
-#include "backend/ITensorRegistry.h"
-#include "Tensor.h"
 #include "IOTensor.h"
+#include "backend/ITensorRegistry.h"
+#include "backend/basic/TensorRegistry.h"
+#include "Tensor.h"
+
 #include <assert.h>
 
 namespace onert

--- a/runtime/onert/core/src/backend/builtin/UserTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.cc
@@ -45,6 +45,7 @@ bool UserTensor::applyShape(const ir::Shape &new_shape)
   if (total_size() < new_size)
     throw InsufficientBufferSizeException{"User given buffer size is too small."};
   setShape(new_shape);
+  set_dynamic(); // set to show shape is updated
   return true;
 }
 

--- a/runtime/onert/core/src/backend/builtin/UserTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.cc
@@ -26,23 +26,11 @@ namespace backend
 namespace builtin
 {
 
-size_t UserTensor::calcOffset(const ir::Coordinates &coords) const
-{
-  size_t rank = getShape().rank();
-  size_t offset = 0;
-  for (size_t i = 0; i < rank; ++i)
-  {
-    offset = offset * getShape().dim(i) + coords[i];
-  }
-  offset *= sizeOfDataType(data_type());
-  return offset;
-}
-
 bool UserTensor::applyShape(const ir::Shape &new_shape)
 {
   // User tensors cannot be reallocated.
   auto new_size = new_shape.num_elements() * ir::sizeOfDataType(data_type());
-  if (total_size() < new_size)
+  if (_size < new_size)
     throw InsufficientBufferSizeException{"User given buffer size is too small."};
   setShape(new_shape);
   set_dynamic(); // set to show shape is updated

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -51,15 +51,9 @@ public:
 
 public:
   uint8_t *buffer() const override { return _buffer; }
-  size_t total_size() const override { return _size; }
-  size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return _layout; }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }
-  ir::Shape getShape() const override { return _info.shape(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
-  bool is_constant() const override { return false; }
   bool applyShape(const ir::Shape &) override;
 
 private:

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -39,19 +39,14 @@ class UserTensor : public IPortableTensor
 {
 public:
   UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
-    : IPortableTensor{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false}
+    : IPortableTensor{info}, _layout{layout}, _buffer{buffer}, _size{size}
   {
   }
 
-  UserTensor(const ir::OperandInfo &info, ir::Layout layout) : UserTensor{info, layout, nullptr, 0}
+  // TODO Better design for UserTensor? (we need const_cast as UserTensor is writable)
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout, const uint8_t *buffer, size_t size)
+    : IPortableTensor{info}, _layout{layout}, _buffer{const_cast<uint8_t *>(buffer)}, _size{size}
   {
-  }
-
-public:
-  void setBuffer(uint8_t *buffer, size_t size)
-  {
-    _buffer = buffer;
-    _size = size;
   }
 
 public:
@@ -60,8 +55,8 @@ public:
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return _layout; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  bool is_dynamic() const override { return _dynamic; }
-  void set_dynamic() override { _dynamic = true; }
+  bool is_dynamic() const override { return _info.isDynamic(); }
+  void set_dynamic() override { _info.setDynamic(); }
   ir::Shape getShape() const override { return _info.shape(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
   bool is_constant() const override { return false; }
@@ -71,7 +66,6 @@ private:
   ir::Layout _layout;
   uint8_t *_buffer;
   size_t _size;
-  bool _dynamic;
 };
 
 } // namespace builtin

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -63,10 +63,9 @@ void WhileLayer::run()
   auto body_exec = _executors->at(_model_index, _body_subg_index);
 
   // Need a temp tensor to hold the cond subgraph output
-  assert(cond_exec->getOutputTensors().size() == 1);
+  assert(cond_exec->outputSize() == 1);
   auto cond_output_tensor = [&]() {
-    auto cond_output = cond_exec->getOutputTensors().at(0);
-    auto tensor = std::make_unique<Tensor>(cond_output->orig_info(), cond_output->orig_layout(),
+    auto tensor = std::make_unique<Tensor>(cond_exec->outputInfo(0), cond_exec->outputLayout(0),
                                            _dyn_memory_manager);
     tensor->set_dynamic();
     tensor->setBuffer(_dyn_memory_manager->allocate(tensor.get(), tensor->total_size()));
@@ -97,9 +96,9 @@ void WhileLayer::run()
   // Need some temp tensors to hold the body subgraph output
   std::vector<std::unique_ptr<Tensor>> temp_outputs_o;
   std::vector<IPortableTensor *> temp_outputs;
-  for (auto &&io_tensor : body_exec->getOutputTensors())
+  for (uint32_t i = 0; i < body_exec->outputSize(); i++)
   {
-    auto tensor = std::make_unique<Tensor>(io_tensor->orig_info(), io_tensor->orig_layout(),
+    auto tensor = std::make_unique<Tensor>(body_exec->outputInfo(i), body_exec->outputLayout(i),
                                            _dyn_memory_manager);
     tensor->set_dynamic();
     tensor->setBuffer(_dyn_memory_manager->allocate(tensor.get(), tensor->total_size()));

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -134,6 +134,7 @@ void Execution::execute()
   VERBOSE(Execution) << "Start execution" << std::endl;
 
   _executors->execute(_ctx);
+
   finished = true;
 
   VERBOSE(Execution) << "Execution finished" << std::endl;

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -53,8 +53,6 @@ public:
 
   const ir::Graph &graph() const final { return _graph; }
 
-  void execute(const ExecutionContext &ctx) final;
-
   void execute(const std::vector<backend::IPortableTensor *> &inputs,
                const std::vector<backend::IPortableTensor *> &outputs,
                const ExecutionOptions &options) override;

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -57,6 +57,24 @@ public:
                const std::vector<backend::IPortableTensor *> &outputs,
                const ExecutionOptions &options) override;
 
+  uint32_t inputSize() const override { return _input_tensors.size(); }
+
+  uint32_t outputSize() const override { return _output_tensors.size(); }
+
+  const ir::OperandInfo &inputInfo(uint32_t index) const override
+  {
+    return _input_tensors[index]->get_info();
+  }
+
+  const ir::OperandInfo &outputInfo(uint32_t index) const override
+  {
+    return _output_tensors[index]->get_info();
+  }
+
+  ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+
+  ir::Layout outputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+
   // Used only in Dataflow and Parallel Executors
   void setIndexedRanks(std::shared_ptr<ir::OperationIndexMap<int64_t>> ranks) final
   {
@@ -67,15 +85,6 @@ public:
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _observers.add(std::move(ref)); };
 
-  const std::vector<backend::builtin::IOTensor *> &getInputTensors() const override
-  {
-    return _input_tensors;
-  }
-
-  const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const override
-  {
-    return _output_tensors;
-  }
   backend::BackendContexts &getBackendContexts() { return _backend_contexts; }
 
   const ExecutionOptions &currentOptions() const override { return _current_options; }

--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -17,9 +17,11 @@
 #ifndef __ONERT_EXEC_EXECUTORS_H__
 #define __ONERT_EXEC_EXECUTORS_H__
 
+#include "IPermuteFunction.h"
 #include "exec/IExecutors.h"
 #include "ir/NNPkg.h"
-#include "IPermuteFunction.h"
+#include "../backend/builtin/EdgeTensor.h"
+#include "../backend/builtin/UserTensor.h"
 
 namespace std
 {
@@ -102,8 +104,6 @@ private:
     void optimize() override {}
   };
 
-  class EdgeTensor;
-
 private:
   std::unordered_map<std::pair<ir::ModelIndex, ir::SubgraphIndex>, std::unique_ptr<IExecutor>>
     _executors;
@@ -130,7 +130,7 @@ private:
   // A: these tensors are currently created depending on the type of `to`
   // TODO Unify tensors with the same `from` tensor and same type
   // NOTE The incomplete type 'EdgeTensor' cannot be declared as unique_ptr.
-  std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _edge_quant_tensors;
+  std::unordered_map<ir::IODesc, std::shared_ptr<backend::builtin::EdgeTensor>> _edge_quant_tensors;
 
   /**
    * @brief Tensors for edges between executors that are not related to type-aware quantization
@@ -139,7 +139,7 @@ private:
   // Q: Why is Key `from` IODesc
   // A: `from` can be connected to multiple `to`
   // NOTE The incomplete type 'EdgeTensor' cannot be declared as unique_ptr.
-  std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _edge_tensors;
+  std::unordered_map<ir::IODesc, std::shared_ptr<backend::builtin::EdgeTensor>> _edge_tensors;
   /**
    * @brief Whether type-aware quantization layers for edges between executors are created
    *
@@ -155,11 +155,13 @@ private:
   std::unordered_map<std::pair<ir::ModelIndex, ir::SubgraphIndex>, std::unique_ptr<PermuteLayer>>
     _pkg_output_quant_layers;
   // Edge tensors of nnpkg inputs/outputs for type-aware quantization
-  std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _pkg_input_quant_tensors;
-  std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _pkg_output_quant_tensors;
+  std::unordered_map<ir::IODesc, std::shared_ptr<backend::builtin::EdgeTensor>>
+    _pkg_input_quant_tensors;
+  std::unordered_map<ir::IODesc, std::shared_ptr<backend::builtin::EdgeTensor>>
+    _pkg_output_quant_tensors;
   // IOTensors for user buffer
-  std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::IOTensor>> _pkg_input_tensors;
-  std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::IOTensor>> _pkg_output_tensors;
+  std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::UserTensor>> _pkg_input_tensors;
+  std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::UserTensor>> _pkg_output_tensors;
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -15,9 +15,10 @@
  */
 
 #include "SingleModelExecutors.h"
-#include <array>
 
-#include "../backend/builtin/IOTensor.h"
+#include "../backend/builtin/UserTensor.h"
+
+#include <array>
 
 namespace onert
 {
@@ -36,24 +37,18 @@ IExecutor *SingleModelExecutors::at(const ir::ModelIndex &,
   return _executors.at(subg_index).get();
 }
 
-uint32_t SingleModelExecutors::inputSize() const
-{
-  return entryExecutor()->getInputTensors().size();
-}
+uint32_t SingleModelExecutors::inputSize() const { return entryExecutor()->inputSize(); }
 
-uint32_t SingleModelExecutors::outputSize() const
-{
-  return entryExecutor()->getOutputTensors().size();
-}
+uint32_t SingleModelExecutors::outputSize() const { return entryExecutor()->outputSize(); }
 
 const ir::OperandInfo &SingleModelExecutors::inputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getInputTensors().at(index.value())->orig_info();
+  return entryExecutor()->inputInfo(index.value());
 }
 
 const ir::OperandInfo &SingleModelExecutors::outputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getOutputTensors().at(index.value())->orig_info();
+  return entryExecutor()->outputInfo(index.value());
 }
 
 void SingleModelExecutors::execute(const ExecutionContext &ctx)

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -18,6 +18,7 @@
 #ifdef RUY_PROFILER
 #include "ruy/profiler/instrumentation.h"
 #endif
+#include "../../backend/builtin/UserTensor.h"
 
 #include <misc/polymorphic_downcast.h>
 

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -62,6 +62,24 @@ public:
                const std::vector<backend::IPortableTensor *> &outputs,
                const ExecutionOptions &options) override;
 
+  uint32_t inputSize() const override { return _input_tensors.size(); }
+
+  uint32_t outputSize() const override { return _output_tensors.size(); }
+
+  const ir::OperandInfo &inputInfo(uint32_t index) const override
+  {
+    return _input_tensors[index]->get_info();
+  }
+
+  const ir::OperandInfo &outputInfo(uint32_t index) const override
+  {
+    return _output_tensors[index]->get_info();
+  }
+
+  ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+
+  ir::Layout outputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+
   void forward(const ExecutionContext &ctx, bool training);
   void backward(const ExecutionContext &ctx, uint32_t training_step);
 
@@ -72,16 +90,6 @@ public:
   };
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _observers.add(std::move(ref)); };
-
-  const std::vector<backend::builtin::IOTensor *> &getInputTensors() const override
-  {
-    return _input_tensors;
-  }
-
-  const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const override
-  {
-    return _output_tensors;
-  }
 
   float getLoss(const ir::IOIndex &pred_io_ind) const;
 

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -56,7 +56,7 @@ public:
 public:
   const ir::Graph &graph() const final { return _trainable_graph.graph(); }
 
-  void execute(const ExecutionContext &ctx) override { forward(ctx, false); };
+  void execute(const ExecutionContext &ctx) { forward(ctx, false); };
 
   void execute(const std::vector<backend::IPortableTensor *> &inputs,
                const std::vector<backend::IPortableTensor *> &outputs,

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -16,8 +16,6 @@
 
 #include "TrainableExecutors.h"
 
-#include "../../backend/builtin/IOTensor.h"
-
 #include <misc/polymorphic_downcast.h>
 
 namespace onert
@@ -41,21 +39,18 @@ TrainableExecutor *TrainableExecutors::at(const ir::ModelIndex &,
   return _executors.at(subg_index).get();
 }
 
-uint32_t TrainableExecutors::inputSize() const { return entryExecutor()->getInputTensors().size(); }
+uint32_t TrainableExecutors::inputSize() const { return entryExecutor()->inputSize(); }
 
-uint32_t TrainableExecutors::outputSize() const
-{
-  return entryExecutor()->getOutputTensors().size();
-}
+uint32_t TrainableExecutors::outputSize() const { return entryExecutor()->outputSize(); }
 
 const ir::OperandInfo &TrainableExecutors::inputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getInputTensors().at(index.value())->orig_info();
+  return entryExecutor()->inputInfo(index.value());
 }
 
 const ir::OperandInfo &TrainableExecutors::outputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getOutputTensors().at(index.value())->orig_info();
+  return entryExecutor()->outputInfo(index.value());
 }
 
 void TrainableExecutors::execute(const ExecutionContext &ctx)


### PR DESCRIPTION
- Revise Tensor struct: IPortableTensor, IOTensor, UserTensor
- Revise Executor I/O setting
  - Merge execute method: use option, input & output tensor
  - Revise MultiModelExecutor for type-aware
  - Remove IOTensor interface in header

Part of #13284