### PR TITLE
[one-cmds] Revisit command schema feature

### DIFF
--- a/docs/release/1.27/index.rst
+++ b/docs/release/1.27/index.rst
@@ -11,3 +11,4 @@
    :caption: Contents:
 
   ./release-note-1.27.0.md
+  ./release-note-1.27.1.md

--- a/docs/release/1.27/release-note-1.27.1.md
+++ b/docs/release/1.27/release-note-1.27.1.md
@@ -1,0 +1,6 @@
+# Release Note 1.27.1
+
+## ONE Compiler
+
+- Command schema supports multiple names.
+- Fix invalid warning on boolean type option in _onecc_.


### PR DESCRIPTION
This commit revists command schema feature.
- Support multiple names
- Fix invalid warning on boolean type option.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>