### PR TITLE
[luci] Add a parameter for hessian to CircleQuantParam

### DIFF
--- a/compiler/luci/lang/include/luci/IR/CircleQuantParam.h
+++ b/compiler/luci/lang/include/luci/IR/CircleQuantParam.h
@@ -28,6 +28,7 @@ struct CircleQuantParam
   std::vector<float> min;
   std::vector<float> max;
   std::vector<float> scale;
+  std::vector<float> hessian;
   std::vector<int64_t> zerop;
   int32_t quantized_dimension{0};
 };

--- a/compiler/luci/lang/src/CircleQuantParam.cpp
+++ b/compiler/luci/lang/src/CircleQuantParam.cpp
@@ -37,6 +37,7 @@ void copy_quantparam(const luci::CircleNode *src, luci::CircleNode *dst)
     qparam->zerop = q->zerop;
     qparam->min = q->min;
     qparam->max = q->max;
+    qparam->hessian = q->hessian;
     qparam->quantized_dimension = q->quantized_dimension;
 
     dst->quantparam(std::move(qparam));

--- a/compiler/luci/lang/src/CircleQuantParam.test.cpp
+++ b/compiler/luci/lang/src/CircleQuantParam.test.cpp
@@ -40,6 +40,7 @@ luci::CircleAdd *build_simple_add_graph(loco::Graph *g)
   qparam->zerop = {0};
   qparam->min = {0.0};
   qparam->max = {1.0};
+  qparam->hessian = {1.0};
   qparam->quantized_dimension = 0;
   node->quantparam(std::move(qparam));
 
@@ -60,6 +61,7 @@ TEST(CircleNodeCloneTest, copy_quantparam)
   const auto *qparam_copy = copy->quantparam();
   ASSERT_EQ(qparam_node->scale, qparam_copy->scale);
   ASSERT_EQ(qparam_node->zerop, qparam_copy->zerop);
+  ASSERT_EQ(qparam_node->hessian, qparam_copy->hessian);
   ASSERT_EQ(qparam_node->quantized_dimension, qparam_copy->quantized_dimension);
 }
 


### PR DESCRIPTION
Changes
- In the GPTQ algorithm, Hessian is used to compensate for the quantization error, so it requires adding the parameter in CircleQauntParam

- related issue : https://github.com/Samsung/ONE/issues/13480


TODO
- Add the record-hessian module to calculate Hessian matrix

ONE-DCO-1.0-Signed-off-by: y01000.you <y01000.you@samsung.com>
