### PR TITLE
[python] Change await to wait to avoid keyword use

### DIFF
--- a/runtime/onert/api/python/include/nnfw_api_wrapper.h
+++ b/runtime/onert/api/python/include/nnfw_api_wrapper.h
@@ -122,7 +122,7 @@ public:
   void set_input_tensorinfo(uint32_t index, const tensorinfo *tensor_info);
   void run();
   void run_async();
-  void await();
+  void wait();
   /**
    * @brief   process input array according to data type of numpy array sent by Python
    *          (int, float, uint8_t, bool, int64_t, int8_t, int16_t)

--- a/runtime/onert/api/python/src/nnfw_api_wrapper.cc
+++ b/runtime/onert/api/python/src/nnfw_api_wrapper.cc
@@ -189,7 +189,7 @@ void NNFW_SESSION::set_input_tensorinfo(uint32_t index, const tensorinfo *tensor
 }
 void NNFW_SESSION::run() { ensure_status(nnfw_run(session)); }
 void NNFW_SESSION::run_async() { ensure_status(nnfw_run_async(session)); }
-void NNFW_SESSION::await() { ensure_status(nnfw_await(session)); }
+void NNFW_SESSION::wait() { ensure_status(nnfw_await(session)); }
 uint32_t NNFW_SESSION::input_size()
 {
   uint32_t number;

--- a/runtime/onert/api/python/src/nnfw_api_wrapper_pybind.cc
+++ b/runtime/onert/api/python/src/nnfw_api_wrapper_pybind.cc
@@ -50,7 +50,7 @@ PYBIND11_MODULE(libnnfw_api_pybind, m)
          "\ttensor_info (tensorinfo): Tensor info to be set")
     .def("run", &NNFW_SESSION::run, "Run inference")
     .def("run_async", &NNFW_SESSION::run_async, "Run inference asynchronously")
-    .def("await", &NNFW_SESSION::await, "Wait for asynchronous run to finish")
+    .def("wait", &NNFW_SESSION::wait, "Wait for asynchronous run to finish")
     .def(
       "set_input",
       [](NNFW_SESSION &session, uint32_t index, py::array_t<float> &buffer) {


### PR DESCRIPTION
This commit changes the function name to avoid conflicts with Python's restricted keywords.

ONE-DCO-1.0-Signed-off-by: Jan Iwaszkiewicz <j.iwaszkiewi@samsung.com>