### PR TITLE
[onert] Add generating training usedefs for Reduce op

### DIFF
--- a/runtime/onert/core/src/ir/train/UseDefGenerator.cc
+++ b/runtime/onert/core/src/ir/train/UseDefGenerator.cc
@@ -254,6 +254,28 @@ void UseDefGenerator::visit(const train::operation::Pool2D &node)
   insertBackPropDef(outgoing_index, backwarding_op_index);
 }
 
+void UseDefGenerator::visit(const train::operation::Reduce &node)
+{
+  if (node.param().reduce_type != ir::operation::Reduce::ReduceType::MEAN)
+  {
+    throw std::runtime_error{"UseDefGenerator: Not yet supported reduce type"};
+  }
+
+  assert(_node_to_idx.find(&node) != _node_to_idx.end());
+  const auto &op_index = _node_to_idx.at(&node);
+  const auto backwarding_op_index = TrainingOperationIndex{op_index, false};
+
+  // Insert use of backwarding(backprop) output
+  const auto &out_index = node.getOutputs().at(0);
+  const auto incoming_index = TrainingOperandIndex{out_index, false};
+  insertUse(incoming_index, backwarding_op_index);
+
+  // Set def of backwarding(backprop) input
+  const auto &in_index = node.getInputs().at(train::operation::Reduce::Input::INPUT);
+  const auto outgoing_index = TrainingOperandIndex{in_index, false};
+  insertBackPropDef(outgoing_index, backwarding_op_index);
+}
+
 void UseDefGenerator::visit(const train::operation::Reshape &node)
 {
   assert(_node_to_idx.find(&node) != _node_to_idx.end());

--- a/runtime/onert/core/src/ir/train/UseDefGenerator.h
+++ b/runtime/onert/core/src/ir/train/UseDefGenerator.h
@@ -70,6 +70,7 @@ public:
   void visit(const train::operation::Loss &node) override;
   void visit(const train::operation::Pad &node) override;
   void visit(const train::operation::Pool2D &node) override;
+  void visit(const train::operation::Reduce &node) override;
   void visit(const train::operation::Reshape &node) override;
 
 private:


### PR DESCRIPTION
This commit adds generating training usedefs for Reduce op.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>