### PR TITLE
[onert-micro] onert_micro_dev as default arm Target

### DIFF
--- a/onert-micro/CMakeLists.txt
+++ b/onert-micro/CMakeLists.txt
@@ -165,11 +165,11 @@ unset(DIS_FLOAT CACHE)
 unset(ENABLE_ONERT_MICRO_TEST CACHE)
 unset(NOT_BUILD_EXTERNALS CACHE)
 
-set(MICRO_ARM_BINARY "${MICRO_ARM_BUILD_DIR}/onert_micro/src/libonert_micro_interpreter.a")
+set(MICRO_ARM_BINARY "${MICRO_ARM_BUILD_DIR}/onert_micro/src/libonert_micro_dev.a")
 
 add_custom_command(
         OUTPUT "${MICRO_ARM_BINARY}"
-        COMMAND "${CMAKE_MAKE_PROGRAM}" onert_micro_interpreter -j ${CPU_COUNT}
+        COMMAND "${CMAKE_MAKE_PROGRAM}" onert_micro_dev -j ${CPU_COUNT}
         WORKING_DIRECTORY "${MICRO_ARM_BUILD_DIR}"
         DEPENDS onert_micro_arm_cmake ${OM_CIRCLE_SCHEMA}
         VERBATIM

--- a/onert-micro/onert-micro/src/api/onert-micro.cpp
+++ b/onert-micro/onert-micro/src/api/onert-micro.cpp
@@ -42,7 +42,8 @@ DataBuffer readFile(const char *path)
   if (!file.good())
   {
     std::string errmsg = "Failed to open file";
-    throw std::runtime_error(errmsg.c_str());
+    std::cerr << errmsg << std::endl;
+    exit(-1); //FIXME: proper way
   }
 
   file.seekg(0, std::ios::end);
@@ -57,7 +58,8 @@ DataBuffer readFile(const char *path)
   if (file.fail())
   {
     std::string errmsg = "Failed to read file";
-    throw std::runtime_error(errmsg.c_str());
+    std::cerr << errmsg << std::endl;
+    exit(-1); //FIXME: proper way
   }
 
   return model_data;

--- a/onert-micro/onert-micro/src/api/onert-micro.cpp
+++ b/onert-micro/onert-micro/src/api/onert-micro.cpp
@@ -43,7 +43,7 @@ DataBuffer readFile(const char *path)
   {
     std::string errmsg = "Failed to open file";
     std::cerr << errmsg << std::endl;
-    exit(-1); //FIXME: proper way
+    exit(-1); // FIXME: proper way
   }
 
   file.seekg(0, std::ios::end);
@@ -59,7 +59,7 @@ DataBuffer readFile(const char *path)
   {
     std::string errmsg = "Failed to read file";
     std::cerr << errmsg << std::endl;
-    exit(-1); //FIXME: proper way
+    exit(-1); // FIXME: proper way
   }
 
   return model_data;


### PR DESCRIPTION
- for cortex arm target, onert_micro_dev is deafult binary
- Fix exception for TizenRT

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>