### PR TITLE
[arser] Support multiline help message alignment

### DIFF
--- a/compiler/arser/include/arser/arser.h
+++ b/compiler/arser/include/arser/arser.h
@@ -252,7 +252,16 @@ public:
 
   Argument &help(std::string help_message)
   {
-    _help_message = help_message;
+    _help_message.emplace_back(help_message);
+    return *this;
+  }
+
+  Argument &help(std::initializer_list<std::string> help_messages)
+  {
+    if (help_messages.size() == 0)
+      throw std::runtime_error("Empty help message list");
+
+    _help_message = help_messages;
     return *this;
   }
 
@@ -304,7 +313,7 @@ private:
   std::string _short_name;
   std::vector<std::string> _names;
   std::string _type = "string";
-  std::string _help_message;
+  std::vector<std::string> _help_message;
   std::function<void(void)> _func;
   uint32_t _nargs{1};
   bool _is_required{false};
@@ -600,11 +609,14 @@ public:
         {
           stream.width(length_of_longest_arg);
           stream << std::left << arser::internal::make_comma_concatenated(arg._names) << "\t";
-          for (size_t i = 0; i < arg._help_message.length(); i += message_width)
+          for (size_t i = 0; i < arg._help_message.size(); i++)
           {
-            if (i)
-              stream << std::string(length_of_longest_arg, ' ') << "\t";
-            stream << arg._help_message.substr(i, message_width) << std::endl;
+            for (size_t j = 0; j < arg._help_message[i].length(); j += message_width)
+            {
+              if (i || j)
+                stream << std::string(length_of_longest_arg, ' ') << "\t";
+              stream << arg._help_message[i].substr(j, message_width) << std::endl;
+            }
           }
         }
         std::cout << std::endl;

--- a/compiler/arser/tests/arser.test.cpp
+++ b/compiler/arser/tests/arser.test.cpp
@@ -505,7 +505,7 @@ TEST(HelpMessageTest, MultilineHelp)
   EXPECT_EQ(expected_out, oss.str());
 }
 
-TEST(HelpMessageTest, MultilineHelpEmpty_Neg)
+TEST(HelpMessageTest, MultilineHelpEmpty_NEG)
 {
   /* arrange */
   Arser arser;

--- a/compiler/arser/tests/arser.test.cpp
+++ b/compiler/arser/tests/arser.test.cpp
@@ -478,3 +478,38 @@ TEST(BasicTest, AccumulateScalarOptions_WrongType_NEG)
 
   EXPECT_THROW(arser.get<float>("--specify"), std::runtime_error);
 }
+
+TEST(HelpMessageTest, MultilineHelp)
+{
+  /* arrange */
+  Arser arser;
+
+  arser.add_argument("-v", "--verbose")
+    .nargs(0)
+    .help({"Provides additional details", "Default: No"});
+
+  std::ostringstream oss;
+  std::string expected_out = "Usage: ./arser [-h] [-v] \n"
+                             "\n"
+                             "[Optional argument]\n"
+                             "-h, --help   \tShow help message and exit\n"
+                             "-v, --verbose\tProvides additional details\n"
+                             "             \tDefault: No\n";
+
+  test::Prompt prompt("./arser -v");
+  /* act */
+  arser.parse(prompt.argc(), prompt.argv());
+  oss << arser;
+
+  /* assert */
+  EXPECT_EQ(expected_out, oss.str());
+}
+
+TEST(HelpMessageTest, MultilineHelpEmpty_Neg)
+{
+  /* arrange */
+  Arser arser;
+  std::initializer_list<std::string> help_msg = {};
+
+  EXPECT_THROW(arser.add_argument("-v", "--verbose").nargs(0).help(help_msg), std::runtime_error);
+}


### PR DESCRIPTION
This commit updates arser to support multiline help message with alignment.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>