### PR TITLE
[onert] Remove IOTensor dependency in IExecutor

### DIFF
--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -21,27 +21,17 @@
 #ifndef __ONERT_EXEC_I_EXECUTOR_H__
 #define __ONERT_EXEC_I_EXECUTOR_H__
 
-#include "ir/Graph.h"
-#include "IFunction.h"
 #include "ExecutionContext.h"
+#include "backend/IPortableTensor.h"
+#include "ir/Graph.h"
 #include "ir/Index.h"
+#include "ir/OperandInfo.h"
 #include "ir/OperationIndexMap.h"
 
 #include <cstdint>
 #include <memory>
-#include <unordered_map>
+#include <vector>
 
-namespace onert
-{
-namespace backend
-{
-class IPortableTensor;
-namespace builtin
-{
-class IOTensor;
-}
-} // namespace backend
-} // namespace onert
 namespace onert
 {
 namespace exec
@@ -93,18 +83,44 @@ struct IExecutor
                        const ExecutionOptions &options) = 0;
 
   /**
-   * @brief Get input tensor objects
-   *
-   * @return Vector of @c IOTensor
+   * @brief   Get input size
+   * @return  Input size
    */
-  virtual const std::vector<backend::builtin::IOTensor *> &getInputTensors() const = 0;
+  virtual uint32_t inputSize() const = 0;
 
   /**
-   * @brief Get output tensor objects
-   *
-   * @return Vector of @c IOTensor
+   * @brief   Get output size
+   * @return  Output size
    */
-  virtual const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const = 0;
+  virtual uint32_t outputSize() const = 0;
+
+  /**
+   * @brief     Get input info at index
+   * @param[in] index Index of input
+   * @return    Input operand info
+   */
+  virtual const ir::OperandInfo &inputInfo(uint32_t index) const = 0;
+
+  /**
+   * @brief     Get output info at index
+   * @param[in] index Index of output
+   * @return    Output operand info
+   */
+  virtual const ir::OperandInfo &outputInfo(uint32_t index) const = 0;
+
+  /**
+   * @brief     Get input layout at index
+   * @param[in] index Index of input
+   * @return    Input operand layout
+   */
+  virtual ir::Layout inputLayout(uint32_t index) const = 0;
+
+  /**
+   * @brief     Get output layout at index
+   * @param[in] index Index of output
+   * @return    Output operand layout
+   */
+  virtual ir::Layout outputLayout(uint32_t index) const = 0;
 
   /**
    * @brief   Return current execution configuration

--- a/runtime/onert/core/src/backend/builtin/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/IfLayer.h
@@ -19,6 +19,7 @@
 
 #include <backend/IPortableTensor.h>
 #include <exec/IExecutors.h>
+#include <exec/IFunction.h>
 #include "../ExternalContext.h"
 
 namespace onert

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -63,11 +63,10 @@ void WhileLayer::run()
   auto body_exec = _executors->at(_model_index, _body_subg_index);
 
   // Need a temp tensor to hold the cond subgraph output
-  assert(cond_exec->getOutputTensors().size() == 1);
+  assert(cond_exec->outputSize() == 1);
   auto cond_output_tensor = [&]() {
-    auto cond_output = cond_exec->getOutputTensors().at(0);
-    auto tensor =
-      std::make_unique<Tensor>(cond_output->get_info(), cond_output->layout(), _dyn_memory_manager);
+    auto tensor = std::make_unique<Tensor>(cond_exec->outputInfo(0), cond_exec->outputLayout(0),
+                                           _dyn_memory_manager);
     tensor->set_dynamic();
     tensor->setBuffer(_dyn_memory_manager->allocate(tensor.get(), tensor->total_size()));
     return tensor;
@@ -97,10 +96,10 @@ void WhileLayer::run()
   // Need some temp tensors to hold the body subgraph output
   std::vector<std::unique_ptr<Tensor>> temp_outputs_o;
   std::vector<IPortableTensor *> temp_outputs;
-  for (auto &&io_tensor : body_exec->getOutputTensors())
+  for (uint32_t i = 0; i < body_exec->outputSize(); i++)
   {
-    auto tensor =
-      std::make_unique<Tensor>(io_tensor->get_info(), io_tensor->layout(), _dyn_memory_manager);
+    auto tensor = std::make_unique<Tensor>(body_exec->outputInfo(i), body_exec->outputLayout(i),
+                                           _dyn_memory_manager);
     tensor->set_dynamic();
     tensor->setBuffer(_dyn_memory_manager->allocate(tensor.get(), tensor->total_size()));
     temp_outputs.push_back(tensor.get());

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -59,6 +59,24 @@ public:
                const std::vector<backend::IPortableTensor *> &outputs,
                const ExecutionOptions &options) override;
 
+  uint32_t inputSize() const override { return _input_tensors.size(); }
+
+  uint32_t outputSize() const override { return _output_tensors.size(); }
+
+  const ir::OperandInfo &inputInfo(uint32_t index) const override
+  {
+    return _input_tensors[index]->get_info();
+  }
+
+  const ir::OperandInfo &outputInfo(uint32_t index) const override
+  {
+    return _output_tensors[index]->get_info();
+  }
+
+  ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+
+  ir::Layout outputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+
   // Used only in Dataflow and Parallel Executors
   void setIndexedRanks(std::shared_ptr<ir::OperationIndexMap<int64_t>> ranks) final
   {
@@ -69,15 +87,6 @@ public:
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _observers.add(std::move(ref)); };
 
-  const std::vector<backend::builtin::IOTensor *> &getInputTensors() const override
-  {
-    return _input_tensors;
-  }
-
-  const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const override
-  {
-    return _output_tensors;
-  }
   backend::BackendContexts &getBackendContexts() { return _backend_contexts; }
 
   const ExecutionOptions &currentOptions() const override { return _current_options; }

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -75,7 +75,10 @@ public:
 
   ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
 
-  ir::Layout outputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+  ir::Layout outputLayout(uint32_t index) const override
+  {
+    return _output_tensors[index]->layout();
+  }
 
   // Used only in Dataflow and Parallel Executors
   void setIndexedRanks(std::shared_ptr<ir::OperationIndexMap<int64_t>> ranks) final

--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -20,6 +20,7 @@
 #include "exec/IExecutors.h"
 #include "ir/NNPkg.h"
 #include "IPermuteFunction.h"
+#include "../backend/builtin/IOTensor.h"
 
 namespace std
 {

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -35,24 +35,18 @@ IExecutor *SingleModelExecutors::at(const ir::ModelIndex &,
   return _executors.at(subg_index).get();
 }
 
-uint32_t SingleModelExecutors::inputSize() const
-{
-  return entryExecutor()->getInputTensors().size();
-}
+uint32_t SingleModelExecutors::inputSize() const { return entryExecutor()->inputSize(); }
 
-uint32_t SingleModelExecutors::outputSize() const
-{
-  return entryExecutor()->getOutputTensors().size();
-}
+uint32_t SingleModelExecutors::outputSize() const { return entryExecutor()->outputSize(); }
 
 const ir::OperandInfo &SingleModelExecutors::inputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getInputTensors().at(index.value())->get_info();
+  return entryExecutor()->inputInfo(index.value());
 }
 
 const ir::OperandInfo &SingleModelExecutors::outputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getOutputTensors().at(index.value())->get_info();
+  return entryExecutor()->outputInfo(index.value());
 }
 
 void SingleModelExecutors::execute(const ExecutionContext &ctx) { entryExecutor()->execute(ctx); }

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -62,6 +62,24 @@ public:
                const std::vector<backend::IPortableTensor *> &outputs,
                const ExecutionOptions &options) override;
 
+  uint32_t inputSize() const override { return _input_tensors.size(); }
+
+  uint32_t outputSize() const override { return _output_tensors.size(); }
+
+  const ir::OperandInfo &inputInfo(uint32_t index) const override
+  {
+    return _input_tensors[index]->get_info();
+  }
+
+  const ir::OperandInfo &outputInfo(uint32_t index) const override
+  {
+    return _output_tensors[index]->get_info();
+  }
+
+  ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+
+  ir::Layout outputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+
   void forward(const ExecutionContext &ctx, bool training);
   void backward(const ExecutionContext &ctx, uint32_t training_step);
 
@@ -72,16 +90,6 @@ public:
   };
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _observers.add(std::move(ref)); };
-
-  const std::vector<backend::builtin::IOTensor *> &getInputTensors() const override
-  {
-    return _input_tensors;
-  }
-
-  const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const override
-  {
-    return _output_tensors;
-  }
 
   float getLoss(const ir::IOIndex &pred_io_ind) const;
 

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -78,7 +78,10 @@ public:
 
   ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
 
-  ir::Layout outputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
+  ir::Layout outputLayout(uint32_t index) const override
+  {
+    return _output_tensors[index]->layout();
+  }
 
   void forward(const ExecutionContext &ctx, bool training);
   void backward(const ExecutionContext &ctx, uint32_t training_step);

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -41,21 +41,18 @@ TrainableExecutor *TrainableExecutors::at(const ir::ModelIndex &,
   return _executors.at(subg_index).get();
 }
 
-uint32_t TrainableExecutors::inputSize() const { return entryExecutor()->getInputTensors().size(); }
+uint32_t TrainableExecutors::inputSize() const { return entryExecutor()->inputSize(); }
 
-uint32_t TrainableExecutors::outputSize() const
-{
-  return entryExecutor()->getOutputTensors().size();
-}
+uint32_t TrainableExecutors::outputSize() const { return entryExecutor()->outputSize(); }
 
 const ir::OperandInfo &TrainableExecutors::inputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getInputTensors().at(index.value())->get_info();
+  return entryExecutor()->inputInfo(index.value());
 }
 
 const ir::OperandInfo &TrainableExecutors::outputInfo(const ir::IOIndex &index) const
 {
-  return entryExecutor()->getOutputTensors().at(index.value())->get_info();
+  return entryExecutor()->outputInfo(index.value());
 }
 
 void TrainableExecutors::execute(const ExecutionContext &ctx)


### PR DESCRIPTION
This commit revisits public header IExecutor.h to remove  dependency with IOTensor class defined in private header IOTensor.h
- Remove getInputTensors() and getOutputTensors() method
- Introduce inputSize(), outputSize(), inputInfo(), outputInfo() method to replace getInputTensors() and getOutputTensors()
- Reorder and remove unused header include in IExecutor.h

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13333