### PR TITLE
[onert/cker] Remove unused variable

### DIFF
--- a/compute/cker/include/cker/operation/SplitV.h
+++ b/compute/cker/include/cker/operation/SplitV.h
@@ -34,8 +34,6 @@ void SplitV(const SplitVParams &params, const Shape &input_shape, const Scalar *
   int axis = params.axis < 0 ? params.axis + split_dimensions : params.axis;
   int outputs_count = params.num_split;
 
-  int64_t split_size = 0;
-
   for (int i = 0; i < outputs_count; i++)
   {
     // TFLITE_DCHECK_EQ(output_shapes[i]->DimensionsCount(), split_dimensions);
@@ -46,7 +44,6 @@ void SplitV(const SplitVParams &params, const Shape &input_shape, const Scalar *
         MatchingDim(output_shapes[i], j, input_shape, j);
       }
     }
-    split_size += output_shapes[i].Dims(axis);
   }
 
   int64_t outer_size = 1;


### PR DESCRIPTION
This commit removes unused variable `split_size` in SplitV.h
 `split_size` is used to update itself only.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>