### PR TITLE
[onert] Fix typo in train kernel generator

### DIFF
--- a/runtime/onert/backend/train/KernelGenerator.cc
+++ b/runtime/onert/backend/train/KernelGenerator.cc
@@ -473,7 +473,7 @@ void KernelGenerator::visit(const ir::train::operation::Pool2D &node)
 
   if (ifm_shape.rank() != 4)
   {
-    std::runtime_error(node.name() + " only supports 4D tensor as input");
+    throw std::runtime_error(node.name() + " only supports 4D tensor as input");
   }
 
   // calcualate padding


### PR DESCRIPTION
This commit adds throw keyword to the train kernel generator.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>