### PR TITLE
[onert] Add generating training usedefs for BinaryArithmetic op

### DIFF
--- a/runtime/onert/core/src/ir/train/UseDefGenerator.h
+++ b/runtime/onert/core/src/ir/train/UseDefGenerator.h
@@ -64,6 +64,7 @@ public:
   UseDefChains operator()();
 
 public:
+  void visit(const train::operation::BinaryArithmetic &node) override;
   void visit(const train::operation::Conv2D &node) override;
   void visit(const train::operation::DepthwiseConv2D &node) override;
   void visit(const train::operation::ElementwiseActivation &node) override;


### PR DESCRIPTION
This commit adds generating training usedefs for BinaryArithmetic operation.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>