### PR TITLE
[onert] Move assertion in loss layers

### DIFF
--- a/runtime/onert/backend/train/ops/LossCategoricalCrossentropyLayer.cc
+++ b/runtime/onert/backend/train/ops/LossCategoricalCrossentropyLayer.cc
@@ -56,6 +56,8 @@ void LossCategoricalCrossentropyLayer::forward(bool)
 
 void LossCategoricalCrossentropyLayer::backward()
 {
+  assert(_back_prop_y_pred != nullptr);
+
   if (_y_pred->data_type() == OperandType::FLOAT32)
   {
     nnfw::cker::train::CategoricalCrossEntropyGrad(

--- a/runtime/onert/backend/train/ops/LossLayer.cc
+++ b/runtime/onert/backend/train/ops/LossLayer.cc
@@ -37,7 +37,7 @@ void LossLayer::configure(const IPortableTensor *y_pred, const IPortableTensor *
   assert(y_pred != nullptr);
   assert(y_true != nullptr);
   assert(output != nullptr);
-  assert(back_prop_y_pred != nullptr);
+  // back_prop_y_pred can be nullptr if backwarding is not required
 
   _y_pred = y_pred;
   _y_true = y_true;

--- a/runtime/onert/backend/train/ops/LossMeanSquaredErrorLayer.cc
+++ b/runtime/onert/backend/train/ops/LossMeanSquaredErrorLayer.cc
@@ -51,6 +51,8 @@ void LossMeanSquaredErrorLayer::forward(bool)
 
 void LossMeanSquaredErrorLayer::backward()
 {
+  assert(_back_prop_y_pred != nullptr);
+
   if (_y_pred->data_type() == OperandType::FLOAT32)
   {
     nnfw::cker::train::MSEGrad(getShape(_y_pred), getBuffer<float>(_y_pred), getShape(_y_true),


### PR DESCRIPTION
This commit moves the assertion that checks backwarding y_pred tensor from constructor to backward.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>