### PR TITLE
[onert] Use original map in ConstantInsertionPass

### DIFF
--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -39,8 +39,6 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::I
   {
     auto &object = _graph.operands().at(input);
 
-    const auto key = ReplaceKey{input, factor};
-
     // Skip if the operand is not constant or not shared constant
     if (!object.isConstant() || object.getUses().size() < 2)
       continue;
@@ -58,37 +56,37 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::I
       continue;
 
     // Different PermuteFactor with original operand
+
+    // Check operand is already created for current input's PermuteFactor
+    // If not, create new operand and register to _replace_operands_map
+    const auto key = ReplaceKey{input, factor};
+    if (_replace_operands_map.count(key) == 0)
     {
-      // Check operand is already created for current input's PermuteFactor
-      // If not, create new operand and register to _replace_operands_map
-      if (_replace_operands_map.count(key) == 0)
-      {
-        ir::Operand new_object(object);
-        new_object.clearDefUse();
-        const auto new_index = _graph.operands().emplace(new_object);
-        _replace_operands_map[key] = new_index;
-      }
-
-      const auto replaced_input = _replace_operands_map[key];
-
-      // Update the same inputs of a node at once because inputs of an operation have the same
-      // PermuteFactor
-      node.replaceInputs(input, replaced_input);
-
-      // Update operand
-      auto &replaced_object = _graph.operands().at(replaced_input);
-      replaced_object.insertUse(node_index);
-
-      VERBOSE(ConstInsertPass) << "New operand " << replaced_input << " added(copy of " << input
-                               << ") for " << factor << std::endl;
-      // Remove this node from uses of origin operand
-      // Constant operand has no def.
-      assert(!object.getDef().valid());
-      object.removeUse(node_index);
-
-      // Remain uses by _keep_operands_map
-      assert(object.getUses().size() != 0);
+      ir::Operand new_object(object);
+      new_object.clearDefUse();
+      const auto new_index = _graph.operands().emplace(new_object);
+      _replace_operands_map[key] = new_index;
     }
+
+    const auto replaced_input = _replace_operands_map[key];
+
+    // Update the same inputs of a node at once because inputs of an operation have the same
+    // PermuteFactor
+    node.replaceInputs(input, replaced_input);
+
+    // Update operand
+    auto &replaced_object = _graph.operands().at(replaced_input);
+    replaced_object.insertUse(node_index);
+
+    VERBOSE(ConstInsertPass) << "New operand " << replaced_input << " added(copy of " << input
+                             << ") for " << factor << std::endl;
+    // Remove this node from uses of origin operand
+    // Constant operand has no def.
+    assert(!object.getDef().valid());
+    object.removeUse(node_index);
+
+    // Remain uses by _keep_operands_map
+    assert(object.getUses().size() != 0);
   }
 
   // Now this runtime does not support the node making output as constant

--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.h
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.h
@@ -66,6 +66,7 @@ private:
   };
 
   std::unordered_map<ReplaceKey, ir::OperandIndex, KeyHasher> _replace_operands_map;
+  std::unordered_map<ir::OperandIndex, PermuteFactor> _keep_operands_map;
 };
 
 } // namespace pass


### PR DESCRIPTION
This commit add original operand map to use original operand if backend layout is same. 
It will prevent removing original operand and reduce constant operand creation.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>