### PR TITLE
[python] Remove deprecated methods using nnfw_set_op_backend

### DIFF
--- a/runtime/onert/api/python/include/nnfw_api_wrapper.h
+++ b/runtime/onert/api/python/include/nnfw_api_wrapper.h
@@ -116,7 +116,6 @@ private:
 
 public:
   NNFW_SESSION(const char *package_file_path, const char *backends);
-  NNFW_SESSION(const char *package_file_path, const char *op, const char *backend);
   ~NNFW_SESSION();
 
   void close_session();

--- a/runtime/onert/api/python/package/libnnfw_api_pybind.py
+++ b/runtime/onert/api/python/package/libnnfw_api_pybind.py
@@ -13,15 +13,11 @@ def num_elems(tensor_info):
     return n
 
 
-class nnfw_session_wrapper(libnnfw_api_pybind.nnfw_session):
+class nnfw_session(libnnfw_api_pybind.nnfw_session):
     """Class inherited nnfw_session for easily processing input/output"""
 
-    def __init__(self, nnpackage_path, backends="cpu", operations=""):
-        if operations:
-            super().__init__(nnpackage_path, operations, backends)
-        else:
-            super().__init__(nnpackage_path, backends)
-
+    def __init__(self, nnpackage_path, backends="cpu"):
+        super().__init__(nnpackage_path, backends)
         self.inputs = []
         self.outputs = []
         self.set_outputs(self.output_size())
@@ -62,16 +58,6 @@ class nnfw_session_wrapper(libnnfw_api_pybind.nnfw_session):
         self.run()
 
         return self.outputs
-
-
-def nnfw_session(nnpackage_path, backends="cpu", operations=""):
-    if operations == "":
-        return nnfw_session_wrapper(nnpackage_path, backends)
-    elif operations:
-        return nnfw_session_wrapper(nnpackage_path, backends, operations)
-    else:
-        print("Syntax Error")
-        return
 
 
 def tensorinfo():

--- a/runtime/onert/api/python/src/nnfw_api_wrapper_pybind.cc
+++ b/runtime/onert/api/python/src/nnfw_api_wrapper_pybind.cc
@@ -42,15 +42,6 @@ PYBIND11_MODULE(libnnfw_api_pybind, m)
       "\t\tMultiple backends can be set and they must be separated by a semicolon "
       "(ex: \"acl_cl;cpu\")\n"
       "\t\tAmong the multiple backends, the 1st element is used as the default backend.")
-    .def(
-      py::init<const char *, const char *, const char *>(), py::arg("package_file_path"),
-      py::arg("op"), py::arg("backends"),
-      "Create a new session instance, load model from nnpackage file or directory, "
-      "set the operation's backend and prepare session to be ready for inference\n"
-      "Parameters:\n"
-      "\tpackage_file_path (str): Path to the nnpackage file or unzipped directory to be loaded\n"
-      "\top (str): operation to be set\n"
-      "\tbackends (str): Bakcend on which operation run")
     .def("set_input_tensorinfo", &NNFW_SESSION::set_input_tensorinfo, py::arg("index"),
          py::arg("tensor_info"),
          "Set input model's tensor info for resizing.\n"


### PR DESCRIPTION
This commit removes calls to deprecated paths (which used `nnfw_set_op_backend` underneath) on Python bindings side.

ONE-DCO-1.0-Signed-off-by: Jan Iwaszkiewicz <j.iwaszkiewi@samsung.com>