### PR TITLE
[onert] Change TrainableExecutor forward call

### DIFF
--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -56,11 +56,14 @@ public:
 public:
   const ir::Graph &graph() const final { return _trainable_graph.graph(); }
 
-  void execute(const ExecutionContext &ctx) override { forward(ctx, false); };
+  void execute(const ExecutionContext &) override { throw std::runtime_error{"Not supported"}; }
 
   void execute(const std::vector<backend::IPortableTensor *> &inputs,
                const std::vector<backend::IPortableTensor *> &outputs,
-               const ExecutionOptions &options) override;
+               const ExecutionOptions &options) override
+  {
+    forward(inputs, outputs, options, false);
+  }
 
   uint32_t inputSize() const override { return _input_tensors.size(); }
 
@@ -83,8 +86,10 @@ public:
     return _output_tensors[index]->layout();
   }
 
-  void forward(const ExecutionContext &ctx, bool training);
-  void backward(const ExecutionContext &ctx, uint32_t training_step);
+  void forward(const std::vector<backend::IPortableTensor *> &inputs,
+               const std::vector<backend::IPortableTensor *> &outputs,
+               const ExecutionOptions &options, bool training);
+  void backward(const ExecutionOptions &options, uint32_t training_step);
 
   // Used only in Dataflow and Parallel Executors
   void setIndexedRanks(std::shared_ptr<ir::OperationIndexMap<int64_t>> ranks) final

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -59,7 +59,12 @@ void TrainableExecutors::execute(const ExecutionContext &ctx)
 {
   if (_executors.size() > 1)
     throw std::runtime_error("TrainableExecutors does not support multiple executors yet");
-  entryExecutor()->forward(ctx, false);
+
+  // UserTensor for Input/Output
+  std::vector<std::unique_ptr<backend::builtin::UserTensor>> tensorpool;
+
+  // Allocate UserTensor and call executor forward
+  forward(ctx, tensorpool, false);
 
   // TODO Support multple executors
 }
@@ -68,10 +73,54 @@ void TrainableExecutors::train(const ExecutionContext &ctx, uint32_t training_st
 {
   if (_executors.size() > 1)
     throw std::runtime_error("TrainableExecutors does not support multiple executors yet");
-  entryExecutor()->forward(ctx, true);
-  entryExecutor()->backward(ctx, training_step);
+
+  // UserTensor for Input/Output
+  std::vector<std::unique_ptr<backend::builtin::UserTensor>> tensorpool;
+
+  // Allocate UserTensor and call executor forward and backward
+  forward(ctx, tensorpool, true);
+  entryExecutor()->backward(ctx.options, training_step);
 
   // TODO Support multple executors
+}
+
+void TrainableExecutors::forward(
+  const ExecutionContext &ctx,
+  std::vector<std::unique_ptr<backend::builtin::UserTensor>> &tensorpool, bool training)
+{
+  // Input/Output Tensor vector for executor
+  std::vector<backend::IPortableTensor *> inputs(ctx.desc.inputs.size());
+  std::vector<backend::IPortableTensor *> outputs(ctx.desc.outputs.size());
+
+  // Prepare UserTensor for input
+  for (uint32_t i = 0; i < inputs.size(); i++)
+  {
+    auto &desc = ctx.desc.inputs[i];
+
+    // Input is optional if buffer is nullptr, and optional input's size is 0
+    if (desc->buffer == nullptr && (desc->size != 0 || desc->info.total_size() != 0))
+      throw std::runtime_error{"Input " + std::to_string(i) + "'s buffer is not set."};
+
+    tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
+      desc->info, desc->layout, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)),
+      desc->size));
+    inputs[i] = tensorpool.back().get();
+  }
+
+  // Prepare UserTensor for output
+  for (uint32_t i = 0; i < outputs.size(); i++)
+  {
+    auto &desc = ctx.desc.outputs[i];
+
+    // If training, output buffer may not be used
+    // So don't check optional
+    tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
+      desc->info, desc->layout, static_cast<uint8_t *>(desc->buffer), desc->size));
+    outputs[i] = tensorpool.back().get();
+  }
+
+  // Call forward
+  entryExecutor()->forward(inputs, outputs, ctx.options, training);
 }
 
 float TrainableExecutors::getLoss(const ir::IOIndex &index) const

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.h
@@ -85,6 +85,14 @@ public:
       &fn) const;
 
 private:
+  // If you want to use I/O buffer on step, tensorpool should be alive until one step is finished
+  // So this method get tensorpool from outside.
+  // tensorpool is not defined as a member variable to avoid memory access conflict between threads.
+  void forward(const ExecutionContext &ctx,
+               std::vector<std::unique_ptr<backend::builtin::UserTensor>> &tensorpool,
+               bool training);
+
+private:
   // TODO Append model index to ModelIndex
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<TrainableExecutor>> _executors;
 };


### PR DESCRIPTION
This commit changes the TrainableExecutor forward to be similar as the ExecutorBase execute implementation.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>