### PR TITLE
[onert] Revisit IOTensor

### DIFF
--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -30,13 +30,21 @@ namespace builtin
 /**
  * @brief Tensor object that indirects to the tensor it is pointing to.
  *
- * A model I/O tensor could be two types.
+ * A executor's I/O tensor could be two types.
  *
- * 1. @c UserTensor, if it is the primary graph
- * 2. Any other derivative of @c IPortableTensor from another backend, otherwise
+ * 1. @c UserTensor, if it is the primary graph (package's input/output)
+ * 2. Any other derivative of @c IPortableTensor from another executor, otherwise
  *
  * To support these, this object indirects everything to the actual tensor pointer.
- * Exceptionally if it is UserTensor, this class creates and manages it.
+ *
+ * IOTensor is derived from IPortableTensor, and it also have "_info" field.
+ * "_info" field is accessed by IPortableTensor's getter method.
+ *
+ * It assumes that IOTensor's info is always same with actual tensor's info except shape.
+ * setTensor() updates IOTensor's info's shape to actual tensor shape.
+ * Actual tensor's info should not be updated directly after setTensor() call until
+ * executor's execution is finished, instead it is allowed to update actual tensor's info
+ * indirectly by IOTensor's setter methods.
  */
 class IOTensor : public IPortableTensor
 {
@@ -47,47 +55,46 @@ public:
 public:
   void setTensor(IPortableTensor *tensor);
   void setUserTensor(uint8_t *buffer, size_t size);
-  const ir::OperandInfo &orig_info() const { return _orig_info; }
-  ir::Layout orig_layout() const { return _orig_layout; }
 
 public:
   uint8_t *buffer() const override { return _tensor->buffer(); }
-  size_t total_size() const override { return _tensor->total_size(); }
+  size_t total_size() const override { return _info.total_size(); }
   size_t calcOffset(const ir::Coordinates &coords) const override
   {
     return _tensor->calcOffset(coords);
   }
-  ir::Layout layout() const override { return _tensor->layout(); }
-  ir::DataType data_type() const override { return _tensor->data_type(); }
-  bool is_dynamic() const override
+  ir::Layout layout() const override { return _orig->layout(); }
+  ir::DataType data_type() const override { return _info.typeInfo().type(); }
+  bool is_dynamic() const override { return _info.isDynamic(); }
+  void set_dynamic() override
   {
-    return _is_dynamic || _orig_info.isDynamic() || (_tensor && _tensor->is_dynamic());
+    _info.setDynamic();
+    _tensor->set_dynamic();
   }
-  void set_dynamic() override { _is_dynamic = true; }
-  ir::Shape getShape() const override { return _tensor->getShape(); }
+  ir::Shape getShape() const override { return _info.shape(); }
   void setShape(const ir::Shape &shape) override
   {
-    // Workaround for IPortableTensor holds _info as its member
     _info.shape(shape);
     _tensor->setShape(shape);
   }
-  bool is_constant() const override { return _tensor->is_constant(); }
+  bool is_constant() const override { return _info.isConstant(); }
   bool applyShape(const ir::Shape &shape) override
   {
-    // Workaround for IPortableTensor holds _info as its member
-    _info.shape(shape);
-    return _tensor->applyShape(shape);
+    auto return_val = _tensor->applyShape(shape);
+    if (return_val)
+    {
+      _info.shape(shape);
+      _info.setDynamic();
+    }
+    return return_val;
   }
 
-public:
-  void setShapeOfIPortableTensor(const ir::Shape &shape) { _info.shape(shape); }
-
 private:
-  const ir::OperandInfo _orig_info;
-  const ir::Layout _orig_layout;
-  bool _is_dynamic{false};
-  IPortableTensor *_tensor{nullptr};        //< The actual tensor that is indirected
-  std::unique_ptr<UserTensor> _user_tensor; //< If it is a user tensor, it is managed by this object
+  IPortableTensor *_tensor{nullptr}; //< The actual tensor that is indirected
+  // "_orig" has UserTensor type original tensor's info with nullptr buffer and layout,
+  // and "_tensor" points to "_user_tensor".
+  // After 1st setTensor(tensor) call, "_tensor" is updated to actual tensor
+  std::unique_ptr<UserTensor> _orig; //< If it is a user tensor, it is managed by this object
 };
 
 } // namespace builtin

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -66,8 +66,8 @@ void WhileLayer::run()
   assert(cond_exec->getOutputTensors().size() == 1);
   auto cond_output_tensor = [&]() {
     auto cond_output = cond_exec->getOutputTensors().at(0);
-    auto tensor = std::make_unique<Tensor>(cond_output->orig_info(), cond_output->orig_layout(),
-                                           _dyn_memory_manager);
+    auto tensor =
+      std::make_unique<Tensor>(cond_output->get_info(), cond_output->layout(), _dyn_memory_manager);
     tensor->set_dynamic();
     tensor->setBuffer(_dyn_memory_manager->allocate(tensor.get(), tensor->total_size()));
     return tensor;
@@ -99,8 +99,8 @@ void WhileLayer::run()
   std::vector<IPortableTensor *> temp_outputs;
   for (auto &&io_tensor : body_exec->getOutputTensors())
   {
-    auto tensor = std::make_unique<Tensor>(io_tensor->orig_info(), io_tensor->orig_layout(),
-                                           _dyn_memory_manager);
+    auto tensor =
+      std::make_unique<Tensor>(io_tensor->get_info(), io_tensor->layout(), _dyn_memory_manager);
     tensor->set_dynamic();
     tensor->setBuffer(_dyn_memory_manager->allocate(tensor.get(), tensor->total_size()));
     temp_outputs.push_back(tensor.get());

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -66,22 +66,6 @@ void ExecutorBase::execute(const std::vector<backend::IPortableTensor *> &inputs
     assert(input->buffer() != nullptr);
     auto input_tensor = _input_tensors[n];
     assert(input_tensor != nullptr);
-    if (input != nullptr)
-    {
-      const auto &orig_input_shape = input_tensor->orig_info().shape();
-      const auto &changed_input_shape =
-        convertShape(input->getShape(), input->layout(), input_tensor->orig_layout());
-      if (input_tensor->get_info().shape() != changed_input_shape)
-      {
-        // TODO Fix this workaround that is introduced since cpu based kernels directly use `_info`
-        // rather than interface methods to avoid virtual function calls.
-        input_tensor->setShapeOfIPortableTensor(changed_input_shape);
-      }
-      if (orig_input_shape != changed_input_shape)
-      {
-        input_tensor->set_dynamic();
-      }
-    }
     input_tensor->setTensor(input);
   }
 

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -47,12 +47,12 @@ uint32_t SingleModelExecutors::outputSize() const
 
 const ir::OperandInfo &SingleModelExecutors::inputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getInputTensors().at(index.value())->orig_info();
+  return entryExecutor()->getInputTensors().at(index.value())->get_info();
 }
 
 const ir::OperandInfo &SingleModelExecutors::outputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getOutputTensors().at(index.value())->orig_info();
+  return entryExecutor()->getOutputTensors().at(index.value())->get_info();
 }
 
 void SingleModelExecutors::execute(const ExecutionContext &ctx) { entryExecutor()->execute(ctx); }

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -50,12 +50,12 @@ uint32_t TrainableExecutors::outputSize() const
 
 const ir::OperandInfo &TrainableExecutors::inputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getInputTensors().at(index.value())->orig_info();
+  return entryExecutor()->getInputTensors().at(index.value())->get_info();
 }
 
 const ir::OperandInfo &TrainableExecutors::outputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getOutputTensors().at(index.value())->orig_info();
+  return entryExecutor()->getOutputTensors().at(index.value())->get_info();
 }
 
 void TrainableExecutors::execute(const ExecutionContext &ctx)


### PR DESCRIPTION
This commit revisits IOTensor
- OperandInfo such as shape, type, dynamic is maintained on its own "_info" field
- Remove orig_info() and orig_layout() getter
- setTensor methods update its own "_info" field if shape is different
- Setter methods update both its own "_info" field and actual tensor

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13333