### PR TITLE
[onert] Add disabling backward to TrainableGraph

### DIFF
--- a/runtime/onert/core/include/ir/train/ITrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/ITrainableOperation.h
@@ -51,6 +51,7 @@ public:
 
   // Mark the node as needed for backward propagation part of the traning
   virtual void enableBackward() = 0;
+  virtual void disableBackward() = 0;
   // Check if the nodes is required for backward propagation part of the traning.
   // If returned false, it means that there are no node before (in topological sense) which is
   // trainable.

--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -112,6 +112,7 @@ public:
   void setOutputs(OperandIndexSequence outputs,
                   std::unordered_map<std::string, IOIndex> name_to_output);
   void enableBackward(const OperationIndex &index);
+  void disableBackward(const OperationIndex &index);
   void setTrainingUseDefs(const UseDefChains &training_defuses);
 
   // Accessors

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -39,6 +39,7 @@ public:
   virtual bool isWeightsUpdateEnabled() const final { return _trainable; }
 
   void enableBackward() final { _required_for_backward = true; }
+  void disableBackward() final { _required_for_backward = false; }
   virtual bool isRequiredForBackward() const final { return _required_for_backward; }
 
 private:

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -140,6 +140,12 @@ void TrainableGraph::enableBackward(const OperationIndex &index)
   op->enableBackward();
 }
 
+void TrainableGraph::disableBackward(const OperationIndex &index)
+{
+  auto &op = dynamic_cast<ir::train::ITrainableOperation &>(_graph.operations().at(index));
+  op.disableBackward();
+}
+
 void TrainableGraph::validateTopologicalOrder(std::vector<ir::OperationIndex> order,
                                               bool is_forward) const
 {


### PR DESCRIPTION
This commit adds disableBackward function in TrainableGRaph to disable backword of an op node.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>