### PR TITLE
[onert] Apply usedef chains for training

### DIFF
--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -161,6 +161,9 @@ public:
   truncateBackwardOrder(std::vector<ir::OperationIndex> backward_order,
                         std::function<bool(const ir::OperationIndex &)> truncating_cond) const;
 
+public:
+  void updateGraphDependency();
+
 private:
   Graph _graph;
   Operands _backward_operands;

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -706,6 +706,20 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
         external_operands.remove(index);
     }
 
+    const auto backend = pair.first;
+    // NOTE The builtin backend does not yet support initializing UseDefs for training
+    //      because it's graph does not have loss operation
+    //      Without loss opeartion, we cannot call btopolSortOperations() or
+    //      getEssentialBackwardOrder()
+    // TODO Modify checking the condition to check whether loss op exists
+    if (backend->config()->id() != "builtin")
+    {
+      // Initialize training def-uses
+      tgraph->updateGraphDependency();
+
+      tgraph->verify();
+    }
+
     // Set trainable context data
     backend::train::TrainableContextData tdata;
     tdata.tgraph = std::move(tgraph);
@@ -717,7 +731,6 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
     tdata.optim_info = training_info.optimizerInfo();
 
     // TODO Remove dynamic_cast
-    const auto backend = pair.first;
     const auto tbackend = dynamic_cast<const backend::train::ITrainableBackend *>(backend);
     if (!tbackend)
     {

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -173,6 +173,15 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
     dot_dumper.dump(*subg, nnfw::misc::str("after_loss_insertion-", subg_index.value()));
   }
 
+  for (auto &&[subg_index, subg] : trainable_subgraphs)
+  {
+    subg->updateGraphDependency();
+    subg->verify();
+
+    dot_dumper.dump(*subg,
+                    nnfw::misc::str("after_initializing_training_usedefs-", subg_index.value()));
+  }
+
   // Change input shape according to batch_size
   for (auto &&pair : trainable_subgraphs)
   {


### PR DESCRIPTION
This commit applies training usedefs to patial trainable graphs to be passed into backends.
   - Add a method to TrainableGraph that initialize training usedefs
   - Call the method for patial trainable graphs

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>