### PR TITLE
[onert] Remove setLayout in graph

### DIFF
--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -92,7 +92,6 @@ public:
   void addOutput(const OperandIndex &ind, const std::string &name = "");
   void verify(void) const;
   void removeOperand(const OperandIndex &ind) { _operands.remove(ind); }
-  void setLayout(Layout layout) { _layout = layout; }
 
 private:
   bool checkOperandsForOperation(const IOperation &operation);

--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -106,7 +106,6 @@ public:
   void addLoss(const OperandIndex &loss_ind, const IOIndex &pred_io_ind);
   void verify() const;
   void removeOperand(const OperandIndex &ind);
-  void setLayout(Layout layout);
   void setInputs(OperandIndexSequence inputs,
                  std::unordered_map<std::string, IOIndex> name_to_input);
   void setOutputs(OperandIndexSequence outputs,

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -141,7 +141,6 @@ void initializeSubgraphIOTensors(compiler::ILoweredGraph &lowered_graph,
   for (auto &&ind : indices)
   {
     const auto &operand = lowered_graph.graph().operands().at(ind);
-    assert(lowered_graph.graph().layout() == ir::Layout::NHWC);
     auto tensor = std::make_unique<backend::builtin::IOTensor>(operand.info());
 
     // Add tensor to builtin TensorRegistry.
@@ -160,7 +159,6 @@ createBackendContexts(compiler::ILoweredGraph &lgraph, bool linear_executor,
   auto init_context_data = [&](const backend::Backend *backend) {
     auto &data = context_data_map[backend];
     auto graph = std::make_unique<ir::Graph>();
-    graph->setLayout(lgraph.graph().layout());
     data.graph = std::move(graph);
   };
 

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -125,8 +125,6 @@ void TrainableGraph::verify(void) const
 
 void TrainableGraph::removeOperand(const OperandIndex &ind) { _graph.removeOperand(ind); }
 
-void TrainableGraph::setLayout(Layout layout) { _graph.setLayout(layout); }
-
 const ITrainableOperation &TrainableGraph::operation(OperationIndex index) const
 {
   // NOTE Virtual inherited objects cannot be static_casted.

--- a/runtime/onert/core/src/loader/CircleLoader.cc
+++ b/runtime/onert/core/src/loader/CircleLoader.cc
@@ -116,9 +116,6 @@ private:
       CircleLoader::loadOperation(op, *subg);
     }
 
-    // TODO Remove frontend layout feature
-    subg->setLayout(ir::Layout::NHWC);
-
     subg->verify();
 
     return subg;

--- a/runtime/onert/loader/trix/TrixLoader.cc
+++ b/runtime/onert/loader/trix/TrixLoader.cc
@@ -231,8 +231,6 @@ std::unique_ptr<ir::Graph> TrixLoader::loadSubgraph()
   // Create operations
   loadBulk(*subg);
 
-  // TODO: NHWC only supported at this moment.
-  subg->setLayout(ir::Layout::NHWC);
   subg->verify();
   return subg;
 }


### PR DESCRIPTION
This commit removes setLayout function in Graph and TrainableGraph.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #12130 #13494