### PR TITLE
[onert] Add assertion to ReLU6

### DIFF
--- a/compute/cker/include/cker/operation/ReLU6.h
+++ b/compute/cker/include/cker/operation/ReLU6.h
@@ -34,6 +34,10 @@ inline void ReLU6(const Shape &input_shape, const float *input_data, const Shape
 {
   const auto input_map = MapAsVector(input_data, input_shape);
   auto output_map = MapAsVector(output_data, output_shape);
+
+  if (output_shape != input_shape)
+    throw std::runtime_error{"cker::ReLU6: Do not match input and output shapes."};
+
   output_map = input_map.cwiseMax(0.0f).cwiseMin(6.0f);
 }
 


### PR DESCRIPTION
This commit adds assertion for checking input and output shapes. Their shapes should match. Otherwise, an error occurs.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>