### PR TITLE
[onert] Remove layout usage in basic tensor

### DIFF
--- a/runtime/onert/backend/train/BackendContext.cc
+++ b/runtime/onert/backend/train/BackendContext.cc
@@ -125,8 +125,7 @@ backend::train::ITensorRegistry *BackendContext::genTrainingTensors()
       assert(tgraph.layout() != ir::Layout::NCHW);
 
       const auto &operand = tgraph.operands().at(ind);
-      tensor_builder->registerBackwardTensorInfo(ind, createBackwardTensorInfo(operand),
-                                                 ir::Layout::NHWC);
+      tensor_builder->registerBackwardTensorInfo(ind, createBackwardTensorInfo(operand));
     }
   });
 
@@ -137,8 +136,8 @@ backend::train::ITensorRegistry *BackendContext::genTrainingTensors()
     {
       DisposableTensorIndex disposable_index{op_index, back_prop_index};
       const auto &operand = tgraph.operands().at(back_prop_index);
-      tensor_builder->registerDisposableBackwardTensorInfo(
-        disposable_index, createBackwardTensorInfo(operand), ir::Layout::NHWC);
+      tensor_builder->registerDisposableBackwardTensorInfo(disposable_index,
+                                                           createBackwardTensorInfo(operand));
     }
   }
 

--- a/runtime/onert/backend/train/Tensor.h
+++ b/runtime/onert/backend/train/Tensor.h
@@ -34,8 +34,7 @@ public:
   Tensor() = delete;
 
 public:
-  Tensor(const ir::OperandInfo &info, const ir::Layout layout)
-    : basic::Tensor{info, layout, nullptr}
+  Tensor(const ir::OperandInfo &info) : basic::Tensor{info, nullptr}
   {
     // DO NOTHING
   }

--- a/runtime/onert/backend/train/TensorBuilder.h
+++ b/runtime/onert/backend/train/TensorBuilder.h
@@ -42,22 +42,18 @@ public:
    * @brief     Register tensor information to allocate on train backend
    * @param[in] ind    Operand index
    * @param[in] info   Operand information
-   * @param[in] layout Operand data layout
    */
-  void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                          ir::Layout backend_layout);
+  void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info);
 
   /**
    * @brief     Register informations of tensor used only in backward to allocate on train backend
    * @param[in] ind    Operand index
    * @param[in] info   Operand information
-   * @param[in] layout Operand data layout
    */
-  void registerBackwardTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                                  ir::Layout backend_layout);
+  void registerBackwardTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info);
 
   void registerDisposableBackwardTensorInfo(const DisposableTensorIndex &index,
-                                            const ir::OperandInfo &info, ir::Layout layout);
+                                            const ir::OperandInfo &info);
 
   // TODO Support memory plan of all tensors
   void notifyFirstUse(const ir::OperandIndex &);

--- a/runtime/onert/backend/train/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/train/ops/BinaryArithmeticLayer.cc
@@ -55,7 +55,7 @@ void BinaryArithmeticLayer::configureBackward(IPortableTensor *back_prop_lhs,
 
   if (activation != ir::Activation::NONE)
   {
-    _act_back_prop_output = std::make_unique<Tensor>(_output->get_info(), _output->layout());
+    _act_back_prop_output = std::make_unique<Tensor>(_output->get_info());
     _act_back_prop_output->setBuffer(std::make_shared<basic::Allocator>(_output->total_size()));
   }
 }

--- a/runtime/onert/backend/train/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/train/ops/ConvolutionLayer.cc
@@ -42,7 +42,7 @@ std::unique_ptr<Tensor> createTransposedWeights(const backend::IPortableTensor *
     ir::Shape{origin_shape.dim(1), origin_shape.dim(2), origin_shape.dim(3), origin_shape.dim(0)};
   transposed_info.shape(transposed_shape);
 
-  return std::make_unique<Tensor>(transposed_info, origin_weights->layout());
+  return std::make_unique<Tensor>(transposed_info);
 }
 
 } // namespace
@@ -84,8 +84,7 @@ void ConvolutionLayer::configureBackward(const IPortableTensor *weights,
   _transposed_weights->setBuffer(
     std::make_shared<basic::Allocator>(_transposed_weights->total_size()));
 
-  _conv_back_prop_output =
-    std::make_unique<BackPropTensor>(back_prop_output->get_info(), back_prop_output->layout());
+  _conv_back_prop_output = std::make_unique<BackPropTensor>(back_prop_output->get_info());
   _conv_back_prop_output->setBuffer(
     std::make_shared<basic::Allocator>(_conv_back_prop_output->total_size()));
 
@@ -95,8 +94,7 @@ void ConvolutionLayer::configureBackward(const IPortableTensor *weights,
 
   if (activation != ir::Activation::NONE)
   {
-    _act_back_prop_output =
-      std::make_unique<BackPropTensor>(_back_prop_output->get_info(), _back_prop_output->layout());
+    _act_back_prop_output = std::make_unique<BackPropTensor>(_back_prop_output->get_info());
     _act_back_prop_output->setBuffer(
       std::make_shared<basic::Allocator>(_act_back_prop_output->total_size()));
   }

--- a/runtime/onert/backend/train/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/train/ops/DepthwiseConvolutionLayer.cc
@@ -55,8 +55,7 @@ void DepthwiseConvolutionLayer::configureBackward(IPortableTensor *back_prop_inp
 
   if (activation != ir::Activation::NONE)
   {
-    _act_back_prop_output =
-      std::make_unique<BackPropTensor>(_back_prop_output->get_info(), _back_prop_output->layout());
+    _act_back_prop_output = std::make_unique<BackPropTensor>(_back_prop_output->get_info());
     _act_back_prop_output->setBuffer(
       std::make_shared<basic::Allocator>(_act_back_prop_output->total_size()));
   }
@@ -90,7 +89,7 @@ void DepthwiseConvolutionLayer::configureBackward(IPortableTensor *back_prop_inp
   // prepare padded_filter buffer for cker
   auto padded_filter_info = ir::OperandInfo(_kernel->get_info());
   padded_filter_info.shape({batch, filter_spatial_size, padded_filter_inner_dim_size});
-  _padded_filter = std::make_unique<Tensor>(padded_filter_info, _kernel->layout());
+  _padded_filter = std::make_unique<Tensor>(padded_filter_info);
   _padded_filter->setBuffer(std::make_shared<basic::Allocator>(_padded_filter->total_size()));
 
   // prepare out_bprop and in_bprop buffer for cker
@@ -98,13 +97,12 @@ void DepthwiseConvolutionLayer::configureBackward(IPortableTensor *back_prop_inp
 
   auto filter_buffers_info = ir::OperandInfo(_kernel->get_info());
   filter_buffers_info.shape({thread_count, filter_spatial_size, padded_filter_inner_dim_size});
-  _filter_buffers = std::make_unique<Tensor>(filter_buffers_info, _kernel->layout());
+  _filter_buffers = std::make_unique<Tensor>(filter_buffers_info);
   _filter_buffers->setBuffer(std::make_shared<basic::Allocator>(_filter_buffers->total_size()));
 
   auto filter_dim_buffers_info = ir::OperandInfo(_back_prop_input->get_info());
   filter_dim_buffers_info.shape({thread_count, padded_filter_inner_dim_size});
-  _filter_dim_buffers =
-    std::make_unique<Tensor>(filter_dim_buffers_info, _back_prop_input->layout());
+  _filter_dim_buffers = std::make_unique<Tensor>(filter_dim_buffers_info);
   _filter_dim_buffers->setBuffer(
     std::make_shared<basic::Allocator>(_filter_dim_buffers->total_size()));
 }

--- a/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
@@ -38,7 +38,7 @@ createTransposedTensor(const backend::IPortableTensor *origin_tensor)
   auto transposed_shape = ir::Shape{origin_shape.dim(1), origin_shape.dim(0)};
   transposed_info.shape(transposed_shape);
 
-  return std::make_unique<backend::train::Tensor>(transposed_info, origin_tensor->layout());
+  return std::make_unique<backend::train::Tensor>(transposed_info);
 }
 
 } // namespace
@@ -97,8 +97,7 @@ void FullyConnectedLayer::configureBackward(
 
   if (activation != ir::Activation::NONE)
   {
-    _act_back_prop_output =
-      std::make_unique<Tensor>(_back_prop_output->get_info(), _back_prop_output->layout());
+    _act_back_prop_output = std::make_unique<Tensor>(_back_prop_output->get_info());
     _act_back_prop_output->setBuffer(
       std::make_shared<basic::Allocator>(_back_prop_output->total_size()));
   }

--- a/runtime/onert/backend/train/ops/PoolLayer.cc
+++ b/runtime/onert/backend/train/ops/PoolLayer.cc
@@ -62,12 +62,12 @@ public:
                                       &_op_params.float_activation_max);
     }
 
-    _arg_max_index = std::make_unique<Tensor>(_output->get_info(), _output->layout());
+    _arg_max_index = std::make_unique<Tensor>(_output->get_info());
     _arg_max_index->setBuffer(std::make_shared<basic::Allocator>(_output->total_size()));
 
     if (activation != ir::Activation::NONE)
     {
-      _act_back_prop_output = std::make_unique<Tensor>(_output->get_info(), _output->layout());
+      _act_back_prop_output = std::make_unique<Tensor>(_output->get_info());
       _act_back_prop_output->setBuffer(std::make_shared<basic::Allocator>(_output->total_size()));
     }
   };

--- a/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
@@ -66,7 +66,7 @@ template <typename T_BackendContext> void planTensors(const T_BackendContext &ct
       //      When we support NCHW tensors as well, we also need to change tensor info to be
       //      permuted shape.
       assert(ctx.operand_layouts().at(ind) == ir::Layout::NHWC);
-      tensor_builder->registerTensorInfo(ind, info, ir::Layout::NHWC);
+      tensor_builder->registerTensorInfo(ind, info);
     }
   });
 
@@ -196,7 +196,7 @@ template <typename T_BackendContext> ITensorRegistry *genTensors(T_BackendContex
       return;
     // NOTE Assuming there is no layout changes (Always assume NHWC or UNKNOWN)
     assert(graph.layout() != ir::Layout::NCHW);
-    tensor_builder->registerTensorInfo(ind, obj.info(), ir::Layout::NHWC);
+    tensor_builder->registerTensorInfo(ind, obj.info());
   });
 
   // TODO Get compiler options from compiler, and use it rather than getting it from Env

--- a/runtime/onert/core/include/backend/basic/DynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/basic/DynamicTensorManager.h
@@ -45,8 +45,7 @@ public:
 
   virtual ~DynamicTensorManager() = default;
 
-  void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
-                   ir::Layout backend_layout);
+  void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info);
 
   std::shared_ptr<DynamicMemoryManager> dynamic_mem_mgr() { return _dynamic_mem_mgr; }
 

--- a/runtime/onert/core/include/backend/basic/StaticTensorManager.h
+++ b/runtime/onert/core/include/backend/basic/StaticTensorManager.h
@@ -45,8 +45,7 @@ public:
   void allocateNonconsts(void);
   void deallocateNonconsts(void);
 
-  void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
-                   ir::Layout backend_layout, bool as_const);
+  void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info, bool as_const);
 
   void claimPlan(const ir::OperandIndex &ind, uint32_t size);
   void releasePlan(const ir::OperandIndex &ind);

--- a/runtime/onert/core/include/backend/basic/TensorBuilder.h
+++ b/runtime/onert/core/include/backend/basic/TensorBuilder.h
@@ -44,10 +44,8 @@ public:
    * @brief     Register tensor information to allocate on CPU backend
    * @param[in] ind    Operand index
    * @param[in] info   Operand information
-   * @param[in] layout Operand data layout
    */
-  void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                          ir::Layout backend_layout);
+  void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info);
 
   void notifyFirstUse(const ir::OperandIndex &);
   void notifyLastUse(const ir::OperandIndex &);

--- a/runtime/onert/core/include/backend/basic/train/TrainableBackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/train/TrainableBackendContextHelpers.h
@@ -41,7 +41,7 @@ ITensorRegistry *genTensors(backend::train::TrainableBackendContext &ctx,
       return;
     // NOTE Assuming there is no layout changes (Always assume NHWC or UNKNOWN)
     assert(tgraph.layout() != ir::Layout::NCHW);
-    tensor_builder->registerTensorInfo(ind, obj.info(), ir::Layout::NHWC);
+    tensor_builder->registerTensorInfo(ind, obj.info());
   });
 
   // For the executors that does not have fixed linear execution order:

--- a/runtime/onert/core/include/backend/basic/train/TrainableTensor.h
+++ b/runtime/onert/core/include/backend/basic/train/TrainableTensor.h
@@ -37,8 +37,8 @@ public:
   virtual ~TrainableTensor() = default;
 
 public:
-  TrainableTensor(const ir::OperandInfo &info, const ir::Layout layout)
-    : ITrainableTensor{info}, _tensor{info, layout, nullptr}, _opt_vars{}
+  TrainableTensor(const ir::OperandInfo &info)
+    : ITrainableTensor{info}, _tensor{info, nullptr}, _opt_vars{}
   {
     // DO NOTHING
   }

--- a/runtime/onert/core/src/backend/basic/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/basic/DynamicTensorManager.cc
@@ -33,11 +33,10 @@ DynamicTensorManager::DynamicTensorManager(const std::shared_ptr<TensorRegistry>
 }
 
 void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
-                                       const ir::OperandInfo &tensor_info,
-                                       ir::Layout backend_layout)
+                                       const ir::OperandInfo &tensor_info)
 {
   assert(_tensors->getNativeTensor(ind) == nullptr);
-  auto tensor = std::make_unique<Tensor>(tensor_info, backend_layout, _dynamic_mem_mgr.get());
+  auto tensor = std::make_unique<Tensor>(tensor_info, _dynamic_mem_mgr.get());
   _tensors->setNativeTensor(ind, std::move(tensor));
 }
 

--- a/runtime/onert/core/src/backend/basic/StaticTensorManager.cc
+++ b/runtime/onert/core/src/backend/basic/StaticTensorManager.cc
@@ -66,19 +66,18 @@ void StaticTensorManager::allocateNonconsts(void)
 void StaticTensorManager::deallocateNonconsts(void) { _nonconst_mgr->deallocate(); }
 
 void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
-                                      const ir::OperandInfo &tensor_info, ir::Layout backend_layout,
-                                      bool as_const)
+                                      const ir::OperandInfo &tensor_info, bool as_const)
 {
   assert(!_tensors->getNativeTensor(ind));
   if (as_const)
   {
-    auto tensor = std::make_unique<ExternalTensor>(tensor_info, backend_layout);
+    auto tensor = std::make_unique<ExternalTensor>(tensor_info);
     _tensors->setNativeTensor(ind, std::move(tensor));
   }
   else
   {
-    auto tensor = std::make_unique<Tensor>(tensor_info, backend_layout,
-                                           _dynamic_tensor_manager->dynamic_mem_mgr().get());
+    auto tensor =
+      std::make_unique<Tensor>(tensor_info, _dynamic_tensor_manager->dynamic_mem_mgr().get());
     _tensors->setNativeTensor(ind, std::move(tensor));
   }
   _as_constants[ind] = as_const;

--- a/runtime/onert/core/src/backend/basic/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/basic/TensorBuilder.cc
@@ -42,20 +42,17 @@ TensorBuilder::TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg,
   /* empty */
 }
 
-void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                                       ir::Layout layout)
+void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info)
 {
   _tensor_info_map.emplace(ind, info);
 
-  // CPU backend supports only one layout as NHWC
-  assert(layout == ir::Layout::NHWC);
   if (info.isDynamic())
   {
-    _dynamic_tensor_mgr->buildTensor(ind, info, layout);
+    _dynamic_tensor_mgr->buildTensor(ind, info);
   }
   else
   {
-    _static_tensor_mgr->buildTensor(ind, info, layout, info.isConstant());
+    _static_tensor_mgr->buildTensor(ind, info, info.isConstant());
   }
 }
 

--- a/runtime/onert/core/src/backend/builtin/IOTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.cc
@@ -29,9 +29,9 @@ namespace builtin
 // With this as a key function, `dynamic_cast` works across dl
 IOTensor::~IOTensor() {}
 
-IOTensor::IOTensor(const ir::OperandInfo &info, ir::Layout layout)
+IOTensor::IOTensor(const ir::OperandInfo &info)
   : IPortableTensor{info}, _tensor{nullptr},
-    _orig{std::make_unique<UserTensor>(info, layout, (uint8_t *)nullptr, 0)}
+    _orig{std::make_unique<UserTensor>(info, ir::Layout::NHWC, (uint8_t *)nullptr, 0)}
 {
   _tensor = _orig.get();
 }

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -49,7 +49,7 @@ namespace builtin
 class IOTensor : public IPortableTensor
 {
 public:
-  IOTensor(const ir::OperandInfo &info, ir::Layout layout);
+  IOTensor(const ir::OperandInfo &info);
   ~IOTensor();
 
 public:

--- a/runtime/onert/core/src/backend/builtin/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/builtin/TensorBuilder.cc
@@ -35,19 +35,18 @@ TensorBuilder::TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg)
   /* empty */
 }
 
-void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                                       ir::Layout backend_layout)
+void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info)
 {
   _tensor_info_map.emplace(ind, info);
 
   VERBOSE_F() << "cpucommon REGISTER!! " << ind << std::endl;
   if (info.isDynamic())
   {
-    _dynamic_tensor_mgr->buildTensor(ind, info, backend_layout);
+    _dynamic_tensor_mgr->buildTensor(ind, info);
   }
   else
   {
-    _static_tensor_mgr->buildTensor(ind, info, backend_layout, info.isConstant());
+    _static_tensor_mgr->buildTensor(ind, info, info.isConstant());
   }
 }
 

--- a/runtime/onert/core/src/backend/builtin/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/builtin/TensorBuilder.h
@@ -43,10 +43,8 @@ public:
    * @brief     Register tensor information to allocate on CPU backend
    * @param[in] ind    Operand index
    * @param[in] info   Operand information
-   * @param[in] layout Operand data layout
    */
-  void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                          ir::Layout backend_layout);
+  void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info);
 
   void notifyFirstUse(const ir::OperandIndex &);
   void notifyLastUse(const ir::OperandIndex &);

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -65,8 +65,7 @@ void WhileLayer::run()
   // Need a temp tensor to hold the cond subgraph output
   assert(cond_exec->outputSize() == 1);
   auto cond_output_tensor = [&]() {
-    auto tensor = std::make_unique<Tensor>(cond_exec->outputInfo(0), cond_exec->outputLayout(0),
-                                           _dyn_memory_manager);
+    auto tensor = std::make_unique<Tensor>(cond_exec->outputInfo(0), _dyn_memory_manager);
     tensor->set_dynamic();
     tensor->setBuffer(_dyn_memory_manager->allocate(tensor.get(), tensor->total_size()));
     return tensor;
@@ -98,8 +97,7 @@ void WhileLayer::run()
   std::vector<IPortableTensor *> temp_outputs;
   for (uint32_t i = 0; i < body_exec->outputSize(); i++)
   {
-    auto tensor = std::make_unique<Tensor>(body_exec->outputInfo(i), body_exec->outputLayout(i),
-                                           _dyn_memory_manager);
+    auto tensor = std::make_unique<Tensor>(body_exec->outputInfo(i), _dyn_memory_manager);
     tensor->set_dynamic();
     tensor->setBuffer(_dyn_memory_manager->allocate(tensor.get(), tensor->total_size()));
     temp_outputs.push_back(tensor.get());

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -113,10 +113,8 @@ void initializeSubgraphIOTensors(compiler::ILoweredGraph &lowered_graph,
   for (auto &&ind : indices)
   {
     const auto &operand = lowered_graph.graph().operands().at(ind);
-    auto tensor = std::make_unique<backend::builtin::IOTensor>(
-      operand.info(),
-      ir::Layout::NHWC /* FIXME find operation for this operand and use frontend_layout */
-    );
+    assert(lowered_graph.graph().layout() == ir::Layout::NHWC);
+    auto tensor = std::make_unique<backend::builtin::IOTensor>(operand.info());
 
     // Add tensor to builtin TensorRegistry.
     builtin_tensor_reg->setNativeIOTensor(ind, std::move(tensor));
@@ -143,10 +141,8 @@ void initializeSubgraphIOTensors(compiler::ILoweredGraph &lowered_graph,
   for (auto &&ind : indices)
   {
     const auto &operand = lowered_graph.graph().operands().at(ind);
-    auto tensor = std::make_unique<backend::builtin::IOTensor>(
-      operand.info(),
-      ir::Layout::NHWC /* FIXME find operation for this operand and use frontend_layout */
-    );
+    assert(lowered_graph.graph().layout() == ir::Layout::NHWC);
+    auto tensor = std::make_unique<backend::builtin::IOTensor>(operand.info());
 
     // Add tensor to builtin TensorRegistry.
     builtin_tensor_reg->setNativeIOTensor(ind, std::move(tensor));


### PR DESCRIPTION
This commit removes layout setting for basic tensor. 
This tensor is used in builtin, cpu, ruy, xnnpack, and train backend.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13494