### PR TITLE
[infra/onert] Remove ACL from runtime package

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -133,7 +133,8 @@ install: install_all_internal
 ###
 ### Command (public)
 ###
-create-package: all runtime_tar_internal
+# Don't install arm compute
+create-package: prepare-buildtool prepare-nncc configure build install_except_acl runtime_tar_internal
 
 create-aclpack: configure acl_tar_internal
 
@@ -213,7 +214,9 @@ install_luci_internal:
 	@cp $(OVERLAY_FOLDER)/lib/libluci*.so $(INSTALL_ALIAS)/lib/nnfw/odc 2>/dev/null || true
 	@cp $(OVERLAY_FOLDER)/lib/libloco*.so $(INSTALL_ALIAS)/lib/nnfw/odc 2>/dev/null || true
 
-install_all_internal: install_internal install_acl_internal install_luci_internal
+install_except_acl: install_internal install_luci_internal
+
+install_all_internal: install_except_acl install_acl_internal
 
 test_suite_internal: install_all_internal
 	@echo "packaging test suite"


### PR DESCRIPTION
This commit update Makefile.template's create-package command to remove arm compute library from runtime tar.gz package again.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>