### PR TITLE
[luci-interpreter] Support int64 dtype in the CircleTranspose

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Transpose.cpp
+++ b/compiler/luci-interpreter/src/kernels/Transpose.cpp
@@ -70,6 +70,11 @@ void Transpose::execute() const
                                        getTensorData<float>(input()), getTensorShape(output()),
                                        getTensorData<float>(output()));
       break;
+    case DataType::S64:
+      tflite::reference_ops::Transpose(params, getTensorShape(input()),
+                                       getTensorData<int64_t>(input()), getTensorShape(output()),
+                                       getTensorData<int64_t>(output()));
+      break;
     case DataType::U8:
       tflite::reference_ops::Transpose(params, getTensorShape(input()),
                                        getTensorData<uint8_t>(input()), getTensorShape(output()),


### PR DESCRIPTION
This commit supports int64 dtype in the CircleTranspose.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>