### PR TITLE
[onert] Use reference in TrainInfoBuilder

### DIFF
--- a/runtime/onert/core/src/exporter/TrainInfoBuilder.h
+++ b/runtime/onert/core/src/exporter/TrainInfoBuilder.h
@@ -31,8 +31,8 @@ class TrainInfoBuilder
 public:
   TrainInfoBuilder(const std::unique_ptr<ir::train::TrainingInfo> &training_info) : _builder(1024)
   {
-    const auto optimizerInfo = training_info->optimizerInfo();
-    const auto lossInfo = training_info->lossInfo();
+    const auto &optimizerInfo = training_info->optimizerInfo();
+    const auto &lossInfo = training_info->lossInfo();
 
     ::circle::Optimizer optimizer;
     ::circle::OptimizerOptions optimizer_opt_type;


### PR DESCRIPTION
This commit updates TrainInfoBuilder constructor to use reference to access training info.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>