### PR TITLE
[onert] Add assertion to check whether tensor is dynamic

### DIFF
--- a/runtime/onert/backend/train/ops/OperationUtils.cc
+++ b/runtime/onert/backend/train/ops/OperationUtils.cc
@@ -29,6 +29,27 @@ namespace train
 namespace ops
 {
 
+nnfw::cker::Shape getShape(const IPortableTensor *tensor)
+{
+  if (tensor == nullptr)
+    return nnfw::cker::Shape();
+
+  assert(!tensor->is_dynamic() && "Dynamic tensor is not supported yet");
+
+  const ir::Shape &shape = tensor->get_info().shape();
+
+  assert(tensor->layout() == ir::Layout::NHWC);
+
+  auto rank = shape.rank();
+  nnfw::cker::Shape ret(rank);
+  auto data = ret.DimsData();
+  for (int i = 0; i < rank; ++i)
+  {
+    data[i] = shape.dim(i);
+  }
+  return ret;
+}
+
 const IPortableTensor *backpropActivation(const ir::Activation &activation,
                                           const IPortableTensor *output,
                                           const IPortableTensor *input_backprop,

--- a/runtime/onert/backend/train/ops/OperationUtils.h
+++ b/runtime/onert/backend/train/ops/OperationUtils.h
@@ -31,10 +31,17 @@ namespace ops
 using OperandType = onert::ir::DataType;
 using cpu::ops::getBuffer;
 using cpu::ops::getPaddingType;
-using cpu::ops::getShape;
 using cpu::ops::getNumberOfDimensions;
 using cpu::ops::getNumberOfElements;
 using cpu::ops::getSizeOfDimension;
+
+/**
+ * @brief Get shape of tensor
+ *
+ * @param tensor tensor to get shape
+ * @return Shape to be used in cker
+ */
+nnfw::cker::Shape getShape(const IPortableTensor *tensor);
 
 /**
  * @brief backpropagate acitvation


### PR DESCRIPTION
This commit add assertion to check whether a tensor dynamic in `getShape`.
  - Introduce getShape into train backend that generates nnfw::cker::Shape from a tensor
  - Add the assertion in that function

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

Related to https://github.com/Samsung/ONE/pull/13351#discussion_r1666185378