### PR TITLE
[luci] Add RELU in RemoveUnnecessaryReshapeNetPass

### DIFF
--- a/compiler/luci/pass/src/RemoveUnnecessaryReshapeNetPass.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessaryReshapeNetPass.cpp
@@ -34,6 +34,7 @@ bool acceptable_intermediate_op(const loco::Node *node)
     case luci::CircleOpcode::MUL:
     case luci::CircleOpcode::TANH:
     case luci::CircleOpcode::LOGISTIC:
+    case luci::CircleOpcode::RELU:
       break;
 
     default:


### PR DESCRIPTION
This commit adds RELU op in RemoveUnnecessaryReshapeNetPass. An internal model has this pattern: Reshape - Relu - Reshape.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>