### PR TITLE
[oenrt_run] Force input/output type to float

### DIFF
--- a/tests/tools/onert_run/src/args.cc
+++ b/tests/tools/onert_run/src/args.cc
@@ -273,6 +273,7 @@ void Args::Initialize(void)
         "e.g. '[0, 40, 2, 80]' to set 0th tensor to 40 and 2nd tensor to 80.\n")
     ("num_runs,r", po::value<int>()->default_value(1)->notifier([&](const auto &v) { _num_runs = v; }), "The number of runs")
     ("fixed_input", "Use same random input data on each run (avaliable on random input)")
+    ("force_float", "Ignore model's input and output type and use float type buffer")
     ("warmup_runs,w", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _warmup_runs = v; }), "The number of warmup runs")
     ("minmax_runs", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _minmax_runs = v; }), "The number of minmax recording runs before full quantization")
     ("run_delay,t", po::value<int>()->default_value(-1)->notifier([&](const auto &v) { _run_delay = v; }), "Delay time(us) between runs (as default no delay")
@@ -374,6 +375,8 @@ void Args::Parse(const int argc, char **argv)
   {
     _fixed_input = true;
   }
+  if (vm.count("force_float"))
+    _force_float = true;
 
   try
   {

--- a/tests/tools/onert_run/src/args.h
+++ b/tests/tools/onert_run/src/args.h
@@ -59,6 +59,7 @@ public:
   const std::string &getLoadRawFilename(void) const { return _load_raw_filename; }
   const int getNumRuns(void) const { return _num_runs; }
   const bool getFixedInput(void) const { return _fixed_input; }
+  const bool getForceFloat(void) const { return _force_float; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
   const int getMinmaxRuns(void) const { return _minmax_runs; }
   const int getRunDelay(void) const { return _run_delay; }
@@ -99,6 +100,7 @@ private:
   TensorShapeMap _shape_run;
   int _num_runs;
   bool _fixed_input = false;
+  bool _force_float = false;
   int _warmup_runs;
   int _minmax_runs;
   int _run_delay;

--- a/tests/tools/onert_run/src/onert_run.cc
+++ b/tests/tools/onert_run/src/onert_run.cc
@@ -295,6 +295,9 @@ int main(const int argc, char **argv)
         // Allocate memory for input data and set buffer
         if (allocate)
         {
+          if (args.getForceFloat())
+            ti.dtype = NNFW_TYPE_TENSOR_FLOAT32;
+
           auto input_size_in_bytes = bufsize_for(&ti);
           inputs[i].alloc(input_size_in_bytes, ti.dtype);
 
@@ -359,6 +362,9 @@ int main(const int argc, char **argv)
     {
       nnfw_tensorinfo ti;
       NNPR_ENSURE_STATUS(nnfw_output_tensorinfo(session, i, &ti));
+      if (args.getForceFloat())
+        ti.dtype = NNFW_TYPE_TENSOR_FLOAT32;
+
       uint64_t output_size_in_bytes = bufsize_for(&ti);
       {
         auto found = output_sizes.find(i);


### PR DESCRIPTION
This commit allows to set input and output buffer data type to float when model is quantized.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13284