### PR TITLE
[onert] Extract planning tensors

### DIFF
--- a/runtime/onert/backend/train/BackendContext.h
+++ b/runtime/onert/backend/train/BackendContext.h
@@ -71,6 +71,10 @@ public:
   backend::ITensorRegistry *genTensors() override;
   backend::train::ITensorRegistry *genTrainingTensors() override;
 
+private:
+  void planForwardTensors();
+  void planBackwardTensors();
+
 public:
   FunctionMap genKernels() override;
 


### PR DESCRIPTION
This commit extracts palnning tensors from generating tensors.
   - Introduce planForwardTensors() and planBackwardTensors()
   - Move loosely planning backwarding code from genTrainingTensors() into planBackwardTensors()

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>