### PR TITLE
[onert] Revisit IPortableTensor

### DIFF
--- a/runtime/onert/backend/train/optimizer/Optimizers.test.cc
+++ b/runtime/onert/backend/train/optimizer/Optimizers.test.cc
@@ -44,34 +44,6 @@ public:
     std::copy(data.begin(), data.end(), _data.begin());
   }
 
-  size_t total_size() const override
-  {
-    size_t total_size = _info.shape().num_elements();
-    total_size *= sizeOfDataType(data_type());
-    return total_size;
-  }
-
-  size_t calcOffset(const ir::Coordinates &coords) const override
-  {
-    const auto &shape = _info.shape();
-    std::vector<size_t> strides(shape.rank());
-
-    size_t stride = 1;
-    for (int32_t i = shape.rank() - 1; i >= 0; --i)
-    {
-      strides.at(i) = stride;
-      stride = stride * shape.dim(i);
-    }
-
-    size_t offset = 0;
-    for (int32_t i = 0; i < shape.rank(); ++i)
-    {
-      offset += (strides[i] * coords[i]);
-    }
-    offset *= sizeOfDataType(data_type());
-    return offset;
-  }
-
   uint8_t *buffer() const override
   {
     if (_data.size() != total_size())
@@ -83,10 +55,6 @@ public:
   template <typename T> const std::vector<T> &data() const { return _data; }
 
   ir::Layout layout() const override { return ir::Layout::NHWC; }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-
-  bool is_dynamic() const override { return false; }
-  Shape getShape() const override { return _info.shape(); }
 
 private:
   using ITensor::setShape;
@@ -113,34 +81,6 @@ public:
     std::copy(data.begin(), data.end(), _data.begin());
   }
 
-  size_t total_size() const override
-  {
-    size_t total_size = _info.shape().num_elements();
-    total_size *= sizeOfDataType(data_type());
-    return total_size;
-  }
-
-  size_t calcOffset(const ir::Coordinates &coords) const override
-  {
-    const auto &shape = _info.shape();
-    std::vector<size_t> strides(shape.rank());
-
-    size_t stride = 1;
-    for (int32_t i = shape.rank() - 1; i >= 0; --i)
-    {
-      strides.at(i) = stride;
-      stride = stride * shape.dim(i);
-    }
-
-    size_t offset = 0;
-    for (int32_t i = 0; i < shape.rank(); ++i)
-    {
-      offset += (strides[i] * coords[i]);
-    }
-    offset *= sizeOfDataType(data_type());
-    return offset;
-  }
-
   uint8_t *buffer() const override
   {
     if (_data.size() != total_size())
@@ -150,10 +90,6 @@ public:
   }
 
   ir::Layout layout() const override { return ir::Layout::NHWC; }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-
-  bool is_dynamic() const override { return false; }
-  Shape getShape() const override { return _info.shape(); }
 
 public:
   std::vector<ITensor *> optVars() override

--- a/runtime/onert/core/include/backend/basic/Tensor.h
+++ b/runtime/onert/core/include/backend/basic/Tensor.h
@@ -71,25 +71,9 @@ public:
 
 public:
   uint8_t *buffer() const override { return _buffer; }
-  /**
-   * @brief Get dimension by index
-   *
-   * @param index Index to get diemension
-   * @return size_t Dimension at index
-   * @note N : dimension(0)
-   *       H : dimension(1)
-   *       W : dimension(2)
-   *       C : dimension(3)
-   */
-  size_t total_size() const override { return _info.total_size(); }
-  size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return _layout; }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  bool is_constant() const override { return _info.isConstant(); }
-  bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }
   bool applyShape(const ir::Shape &new_shape) override;
-  const ir::Sparsity *sparsity() const override { return _info.typeInfo().sparsity(); }
 
   virtual void increase_ref()
   {
@@ -140,7 +124,6 @@ public:
   virtual int32_t num_references() { return _num_references; }
 
   void setShape(const ir::Shape &new_shape) override;
-  ir::Shape getShape() const override;
 
 protected:
   ir::Layout _layout;
@@ -199,8 +182,6 @@ public:
 public:
   uint8_t *buffer() const override { return _buffer; }
 
-  bool is_constant() const override { return true; }
-  bool is_dynamic() const override { return false; }
   void set_dynamic() override
   {
     throw std::runtime_error("This tensor does not support changing dynamic");

--- a/runtime/onert/core/include/backend/basic/train/TrainableTensor.h
+++ b/runtime/onert/core/include/backend/basic/train/TrainableTensor.h
@@ -51,27 +51,7 @@ public:
 
 public:
   uint8_t *buffer() const override { return _tensor.buffer(); }
-  /**
-   * @brief Get dimension by index
-   *
-   * @param index Index to get diemension
-   * @return size_t Dimension at index
-   * @note N : dimension(0)
-   *       H : dimension(1)
-   *       W : dimension(2)
-   *       C : dimension(3)
-   */
-  size_t total_size() const override { return _tensor.total_size(); }
-  size_t calcOffset(const ir::Coordinates &coords) const override
-  {
-    return _tensor.calcOffset(coords);
-  }
   ir::Layout layout() const override { return _tensor.layout(); }
-  ir::DataType data_type() const override { return _tensor.data_type(); }
-  bool is_constant() const override { return _tensor.is_constant(); }
-  bool is_dynamic() const override { return _tensor.is_dynamic(); }
-  ir::Shape getShape() const override { return _tensor.getShape(); };
-  const ir::OperandInfo &get_info() { return _tensor.get_info(); }
 
 public:
   std::vector<ITensor *> optVars() override;

--- a/runtime/onert/core/src/backend/IPortableTensor.cc
+++ b/runtime/onert/core/src/backend/IPortableTensor.cc
@@ -25,5 +25,20 @@ namespace backend
 // With this as a key function, `dynamic_cast` works across dl
 IPortableTensor::~IPortableTensor() {}
 
+size_t IPortableTensor::calcOffset(const ir::Coordinates &coords) const
+{
+  auto shape = _info.shape();
+  size_t rank = shape.rank();
+  rank = rank == 0 ? 1 : rank;
+  size_t offset = 0;
+  for (size_t i = 0; i < rank; ++i)
+  {
+    auto dim = shape.rank() == 0 ? 1 : shape.dim(i);
+    offset = offset * dim + coords[i];
+  }
+  offset *= sizeOfDataType(data_type());
+  return offset;
+}
+
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/basic/Tensor.cc
+++ b/runtime/onert/core/src/backend/basic/Tensor.cc
@@ -28,21 +28,6 @@ namespace basic
 
 Tensor::~Tensor() {}
 
-size_t Tensor::calcOffset(const ir::Coordinates &coords) const
-{
-  auto shape = getShape();
-  size_t rank = shape.rank();
-  rank = rank == 0 ? 1 : rank;
-  size_t offset = 0;
-  for (size_t i = 0; i < rank; ++i)
-  {
-    auto dim = shape.rank() == 0 ? 1 : shape.dim(i);
-    offset = offset * dim + coords[i];
-  }
-  offset *= sizeOfDataType(data_type());
-  return offset;
-}
-
 void Tensor::setShape(const ir::Shape &new_shape) { _info.shape(new_shape); }
 
 bool Tensor::applyShape(const ir::Shape &new_shape)
@@ -83,8 +68,6 @@ bool Tensor::applyShape(const ir::Shape &new_shape)
   }
   return true;
 }
-
-ir::Shape Tensor::getShape() const { return _info.shape(); }
 
 void Tensor::deallocBuffer()
 {

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -58,26 +58,17 @@ public:
 
 public:
   uint8_t *buffer() const override { return _tensor->buffer(); }
-  size_t total_size() const override { return _info.total_size(); }
-  size_t calcOffset(const ir::Coordinates &coords) const override
-  {
-    return _tensor->calcOffset(coords);
-  }
   ir::Layout layout() const override { return _orig->layout(); }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override
   {
     _info.setDynamic();
     _tensor->set_dynamic();
   }
-  ir::Shape getShape() const override { return _info.shape(); }
   void setShape(const ir::Shape &shape) override
   {
     _info.shape(shape);
     _tensor->setShape(shape);
   }
-  bool is_constant() const override { return _info.isConstant(); }
   bool applyShape(const ir::Shape &shape) override
   {
     auto return_val = _tensor->applyShape(shape);

--- a/runtime/onert/core/src/backend/builtin/UserTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.cc
@@ -26,23 +26,11 @@ namespace backend
 namespace builtin
 {
 
-size_t UserTensor::calcOffset(const ir::Coordinates &coords) const
-{
-  size_t rank = getShape().rank();
-  size_t offset = 0;
-  for (size_t i = 0; i < rank; ++i)
-  {
-    offset = offset * getShape().dim(i) + coords[i];
-  }
-  offset *= sizeOfDataType(data_type());
-  return offset;
-}
-
 bool UserTensor::applyShape(const ir::Shape &new_shape)
 {
   // User tensors cannot be reallocated.
   auto new_size = new_shape.num_elements() * ir::sizeOfDataType(data_type());
-  if (total_size() < new_size)
+  if (_size < new_size)
     throw InsufficientBufferSizeException{"User given buffer size is too small."};
   setShape(new_shape);
   return true;

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -39,39 +39,21 @@ class UserTensor : public IPortableTensor
 {
 public:
   UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
-    : IPortableTensor{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false}
+    : IPortableTensor{info}, _layout{layout}, _buffer{buffer}, _size{size}
   {
-  }
-
-  UserTensor(const ir::OperandInfo &info, ir::Layout layout) : UserTensor{info, layout, nullptr, 0}
-  {
-  }
-
-public:
-  void setBuffer(uint8_t *buffer, size_t size)
-  {
-    _buffer = buffer;
-    _size = size;
   }
 
 public:
   uint8_t *buffer() const override { return _buffer; }
-  size_t total_size() const override { return _size; }
-  size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return _layout; }
-  ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  bool is_dynamic() const override { return _dynamic; }
-  void set_dynamic() override { _dynamic = true; }
-  ir::Shape getShape() const override { return _info.shape(); }
+  void set_dynamic() override { _info.setDynamic(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
-  bool is_constant() const override { return false; }
   bool applyShape(const ir::Shape &) override;
 
 private:
   ir::Layout _layout;
   uint8_t *_buffer;
   size_t _size;
-  bool _dynamic;
 };
 
 } // namespace builtin


### PR DESCRIPTION
This commit revisits IPortableTensor interface
- Introduce getters for tensor info
- Introduce calcOffset() to calculate offset by using tensor info
- Remove tensor info getter and calcOffset() from derived classes
  - Derived classes use IPortableTensor's getters and calcOffset() instead of its own methods

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/13333