### PR TITLE
[onert] Add notifyBackwardLastUse() to TensorBuilder

### DIFF
--- a/runtime/onert/backend/train/TensorBuilder.cc
+++ b/runtime/onert/backend/train/TensorBuilder.cc
@@ -136,6 +136,18 @@ void TensorBuilder::notifyBackwardFirstUse(const ir::OperandIndex &index)
   }
 }
 
+void TensorBuilder::notifyBackwardLastUse(const ir::OperandIndex &index)
+{
+  if (_as_constants[index])
+  {
+    _tensor_mgr->releaseGradientPlan(index);
+  }
+  else
+  {
+    _tensor_mgr->releaseBackPropPlan(index);
+  }
+}
+
 void TensorBuilder::notifyDisposableBackPropFirstUse(const DisposableTensorIndex &index)
 {
   _tensor_mgr->claimDisposableBackPropPlan(index);

--- a/runtime/onert/backend/train/TensorBuilder.h
+++ b/runtime/onert/backend/train/TensorBuilder.h
@@ -63,6 +63,7 @@ public:
   void notifyFirstUse(const ir::OperandIndex &);
   void notifyLastUse(const ir::OperandIndex &);
   void notifyBackwardFirstUse(const ir::OperandIndex &);
+  void notifyBackwardLastUse(const ir::OperandIndex &);
   void notifyDisposableBackPropFirstUse(const DisposableTensorIndex &);
   void notifyDisposableBackPropLastUse(const DisposableTensorIndex &);
 


### PR DESCRIPTION
This commit adds a method that can notify last used node to support releasing memory of backwarding tensors.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>