### PR TITLE
[onert] Add generating training usedefs for Softmax op

### DIFF
--- a/runtime/onert/core/src/ir/train/UseDefGenerator.h
+++ b/runtime/onert/core/src/ir/train/UseDefGenerator.h
@@ -67,6 +67,7 @@ public:
   void visit(const train::operation::Conv2D &node) override;
   void visit(const train::operation::Loss &node) override;
   void visit(const train::operation::Reshape &node) override;
+  void visit(const train::operation::Softmax &node) override;
 
 private:
   void insertUse(const TrainingOperandIndex &operand_index, const TrainingOperationIndex &op_index);


### PR DESCRIPTION
This commit adds generating training usedefs for Softmax operation.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>