### PR TITLE
[onert] Replace btopolSortOperations with essentialBackwardOrder

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -741,9 +741,7 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
   Linear::dump(*lowered_graph, order);
 
   // linearize for backwarding
-  auto backward_order = lowered_graph->trainable_graph().btopolSortOperations();
-  // get rid of all nodes not reachable from a node with trainable parameters
-  backward_order = lowered_graph->trainable_graph().truncateBackwardOrder(backward_order);
+  auto backward_order = lowered_graph->trainable_graph().essentialBackwardOrder();
   VERBOSE(ExecutorFactory) << "Linearize for backwarding order" << std::endl;
   Linear::dump(*lowered_graph, backward_order);
 


### PR DESCRIPTION
This commit replaces btopolSortOperations with essentialBackwardOrder.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>