### PR TITLE
[infra] Update tizen test build

### DIFF
--- a/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
@@ -14,3 +14,5 @@ option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OF
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
+# Tizen boost package does not have static library
+option(Boost_USE_STATIC_LIBS "Determine whether or not static linking for Boost" OFF)

--- a/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
@@ -14,3 +14,5 @@ option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OF
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
+# Tizen boost package does not have static library
+option(Boost_USE_STATIC_LIBS "Determine whether or not static linking for Boost" OFF)

--- a/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
@@ -14,3 +14,5 @@ option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OF
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
+# Tizen boost package does not have static library
+option(Boost_USE_STATIC_LIBS "Determine whether or not static linking for Boost" OFF)

--- a/infra/nnfw/cmake/options/options_riscv64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_riscv64-tizen.cmake
@@ -15,3 +15,5 @@ option(BUILD_XNNPACK "Build XNNPACK" OFF)
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
+# Tizen boost package does not have static library
+option(Boost_USE_STATIC_LIBS "Determine whether or not static linking for Boost" OFF)

--- a/infra/nnfw/cmake/options/options_x86_64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_x86_64-tizen.cmake
@@ -15,3 +15,5 @@ option(BUILD_XNNPACK "Build XNNPACK" OFF)
 option(BUILD_NPUD "Build NPU daemon" OFF)
 # Do not allow to use CONFIG option on Tizen
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
+# Tizen boost package does not have static library
+option(Boost_USE_STATIC_LIBS "Determine whether or not static linking for Boost" OFF)

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -59,7 +59,7 @@ Requires(postun): /sbin/ldconfig
 %if %{test_build} == 1
 BuildRequires:  pkgconfig(boost)
 BuildRequires:  pkgconfig(tensorflow2-lite)
-BuildRequires:  hdf5-devel
+BuildRequires:  hdf5-devel-static
 BuildRequires:  libaec-devel
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(libjpeg)


### PR DESCRIPTION
This commit updates tizen test build
- Disables boost static linking on tizen.
  - Tizen is not supporting boost library static linking.
- Use hdf5 static devel package

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

It will resolve build fail #13355