### PR TITLE
[luci-pass-value-test] Add disabled Pad_001

### DIFF
--- a/compiler/luci-pass-value-py-test/test.lst
+++ b/compiler/luci-pass-value-py-test/test.lst
@@ -85,3 +85,7 @@ eval(Net_Dequantize_Add_000 fold_dequantize)
 # test for common subexpression elimination
 eval(CSE_Quantize_000 common_subexpression_elimination)
 eval(CSE_Transpose_000 common_subexpression_elimination)
+
+# test for canonicalization, with any optimization
+# TODO enable Pad_001 when TF version up supports INT4 paddings
+# eval(Pad_001 fuse_instnorm) --> tflite(v2.12.1) does not support INT64 paddings


### PR DESCRIPTION
This will add disabled Pad_001 value test as current tflite doesn't support INT64 yet.
