### PR TITLE
[luci/pass] Extract canonicalize method

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -148,6 +148,8 @@ public:
   void sparsify(loco::Graph *) const;
 
 private:
+  void canonicalize(loco::Graph *) const;
+
   std::unique_ptr<Options> _options;
 };
 


### PR DESCRIPTION
This will extract canonicalize method with
- run before convert_nchw_to_nhwc
- also run remove dead node pass to remove unnecessary nodes

so that convert_nchw_to_nhwc have have canonicalized properties.