### PR TITLE
[onert/kbenchmark] Use arser for kbenchmark

### DIFF
--- a/tools/kbenchmark/CMakeLists.txt
+++ b/tools/kbenchmark/CMakeLists.txt
@@ -8,12 +8,6 @@ if(NOT Nonius_FOUND)
   return()
 endif(NOT Nonius_FOUND)
 
-nnfw_find_package(Boost REQUIRED program_options)
-
-if(NOT Boost_FOUND)
-  return()
-endif(NOT Boost_FOUND)
-
 # driver
 file(GLOB_RECURSE SOURCES "*.cc")
 
@@ -22,7 +16,7 @@ target_compile_options(kbenchmark PRIVATE -Wno-psabi)
 target_include_directories(kbenchmark PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(kbenchmark PUBLIC nonius)
 target_link_libraries(kbenchmark PUBLIC dl)
-target_link_libraries(kbenchmark PUBLIC pthread boost_program_options)
+target_link_libraries(kbenchmark PUBLIC pthread arser)
 install(TARGETS kbenchmark DESTINATION bin)
 
 # kernel libraries


### PR DESCRIPTION
This commit updates kbenchmark to use arser for argument parsing instead of boost::program_options.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13366