### PR TITLE
[onert/training] Store disposable tensor indices in TensorBuilder

### DIFF
--- a/runtime/onert/backend/train/TensorBuilder.cc
+++ b/runtime/onert/backend/train/TensorBuilder.cc
@@ -101,6 +101,8 @@ void TensorBuilder::registerDisposableBackwardTensorInfo(const DisposableTensorI
 
   auto disposable_tensor = std::make_unique<BackPropTensor>(info, layout);
   _tensor_reg->setDisposableBackPropTensor(index, std::move(disposable_tensor));
+
+  _disposable_backprops.add(index);
 }
 
 void TensorBuilder::notifyFirstUse(const ir::OperandIndex &index)
@@ -152,6 +154,11 @@ bool TensorBuilder::isRegistered(const ir::OperandIndex &index) const
 bool TensorBuilder::isRegisteredBackward(const ir::OperandIndex &index) const
 {
   return _backward_tensor_info_map.find(index) != _backward_tensor_info_map.end();
+}
+
+bool TensorBuilder::isRegisteredDisposableBackwardTensor(const DisposableTensorIndex &index) const
+{
+  return _disposable_backprops.contains(index);
 }
 
 void TensorBuilder::allocate(void)

--- a/runtime/onert/backend/train/TensorBuilder.h
+++ b/runtime/onert/backend/train/TensorBuilder.h
@@ -20,6 +20,7 @@
 #include "DisposableTensorIndex.h"
 #include "TensorManager.h"
 #include "TensorRegistry.h"
+#include "util/Set.h"
 
 #include <exec/train/optimizer/Optimizer.h>
 
@@ -67,6 +68,7 @@ public:
 
   bool isRegistered(const ir::OperandIndex &) const;
   bool isRegisteredBackward(const ir::OperandIndex &) const;
+  bool isRegisteredDisposableBackwardTensor(const DisposableTensorIndex &index) const;
 
   void allocate(void);
   void allocateBackward(void);
@@ -77,6 +79,7 @@ private:
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
   ir::OperandIndexMap<ir::OperandInfo> _backward_tensor_info_map;
   ir::OperandIndexMap<bool> _as_constants;
+  util::Set<DisposableTensorIndex> _disposable_backprops;
   const exec::train::optimizer::Optimizer *_optimizer;
 };
 


### PR DESCRIPTION
This commit stores disposable tensor indices in TensorBuilder.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>