### PR TITLE
[onert] Introduce TrainableConstantInsertionPass

### DIFF
--- a/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
+++ b/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
@@ -26,6 +26,7 @@
 #include "../../backend/builtin/Config.h"
 #include "../../dumper/text/GraphDumper.h"
 #include "../../ir/verifier/Verifier.h"
+#include "pass/TrainableConstantInsertionPass.h"
 #include "TrainableOperationConverter.h"
 
 #include "backend/Backend.h"
@@ -99,6 +100,7 @@ void LoweredTrainableGraph::lowerGraph(const CompilerOptions &options)
   // Mandatory passes - kind of legalization(?)
   compiler::pass::PassRunner{}
     .append(std::make_unique<compiler::pass::ConstantInsertionPass>(*this))
+    .append(std::make_unique<compiler::train::pass::TrainableConstantInsertionPass>(*this))
     .append(std::make_unique<compiler::pass::ConstantLoweringPass>(*this))
     .append(std::make_unique<compiler::pass::PermutationOperationPass>(*this))
     .append(std::make_unique<compiler::pass::PermutationInsertionPass>(*this))

--- a/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TrainableConstantInsertionPass.h"
+
+#include "ir/Graph.h"
+#include "util/logging.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+namespace pass
+{
+
+void TrainableConstantInsertionPass::callback(const ir::OperationIndex &node_index,
+                                              ir::IOperation &node)
+{
+  for (const auto &input : node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+  {
+    auto &object = _graph.operands().at(input);
+
+    // Skip if the operand is not constant or not shared constant
+    if (!object.isConstant() || object.getUses().size() < 2)
+      continue;
+
+    // Insert new operands for shared constant except for the current node.
+    const auto uses = object.getUses();
+    for (const auto &use_index : uses)
+    {
+      if (use_index == node_index)
+        continue;
+
+      // NOTE The PermuteFactor(backend and layout) of the current node and the use node may be
+      //      different. But there is no problem because both nodes' constant operand will have
+      //      only one use node.
+      const auto new_index = insertNewOperand(object);
+      updateUseDef(input, new_index, use_index);
+    }
+
+    // The input of the current node will have one use as the current node
+    assert(object.getUses().size() == 1 && object.getUses().contains(node_index));
+  }
+}
+
+ir::OperandIndex TrainableConstantInsertionPass::insertNewOperand(const ir::Operand &object)
+{
+  ir::Operand new_object(object);
+  new_object.clearDefUse();
+  return _graph.operands().emplace(new_object);
+}
+
+void TrainableConstantInsertionPass::updateUseDef(const ir::OperandIndex &old_index,
+                                                  const ir::OperandIndex &new_index,
+                                                  const ir::OperationIndex &node_index)
+{
+  const auto op_lower_info = _lowered_graph.lower_info().operation.getRawPtr(node_index);
+  const auto backend = op_lower_info->backend();
+  const auto layout = op_lower_info->layout();
+  const auto factor = PermuteFactor{backend, layout};
+
+  // Update the same inputs of a node at once because inputs of an operation have the same
+  // PermuteFactor
+  auto &target_node = _graph.operations().at(node_index);
+  target_node.replaceInputs(old_index, new_index);
+
+  // Update the new operand
+  auto &new_object = _graph.operands().at(new_index);
+  new_object.insertUse(node_index);
+
+  VERBOSE(TrainConstInsertPass) << "New operand " << new_index << " added(copy of " << old_index
+                                << ") for " << factor << std::endl;
+
+  // Remove the use node from uses of origin operand
+  // Constant operand has no def.
+  auto &old_object = _graph.operands().at(old_index);
+  assert(!old_object.getDef().valid());
+  old_object.removeUse(node_index);
+}
+
+} // namespace pass
+} // namespace train
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.h
+++ b/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_TRAIN_PASS_TRAINABLE_CONSTANT_INSERTION_PASS_H__
+#define __ONERT_COMPILER_TRAIN_PASS_TRAINABLE_CONSTANT_INSERTION_PASS_H__
+
+#include "../../pass/LoweredOperationPass.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+namespace pass
+{
+
+// TODO Consider to insert trainable constants only when the correspoding constant is a training
+//      parameter(weights or bias) if there are memory issues.
+class TrainableConstantInsertionPass : public compiler::pass::LoweredOperationPass
+{
+public:
+  using LoweredOperationPass::LoweredOperationPass;
+
+public:
+  std::string id() final { return "TrainableConstantInsertionPass"; }
+
+public:
+  void callback(const ir::OperationIndex &index, ir::IOperation &node) final;
+
+private:
+  ir::OperandIndex insertNewOperand(const ir::Operand &object);
+  void updateUseDef(const ir::OperandIndex &old_index, const ir::OperandIndex &new_index,
+                    const ir::OperationIndex &node_index);
+};
+
+} // namespace pass
+} // namespace train
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_TRAIN_PASS_TRAINABLE_CONSTANT_INSERTION_PASS_H__


### PR DESCRIPTION
This commit introduces TrainableConstantInsertionPass that resolves shared contants issue in training.
   - Introduce TrainableConstantInsertionPass that makes constant operand have only one use node.
   - Apply TrainableConstantInsertionPass to training

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>