### PR TITLE
[oenrt] Remove supportLayout function in backend config

### DIFF
--- a/runtime/onert/backend/acl_cl/Config.cc
+++ b/runtime/onert/backend/acl_cl/Config.cc
@@ -47,8 +47,6 @@ bool Config::initialize()
   return true;
 }
 
-ir::Layout Config::supportLayout(const ir::IOperation &, ir::Layout) { return ir::Layout::NHWC; }
-
 } // namespace acl_cl
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/acl_cl/Config.h
+++ b/runtime/onert/backend/acl_cl/Config.h
@@ -35,7 +35,6 @@ public:
   std::string id() override { return "acl_cl"; }
   bool initialize() override;
   bool supportPermutation() override { return true; }
-  ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) override;
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return true; }
   void sync() const override { arm_compute::CLScheduler::get().sync(); }

--- a/runtime/onert/backend/acl_neon/Config.cc
+++ b/runtime/onert/backend/acl_neon/Config.cc
@@ -27,8 +27,6 @@ namespace acl_neon
 
 bool Config::initialize() { return true; }
 
-ir::Layout Config::supportLayout(const ir::IOperation &, ir::Layout) { return ir::Layout::NHWC; }
-
 } // namespace acl_neon
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/acl_neon/Config.h
+++ b/runtime/onert/backend/acl_neon/Config.h
@@ -33,7 +33,6 @@ class Config : public IConfig
 public:
   std::string id() override { return "acl_neon"; }
   bool initialize() override;
-  ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }

--- a/runtime/onert/backend/cpu/Config.cc
+++ b/runtime/onert/backend/cpu/Config.cc
@@ -25,8 +25,6 @@ namespace cpu
 
 bool Config::initialize() { return true; }
 
-ir::Layout Config::supportLayout(const ir::IOperation &, ir::Layout) { return ir::Layout::NHWC; }
-
 } // namespace cpu
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/cpu/Config.h
+++ b/runtime/onert/backend/cpu/Config.h
@@ -33,7 +33,6 @@ class Config : public IConfig
 public:
   std::string id() override { return "cpu"; }
   bool initialize() override;
-  ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return true; }
   bool supportFP16() override { return false; }

--- a/runtime/onert/backend/ruy/Config.cc
+++ b/runtime/onert/backend/ruy/Config.cc
@@ -25,8 +25,6 @@ namespace ruy
 
 bool Config::initialize() { return true; }
 
-ir::Layout Config::supportLayout(const ir::IOperation &, ir::Layout) { return ir::Layout::NHWC; }
-
 } // namespace ruy
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/ruy/Config.h
+++ b/runtime/onert/backend/ruy/Config.h
@@ -33,7 +33,6 @@ class Config : public IConfig
 public:
   std::string id() override { return "ruy"; }
   bool initialize() override;
-  ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return true; }
   bool supportFP16() override { return false; }

--- a/runtime/onert/backend/train/Config.cc
+++ b/runtime/onert/backend/train/Config.cc
@@ -25,8 +25,6 @@ namespace train
 
 bool Config::initialize() { return true; }
 
-ir::Layout Config::supportLayout(const ir::IOperation &, ir::Layout) { return ir::Layout::NHWC; }
-
 } // namespace train
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/train/Config.h
+++ b/runtime/onert/backend/train/Config.h
@@ -32,7 +32,6 @@ class Config : public IConfig
 public:
   std::string id() override { return "train"; }
   bool initialize() override;
-  ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }

--- a/runtime/onert/backend/trix/Config.cc
+++ b/runtime/onert/backend/trix/Config.cc
@@ -25,8 +25,6 @@ namespace trix
 
 bool Config::initialize() { return true; }
 
-ir::Layout Config::supportLayout(const ir::IOperation &, ir::Layout) { return ir::Layout::NHWC; }
-
 } // namespace trix
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/trix/Config.h
+++ b/runtime/onert/backend/trix/Config.h
@@ -33,7 +33,6 @@ class Config : public IConfig
 public:
   std::string id() override { return "trix"; }
   bool initialize() override;
-  ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }

--- a/runtime/onert/backend/xnnpack/Config.cc
+++ b/runtime/onert/backend/xnnpack/Config.cc
@@ -37,8 +37,6 @@ bool Config::initialize()
   return true;
 }
 
-ir::Layout Config::supportLayout(const ir::IOperation &, ir::Layout) { return ir::Layout::NHWC; }
-
 } // namespace xnnpack
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/xnnpack/Config.h
+++ b/runtime/onert/backend/xnnpack/Config.h
@@ -36,7 +36,6 @@ public:
 public:
   std::string id() override { return "xnnpack"; }
   bool initialize() override;
-  ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return true; }
   bool supportFP16() override { return false; }

--- a/runtime/onert/core/include/backend/IConfig.h
+++ b/runtime/onert/core/include/backend/IConfig.h
@@ -46,14 +46,6 @@ struct IConfig
    */
   virtual bool initialize() = 0;
   /**
-   * @brief Returns supported layout for the given \p node and \p frontend_layout
-   *
-   * @param node IOperation
-   * @param frontend_layout The layout defined in the model
-   * @return ir::Layout The layout that the backend kernel actually uses
-   */
-  virtual ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) = 0;
-  /**
    * @brief The function that is called after each Operation run on profiling mode.
    *        This may be useful for profiling GPU-based or special computing units.
    */

--- a/runtime/onert/core/src/backend/builtin/Config.cc
+++ b/runtime/onert/core/src/backend/builtin/Config.cc
@@ -27,11 +27,6 @@ std::string Config::ID = "builtin";
 
 bool Config::initialize() { return true; }
 
-ir::Layout Config::supportLayout(const ir::IOperation &, ir::Layout frontend_layout)
-{
-  return frontend_layout;
-}
-
 } // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/Config.h
+++ b/runtime/onert/core/src/backend/builtin/Config.h
@@ -34,7 +34,6 @@ public:
   static std::string ID;
   std::string id() override { return ID; }
   bool initialize() override;
-  ir::Layout supportLayout(const ir::IOperation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return false; }
   bool supportDynamicTensor() override
   {

--- a/runtime/onert/core/src/compiler/HEScheduler.test.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.test.cc
@@ -43,7 +43,6 @@ struct MockConfigCPU : public IConfig
   std::string id() override { return "cpu"; }
   bool initialize() override { return true; };
   bool supportPermutation() override { return false; }
-  Layout supportLayout(const IOperation &, Layout) override { return Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }
 };
@@ -70,10 +69,6 @@ struct MockConfigGPU : public IConfig
   std::string id() override { return "gpu"; }
   bool initialize() override { return true; };
   bool supportPermutation() override { return false; }
-  ir::Layout supportLayout(const ir::IOperation &, ir::Layout) override
-  {
-    return ir::Layout::UNKNOWN;
-  }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }
 };
@@ -92,10 +87,6 @@ struct MockConfigNPU : public IConfig
   std::string id() override { return "npu"; }
   bool initialize() override { return true; };
   bool supportPermutation() override { return false; }
-  ir::Layout supportLayout(const ir::IOperation &, ir::Layout) override
-  {
-    return ir::Layout::UNKNOWN;
-  }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }
 };

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -129,11 +129,8 @@ void LoweredGraph::makeLowerInfo(const compiler::BackendResolver &backend_resolv
       throw std::runtime_error{"Fail to find backend for " + op.name() + " operation"};
     }
 
-    auto frontend_layout = _graph.layout();
-
-    // The layout of each backend should be set at another place
-    // TODO Change setting layout of each backend at another place
-    auto backend_layout = backend->config()->supportLayout(op, frontend_layout);
+    // Backend layout is always NHWC
+    auto backend_layout = ir::Layout::NHWC;
 
     for (auto &&ind : op.getInputs() | ir::Remove::UNDEFINED)
     {

--- a/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
+++ b/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
@@ -157,11 +157,8 @@ void LoweredTrainableGraph::makeLowerInfo(const compiler::BackendResolver &backe
         throw std::runtime_error{"Fail to find backend for " + op.name() + " operation"};
       }
 
-      auto frontend_layout = _trainable_graph.layout();
-
-      // The layout of each backend should be set at another place
-      // TODO Change setting layout of each backend at another place
-      auto backend_layout = backend->config()->supportLayout(op, frontend_layout);
+      // Backend layout is always NHWC
+      auto backend_layout = ir::Layout::NHWC;
 
       for (auto &&ind : op.getInputs() | ir::Remove::UNDEFINED)
       {

--- a/runtime/onert/core/src/exec/ExecTime.test.cc
+++ b/runtime/onert/core/src/exec/ExecTime.test.cc
@@ -34,10 +34,6 @@ struct MockConfig : public IConfig
   std::string id() override { return "b1"; }
   bool initialize() override { return true; };
   bool supportPermutation() override { return false; }
-  ir::Layout supportLayout(const ir::IOperation &, ir::Layout) override
-  {
-    return ir::Layout::UNKNOWN;
-  }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }
 };


### PR DESCRIPTION
This commit removes supportLayout function from IConfig interface.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13494