### PR TITLE
[onert/test] Use arser for tflite_run argument parsing

### DIFF
--- a/infra/nnfw/CMakeLists.txt
+++ b/infra/nnfw/CMakeLists.txt
@@ -117,6 +117,13 @@ endif(ENABLE_COVERAGE)
 
 nnas_include(AddSubdirectories)
 
+# Add arser for test driver
+# TODO: Better way to handle this
+if(ENABLE_TEST)
+  add_library(arser INTERFACE)
+  target_include_directories(arser INTERFACE ${NNAS_PROJECT_SOURCE_DIR}/compiler/arser/include/)
+endif(ENABLE_TEST)
+
 add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/compute compute)
 add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/runtime runtime)
 add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/tests tests)

--- a/tests/tools/tflite_run/CMakeLists.txt
+++ b/tests/tools/tflite_run/CMakeLists.txt
@@ -7,25 +7,12 @@ list(APPEND TFLITE_RUN_SRCS "src/args.cc")
 list(APPEND TFLITE_RUN_SRCS "src/tensor_dumper.cc")
 list(APPEND TFLITE_RUN_SRCS "src/tensor_loader.cc")
 
-nnfw_find_package(Boost REQUIRED program_options)
-
 add_executable(tflite_run ${TFLITE_RUN_SRCS})
-target_include_directories(tflite_run PRIVATE src)
-target_include_directories(tflite_run PRIVATE ${Boost_INCLUDE_DIRS})
 
-target_link_libraries(tflite_run nnfw_lib_tflite)
-target_link_libraries(tflite_run ${Boost_PROGRAM_OPTIONS_LIBRARY})
-
-target_link_libraries(tflite_run nnfw_lib_benchmark)
+target_link_libraries(tflite_run nnfw_lib_tflite nnfw_lib_benchmark)
+target_link_libraries(tflite_run arser)
 
 install(TARGETS tflite_run DESTINATION bin)
-
-# TEST BUILD
-nnfw_find_package(GTest)
-
-if(NOT GTest_FOUND)
-  return()
-endif(NOT GTest_FOUND)
 
 ## Add test cpp file
 add_executable(tflite_test src/tflite_test.cc)

--- a/tests/tools/tflite_run/src/args.h
+++ b/tests/tools/tflite_run/src/args.h
@@ -18,9 +18,7 @@
 #define __TFLITE_RUN_ARGS_H__
 
 #include <string>
-#include <boost/program_options.hpp>
-
-namespace po = boost::program_options;
+#include <arser/arser.h>
 
 namespace TFLiteRun
 {
@@ -42,7 +40,6 @@ public:
   const bool getGpuMemoryPoll(void) const { return _gpumem_poll; }
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const bool getWriteReport(void) const { return _write_report; }
-  const bool getModelValidate(void) const { return _tflite_validate; }
   const int getVerboseLevel(void) const { return _verbose_level; }
 
 private:
@@ -50,8 +47,7 @@ private:
   void Parse(const int argc, char **argv);
 
 private:
-  po::positional_options_description _positional;
-  po::options_description _options;
+  arser::Arser _arser;
 
   std::string _tflite_filename;
   std::string _dump_filename;
@@ -64,7 +60,6 @@ private:
   bool _gpumem_poll;
   bool _mem_poll;
   bool _write_report;
-  bool _tflite_validate;
   int _verbose_level;
 };
 


### PR DESCRIPTION
This commit updates tflite_run to use arser for argument parsing instead of boost::program_options.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>