### PR TITLE
[onert] Use structured binding declaration in optimizers

### DIFF
--- a/runtime/onert/backend/train/optimizer/Adam.cc
+++ b/runtime/onert/backend/train/optimizer/Adam.cc
@@ -38,10 +38,9 @@ double Adam::getLearningRate(uint32_t training_step) const
 
 void Adam::applyGradient(const UpdateFactors &factors) const
 {
-  const auto training_step = std::get<size_t>(factors);
-  const auto &grad_tensor = std::get<const backend::IPortableTensor &>(factors);
-  auto &trainable_tensor = std::get<backend::train::ITrainableTensor &>(factors);
+  auto [grad_tensor, trainable_tensor, training_step] = factors;
   assert(trainable_tensor.data_type() == grad_tensor.data_type());
+
   const auto opt_vars = trainable_tensor.optVars();
   assert(opt_vars.size() == 2);
   // Get the variable for exponential moving average of the gradient

--- a/runtime/onert/backend/train/optimizer/SGD.cc
+++ b/runtime/onert/backend/train/optimizer/SGD.cc
@@ -37,9 +37,7 @@ double SGD::getLearningRate(uint32_t) const
 
 void SGD::applyGradient(const UpdateFactors &factors) const
 {
-  const auto lr = getLearningRate(std::get<size_t>(factors));
-  const auto &grad_tensor = std::get<const backend::IPortableTensor &>(factors);
-  auto &trainable_tensor = std::get<backend::train::ITrainableTensor &>(factors);
+  auto [grad_tensor, trainable_tensor, training_step] = factors;
   assert(trainable_tensor.data_type() == grad_tensor.data_type());
 
   if (trainable_tensor.getShape() != grad_tensor.getShape())
@@ -47,6 +45,7 @@ void SGD::applyGradient(const UpdateFactors &factors) const
     throw std::runtime_error("SGD: Invalid gradient tensor");
   }
 
+  const auto lr = getLearningRate(training_step);
   switch (grad_tensor.data_type())
   {
     case ir::DataType::FLOAT32:


### PR DESCRIPTION
This commit replaces using `std::get` on tuples with using structured binding declaration in training optimizers.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>