### PR TITLE
[onert] Plan non-const tensors on train backend

### DIFF
--- a/runtime/onert/backend/train/TensorPlanner.cc
+++ b/runtime/onert/backend/train/TensorPlanner.cc
@@ -110,6 +110,7 @@ void TensorPlanner::planNonConstTensors(TensorBuilder *tensor_builder)
 
       const auto output_index = ir::train::TrainingOperandIndex{output, true};
       assert(defs_map.find(output_index) != defs_map.end());
+      assert(defs_map.at(output_index) == 1);
       defs_map[output_index] = 0;
       tensor_builder->notifyFirstUse(output_index.index());
     }

--- a/runtime/onert/backend/train/TensorPlanner.cc
+++ b/runtime/onert/backend/train/TensorPlanner.cc
@@ -41,7 +41,7 @@ void TensorPlanner::planNonConstTensors(TensorBuilder *tensor_builder)
 
   const auto &training_usedefs = _tgraph.trainingUseDefs();
 
-  // NOTE The uses_map and defs_map must have size of only registered tensors
+  // NOTE The uses_map and defs_map must have the size of only registered tensors
   std::unordered_map<ir::train::TrainingOperandIndex, uint32_t> uses_map;
   std::unordered_map<ir::train::TrainingOperandIndex, uint32_t> defs_map;
 


### PR DESCRIPTION
This commit add planning non-const tensors(forwarding non-const tensors) on train backend.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>