### PR TITLE
[infra/onert] Use static link for Boost and HDF5

### DIFF
--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -90,6 +90,8 @@ option(DOWNLOAD_FXDIV "Download fxdiv source" ON)
 option(BUILD_FXDIV "Build fxdiv library from the source" ON)
 option(DOWNLOAD_PYBIND11 "Download Pybind11 source" OFF)
 option(BUILD_PYTHON_BINDING "Build python binding" OFF)
+option(HDF5_USE_STATIC_LIBRARIES "Determine whether or not static linking for HDF5" ON)
+option(Boost_USE_STATIC_LIBS "Determine whether or not static linking for Boost" ON)
 
 #
 ## Default sample build configuration

--- a/infra/nnfw/cmake/packages/BoostConfig.cmake
+++ b/infra/nnfw/cmake/packages/BoostConfig.cmake
@@ -32,10 +32,7 @@ function(_Boost_Build Boost_PREFIX)
 
   list(APPEND Boost_Options --build-dir=${BoostBuild_DIR})
   list(APPEND Boost_Options --prefix=${BoostInstall_DIR})
-  list(APPEND Boost_Options --with-log)
   list(APPEND Boost_Options --with-program_options)
-  list(APPEND Boost_Options --with-system)
-  list(APPEND Boost_Options --with-filesystem)
 
   if(DEFINED EXTERNALS_BUILD_THREADS)
     set(N ${EXTERNALS_BUILD_THREADS})
@@ -80,7 +77,7 @@ endfunction(_Boost_Build)
 if (NOT BUILD_BOOST)
   # BoostConfig.cmake does not honor QUIET argument at least till cmake 1.70.0.
   # Thus, don't try to find_package if you're not entirely sure you have boost.
-  find_package(Boost 1.58.0 QUIET COMPONENTS log program_options filesystem system)
+  find_package(Boost 1.58.0 QUIET COMPONENTS program_options)
   if(Boost_FOUND)
     return()
   endif()
@@ -99,5 +96,5 @@ if(BUILD_BOOST)
   set(Boost_USE_STATIC_LIBS ON)
 
   # We built boost library so update Boost variables.
-  find_package(Boost 1.58.0 QUIET COMPONENTS log program_options filesystem system)
+  find_package(Boost 1.58.0 QUIET COMPONENTS program_options)
 endif(BUILD_BOOST)

--- a/infra/nnfw/cmake/packages/HDF5Config.cmake
+++ b/infra/nnfw/cmake/packages/HDF5Config.cmake
@@ -1,4 +1,8 @@
 # Don't cache HDF5_*. Otherwise it will use the cached value without searching.
+if (HDF5_INCLUDE_DIRS AND HDF5_CXX_LIBRARIES AND HDF5_FOUND)
+  return()
+endif()
+
 unset(HDF5_DIR CACHE)
 unset(HDF5_INCLUDE_DIRS CACHE)
 unset(HDF5_CXX_LIBRARY_hdf5 CACHE)
@@ -62,11 +66,17 @@ else()
     return()
   endif()
 
-  # We can use "hdf5" and "hdf5_cpp" to use the same file founded with above.
-  list(APPEND HDF5_CXX_LIBRARIES ${HDF5_CXX_LIBRARY_hdf5} ${HDF5_CXX_LIBRARY_hdf5_cpp} "sz" "z" "dl" "m")
+  find_library(HDF5_DEP_sz NAMES sz ONLY_CMAKE_FIND_ROOT_PATH)
+  list(APPEND HDF5_CXX_LIBRARY_DEPS ${HDF5_DEP_sz})
 
-  # Append missing libaec which is required by libsz, which is required by libhdf5
-  list(APPEND HDF5_CXX_LIBRARIES "aec")
+  find_library(HDF5_DEP_z NAMES z ONLY_CMAKE_FIND_ROOT_PATH)
+  list(APPEND HDF5_CXX_LIBRARY_DEPS ${HDF5_DEP_z})
+
+  find_library(HDF5_DEP_m NAMES m ONLY_CMAKE_FIND_ROOT_PATH)
+  list(APPEND HDF5_CXX_LIBRARY_DEPS ${HDF5_DEP_m})
+
+  ### Caution: You must keep appending order for static linking
+  list(APPEND HDF5_CXX_LIBRARIES ${HDF5_CXX_LIBRARY_hdf5_cpp} ${HDF5_CXX_LIBRARY_hdf5} ${HDF5_CXX_LIBRARY_DEPS})
 
   set(HDF5_FOUND TRUE)
 endif()


### PR DESCRIPTION
This commit updates cmake build option to use static link for Boost and HDF5. 
It will help to use test driver on upper linux version without rebuild.
It includes removing unused boost component linking.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>