### PR TITLE
[one-cmds] Raise error when backend and target option are given

### DIFF
--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -165,6 +165,10 @@ def verify_arg(parser: ArgumentParser, args):
     if oneutils.is_valid_attr(args, 'backend') and oneutils.is_valid_attr(
             args, 'workflow'):
         parser.error('\'backend\' option can be used only with \'config\' option')
+    if oneutils.is_valid_attr(args, 'backend') and oneutils.is_valid_attr(args, 'target'):
+        parser.error(
+            '\'backend\' and \'target\' are mutually exclusive option. \'target\' option automatically set a backend.'
+        )
 
     if oneutils.is_valid_attr(args, 'backend'):
         verify_backend_args(parser, args)

--- a/compiler/one-cmds/tests/onecc_neg_037.test
+++ b/compiler/one-cmds/tests/onecc_neg_037.test
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# use 'backend' option with 'target' option simultaneously
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "'backend' and 'target' are mutually exclusive option. 'target' option automatically set a backend." "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+rm -f ${filename}.log
+
+# run test
+onecc -C "dummy_cfg" -b "dummy_backend" -T "dummy_target" > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255


### PR DESCRIPTION
This commit raises an error when backend and target option are given simultaneously.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>