### PR TITLE
[onert] Add use-def chains to TrainableGraph

### DIFF
--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -22,6 +22,7 @@
 
 #include "ir/Graph.h"
 #include "ir/train/ITrainableOperation.h"
+#include "ir/train/UseDefChains.h"
 
 namespace onert
 {
@@ -30,6 +31,7 @@ namespace ir
 namespace train
 {
 
+// TODO Add Phase enum
 class TrainableGraph : public IGraph
 {
 public:
@@ -110,6 +112,7 @@ public:
   void setOutputs(OperandIndexSequence outputs,
                   std::unordered_map<std::string, IOIndex> name_to_output);
   void enableBackward(const OperationIndex &index);
+  void setTrainingUseDefs(const UseDefChains &training_defuses);
 
   // Accessors
 public:
@@ -127,11 +130,13 @@ public:
 
 public:
   const ITrainableOperation &operation(OperationIndex index) const;
+  const UseDefChains &trainingUseDefs() const { return _training_defuses; }
 
 private:
   void validateTopologicalOrder(std::vector<ir::OperationIndex> order, bool is_forward) const;
   void validateForwardTopologicalOrder(const std::vector<ir::OperationIndex> &order) const;
   void validateBackwardTopologicalOrder(const std::vector<ir::OperationIndex> &order) const;
+  void verifyTrainingUseDefs() const;
 
 public:
   std::vector<ir::OperationIndex> topolSortOperations() const;
@@ -144,6 +149,7 @@ public:
 private:
   Graph _graph;
   Operands _backward_operands;
+  UseDefChains _training_defuses;
 
   std::unordered_map<IOIndex, OperandIndex> _losses;
 };

--- a/runtime/onert/core/include/ir/train/UseDefChains.h
+++ b/runtime/onert/core/include/ir/train/UseDefChains.h
@@ -20,6 +20,8 @@
 #include "ir/train/UseDefChain.h"
 #include "ir/train/Index.h"
 
+#include <unordered_map>
+
 namespace onert
 {
 namespace ir

--- a/runtime/onert/core/src/ir/verifier/Verifier.h
+++ b/runtime/onert/core/src/ir/verifier/Verifier.h
@@ -17,6 +17,8 @@
 #ifndef __ONERT_GRAPH_VERIFIER_VERIFIER_H__
 #define __ONERT_GRAPH_VERIFIER_VERIFIER_H__
 
+#include "ir/train/UseDefChains.h"
+
 namespace onert
 {
 namespace ir
@@ -53,12 +55,14 @@ class DAGChecker : public IVerifier
 {
 public:
   bool verify(const Graph &graph) const noexcept override;
+  bool verify(const train::UseDefChains &training_defuses) const noexcept;
 };
 
 class EdgeChecker : public IVerifier
 {
 public:
   bool verify(const Graph &graph) const noexcept override;
+  bool verify(const train::UseDefChains &training_defuses) const noexcept;
 };
 
 /**


### PR DESCRIPTION
This commit adds use-def chains to TrainableGraph.
   - Add use-def chains for training to TrainableGraph
   - Add verifying UseDefChains to DagChecker and EdgeChecker and apply it to TrainableGraph

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>