### PR TITLE
[onert/tflite_comparator] Use arser for tflite_comparator

### DIFF
--- a/tests/tools/tflite_comparator/CMakeLists.txt
+++ b/tests/tools/tflite_comparator/CMakeLists.txt
@@ -11,13 +11,10 @@ endif(NOT BUILD_ONERT)
 list(APPEND SOURCES "src/tflite_comparator.cc")
 list(APPEND SOURCES "src/args.cc")
 
-nnfw_find_package(Boost REQUIRED program_options)
-
 add_executable(tflite_comparator ${SOURCES})
-target_include_directories(tflite_comparator PRIVATE ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(tflite_comparator nnfw-dev)
 target_link_libraries(tflite_comparator nnfw_lib_tflite nnfw_lib_misc)
-target_link_libraries(tflite_comparator ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(tflite_comparator arser)
 
 install(TARGETS tflite_comparator DESTINATION bin)

--- a/tests/tools/tflite_comparator/src/args.h
+++ b/tests/tools/tflite_comparator/src/args.h
@@ -18,9 +18,7 @@
 #define __TFLITE_LOADER_TOOLS_SRC_ARGS_H__
 
 #include <string>
-#include <boost/program_options.hpp>
-
-namespace po = boost::program_options;
+#include <arser/arser.h>
 
 namespace TFLiteRun
 {
@@ -39,8 +37,7 @@ private:
   void Parse(const int argc, char **argv);
 
 private:
-  po::options_description _options;
-  po::positional_options_description _positional;
+  arser::Arser _arser;
 
   std::string _tflite_filename;
   std::vector<std::string> _data_filenames;


### PR DESCRIPTION
This commit updates tflite_comparator to use arser for argument parsing instead of boost::program_options.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft:  #13366