### PR TITLE
[onert/onert_run] Reshape output shape

### DIFF
--- a/tests/tools/onert_run/src/args.cc
+++ b/tests/tools/onert_run/src/args.cc
@@ -231,6 +231,18 @@ void Args::Initialize(void)
     }
   };
 
+  auto process_output_shape = [&](const std::string &shape_str) {
+    try
+    {
+      handleShapeJsonParam(_output_shape, shape_str);
+    }
+    catch (const std::exception &e)
+    {
+      std::cerr << "error with '--output_shape' option: " << shape_str << std::endl;
+      exit(1);
+    }
+  };
+
   auto process_shape_run = [&](const std::string &shape_str) {
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
     if (shape_str == "H5" || shape_str == "h5")
@@ -298,6 +310,10 @@ void Args::Initialize(void)
 #endif
          "For detailed description, please consutl the description of nnfw_set_input_tensorinfo()\n"
          )
+    ("output_shape", po::value<std::string>()->default_value("[]")->notifier(process_output_shape),
+         "Set output shape for dump.\n"
+         "Size should be same.\n"
+         "'[0, [1, 2], 2, []]': set 0th tensor to [1, 2] and 2nd tensor to [] (scalar).\n")
     ("verbose_level,v", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _verbose_level = v; }),
          "Verbose level\n"
          "0: prints the only result. Messages btw run don't print\n"

--- a/tests/tools/onert_run/src/args.h
+++ b/tests/tools/onert_run/src/args.h
@@ -70,6 +70,7 @@ public:
   const bool printVersion(void) const { return _print_version; }
   TensorShapeMap &getShapeMapForPrepare() { return _shape_prepare; }
   TensorShapeMap &getShapeMapForRun() { return _shape_run; }
+  TensorShapeMap &getOutputShapeMap() { return _output_shape; }
   /// @brief Return true if "--shape_run" or "--shape_prepare" is provided
   bool shapeParamProvided();
   const int getVerboseLevel(void) const { return _verbose_level; }
@@ -98,6 +99,7 @@ private:
   std::string _load_raw_filename;
   TensorShapeMap _shape_prepare;
   TensorShapeMap _shape_run;
+  TensorShapeMap _output_shape;
   int _num_runs;
   bool _fixed_input = false;
   bool _force_float = false;

--- a/tests/tools/onert_run/src/onert_run.cc
+++ b/tests/tools/onert_run/src/onert_run.cc
@@ -440,16 +440,25 @@ int main(const int argc, char **argv)
     if (!args.getDumpFilename().empty())
     {
       std::vector<TensorShape> output_shapes;
+      auto output_shape_map = args.getOutputShapeMap();
       for (uint32_t i = 0; i < num_outputs; i++)
       {
         nnfw_tensorinfo ti;
         NNPR_ENSURE_STATUS(nnfw_output_tensorinfo(session, i, &ti));
 
-        TensorShape shape;
-        for (uint32_t j = 0; j < ti.rank; j++)
-          shape.emplace_back(ti.dims[j]);
+        auto found = output_shape_map.find(i);
+        if (found != output_shape_map.end())
+        {
+          output_shapes.emplace_back(found->second);
+        }
+        else
+        {
+          TensorShape shape;
+          for (uint32_t j = 0; j < ti.rank; j++)
+            shape.emplace_back(ti.dims[j]);
 
-        output_shapes.emplace_back(shape);
+          output_shapes.emplace_back(shape);
+        }
       }
 
       H5Formatter().dumpOutputs(args.getDumpFilename(), outputs, output_shapes);


### PR DESCRIPTION
This commit adds options to change output shape for output dump. 
It helps h5diff between circle(tflite) and tvn model output: different output rank.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13284