### PR TITLE
[onert] Change Edge tensor type in MultiModelExecutors

### DIFF
--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -20,7 +20,7 @@
 #include "exec/IExecutors.h"
 #include "ir/NNPkg.h"
 #include "IPermuteFunction.h"
-#include "../backend/builtin/IOTensor.h"
+#include "../backend/builtin/UserTensor.h"
 
 namespace std
 {
@@ -159,8 +159,8 @@ private:
   std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _pkg_input_quant_tensors;
   std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _pkg_output_quant_tensors;
   // IOTensors for user buffer
-  std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::IOTensor>> _pkg_input_tensors;
-  std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::IOTensor>> _pkg_output_tensors;
+  std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::UserTensor>> _pkg_input_tensors;
+  std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::UserTensor>> _pkg_output_tensors;
 };
 
 } // namespace exec


### PR DESCRIPTION
This commit changes edge tensor type in MultiModelExecutors
- Package I/O edge: IOTensor -> UserTensor
  - Change to use UserTensor to represent buffer from user. IOTensor is indirect tensor to represent executor I/O in each executor
- Edge between executor: EdgeTensor derived from IOTensor -> derived from IPortableTensor
  - Change to use EdgeTensor derived from IPortableTensor to represent buffer allocated in executors

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13333