### PR TITLE
[onert] Add missing definition in TrainableGraph

### DIFF
--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -146,6 +146,16 @@ void TrainableGraph::disableBackward(const OperationIndex &index)
   op.disableBackward();
 }
 
+void TrainableGraph::setTrainingUseDefs(const UseDefChains &training_defuses)
+{
+  _training_defuses.clear();
+  // TODO Replace this loop with `std::unordered_map::insert_range` since C++23
+  for (const auto &defuse_chain : training_defuses)
+  {
+    _training_defuses.emplace(defuse_chain.first, defuse_chain.second);
+  }
+}
+
 void TrainableGraph::validateTopologicalOrder(std::vector<ir::OperationIndex> order,
                                               bool is_forward) const
 {


### PR DESCRIPTION
This commit adds the missing definition of setTrainingUseDef in TrainableGraph.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>