### PR TITLE
[compute/cker] Mark UNUSED_RELEASE

### DIFF
--- a/compute/cker/include/cker/operation/Concatenation.h
+++ b/compute/cker/include/cker/operation/Concatenation.h
@@ -54,6 +54,7 @@ inline void Concatenation(const ConcatenationParams &params, const Shape *const 
     concat_size += input_shapes[i]->Dims(axis);
   }
   assert(concat_size == output_shape.Dims(axis));
+  UNUSED_RELEASE(concat_size);
   int64_t outer_size = 1;
   for (int i = 0; i < axis; ++i)
   {
@@ -110,6 +111,7 @@ inline void ConcatenationWithScaling(const ConcatenationParams &params,
     concat_size += input_shapes[i]->Dims(axis);
   }
   assert(concat_size == output_shape.Dims(axis));
+  UNUSED_RELEASE(concat_size);
   int64_t outer_size = 1;
   for (int i = 0; i < axis; ++i)
   {

--- a/compute/cker/include/cker/operation/StridedSlice.h
+++ b/compute/cker/include/cker/operation/StridedSlice.h
@@ -254,6 +254,7 @@ void checkOutputSize(const StridedSliceParams &op_params, const Shape &input_sha
   }
 
   assert(output_shape.DimensionsCount() == shape_size);
+  UNUSED_RELEASE(shape_size);
 }
 
 template <typename T>


### PR DESCRIPTION
This commit marks the UNUSED_RELEASE macro as unused on release build because it is only used on assert.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>