### PR TITLE
[onert] Remove frontend layout usage in ACL backend

### DIFF
--- a/runtime/onert/backend/acl_cl/ConstantInitializer.cc
+++ b/runtime/onert/backend/acl_cl/ConstantInitializer.cc
@@ -96,12 +96,10 @@ void ConstantInitializer::visit(const ir::operation::Reverse &node)
   const auto &axis_obj = _operands.at(axis_index);
 
   const auto ifm_rank = input_obj.shape().rank();
-  const auto frontend_layout = this->_current_layout;
 
   if (axis_obj.isConstant())
   {
-    _init_map[axis_index] = [ifm_rank, frontend_layout](const ir::Operand &operand,
-                                                        backend::ITensor &obj) {
+    _init_map[axis_index] = [ifm_rank](const ir::Operand &operand, backend::ITensor &obj) {
       assert(operand.data());
 
       const auto axis_value = *(reinterpret_cast<const int32_t *>(operand.data()->base()));
@@ -111,7 +109,7 @@ void ConstantInitializer::visit(const ir::operation::Reverse &node)
         axis_tmp = axis_tmp + ifm_rank;
       }
 
-      auto axis = acl_common::ToARMComputeAxis(ifm_rank, axis_tmp, frontend_layout).value();
+      auto axis = acl_common::ToARMComputeAxis(ifm_rank, axis_tmp).value();
 
       obj.access([&](ITensor &tensor) {
         int32_t *into = reinterpret_cast<int32_t *>(tensor.buffer());

--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -48,7 +48,7 @@ KernelGenerator::KernelGenerator(
   const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
   const std::shared_ptr<acl_common::AclTensorRegistry<TensorManager>> &tensor_reg)
   : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx(graph.operations()),
-    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg(tensor_reg)
+    _tensor_builder(tensor_builder), _tensor_reg(tensor_reg)
 {
   // DO NOTHING
 }
@@ -164,8 +164,8 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
   const auto ker_index{node.getInputs().at(Conv2D::Input::KERNEL)};
   const auto bias_index{node.getInputs().at(Conv2D::Input::BIAS)};
 
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [depth_out, kernel_height, kernel_width, depth_in].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);
@@ -201,8 +201,8 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto ker_index{node.getInputs().at(DepthwiseConv2D::Input::KERNEL)};
   const auto bias_index{node.getInputs().at(DepthwiseConv2D::Input::BIAS)};
 
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [1, kernel_height, kernel_width, depth_out].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);
@@ -269,8 +269,7 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
   else
   {
     const auto rank = _ctx.at(ofm_index).shape().rank();
-    const auto frontend_layout = _current_layout;
-    const auto fixed_axis = acl_common::ToARMComputeAxis(rank, axis, frontend_layout).value();
+    const auto fixed_axis = acl_common::ToARMComputeAxis(rank, axis).value();
     fn = acl_common::generateLayer<::arm_compute::CLConcatenateLayer>(
       input_tensors, output_tensor->handle(), fixed_axis);
   }
@@ -289,7 +288,7 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
 
   auto fn = acl_common::kernelGenFullyConnected<acl_common::AclFunction, ::arm_compute::ICLTensor,
                                                 ::arm_compute::CLFullyConnectedReshapingLayer>(
-    node, _ctx, _tensor_builder, _tensor_reg, _current_layout);
+    node, _ctx, _tensor_builder, _tensor_reg);
   _return_fn = std::make_unique<exec::FunctionSequence>(
     std::move(fn), ActivationBuilder::generate(activation, output_tensor->handle()));
 }
@@ -308,18 +307,17 @@ void KernelGenerator::visit(const ir::operation::Reduce &node)
   // Convert to ACL axes taking into account negative values and possible duplicates.
   const auto &axes = _ctx.at(axes_index);
   const auto input_rank = _ctx.at(input_index).shape().rank();
-  const auto frontend_layout = _current_layout;
 
   std::unique_ptr<arm_compute::IFunction> fn;
   if (reduce_type == ir::operation::Reduce::ReduceType::MEAN)
   {
-    const auto acl_axes = acl_common::asCoordinates(axes, input_rank, frontend_layout);
+    const auto acl_axes = acl_common::asCoordinates(axes, input_rank);
     fn = acl_common::generateLayer<arm_compute::CLReduceMean>(input_tensor->handle(), acl_axes,
                                                               keep_dims, output_tensor->handle());
   }
   else
   {
-    const auto acl_axes = acl_common::asSet(axes, input_rank, frontend_layout);
+    const auto acl_axes = acl_common::asSet(axes, input_rank);
 
     fn = acl_common::generateLayer<arm_compute::CLReduceOperation>(
       _tensor_builder->acl_tensor_manager()->internal_buffer_manager(), input_tensor->handle(),
@@ -336,11 +334,6 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
 
   auto output_tensor = _tensor_reg->getAclTensor(output_index);
   auto input_tensor = _tensor_reg->getAclTensor(input_index);
-
-  // NOTE This operation must not be changed the layout from frontend to backend
-  //      So, PermutationOperationPass makes layouts of frontend and backend the same.
-  assert((_ctx.at(input_index).shape().rank() < 4 && _ctx.at(output_index).shape().rank() < 4) ||
-         _current_layout == ir::Layout::NHWC);
 
   auto fn = acl_common::generateLayer<arm_compute::CLReshapeLayer>(input_tensor->handle(),
                                                                    output_tensor->handle());
@@ -394,7 +387,6 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
 
   auto outputData_tensor = _tensor_reg->getAclTensor(output_index);
   auto inputData_tensor = _tensor_reg->getAclTensor(input_index);
-  const auto frontend_layout = _current_layout;
 
   // Set initializers for indices data such as order of inputData
   int input_rank = _ctx.at(input_index).shape().rank();
@@ -423,8 +415,7 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
     assert(beginData_base != nullptr);
     for (int n = 0; n < input_rank; ++n)
     {
-      auto axis =
-        ::onert::backend::acl_common::ToARMComputeAxis(input_rank, n, frontend_layout).value();
+      auto axis = ::onert::backend::acl_common::ToARMComputeAxis(input_rank, n).value();
 
       int32_t begin_value = *(reinterpret_cast<const int32_t *>(beginData_base) + n);
       starts[axis] = begin_value;
@@ -459,7 +450,6 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
 
   auto outputData_tensor = _tensor_reg->getAclTensor(output_index);
   auto inputData_tensor = _tensor_reg->getAclTensor(input_index);
-  const auto frontend_layout = _current_layout;
 
   // Set initializers for indices data such as order of inputData
   int input_rank = _ctx.at(input_index).shape().rank();
@@ -496,8 +486,7 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
     assert(startData_base != nullptr);
     for (int n = 0; n < input_rank; ++n)
     {
-      auto axis =
-        ::onert::backend::acl_common::ToARMComputeAxis(input_rank, n, frontend_layout).value();
+      auto axis = ::onert::backend::acl_common::ToARMComputeAxis(input_rank, n).value();
 
       int32_t start_value = *(reinterpret_cast<const int32_t *>(startData_base) + n);
       starts[axis] = start_value;
@@ -511,12 +500,10 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   }
 
   // Set mask bits such as order of inputData
-  const auto begin_mask =
-    acl_common::ReorderBits<int32_t>(node.param().begin_mask, input_rank, frontend_layout);
-  const auto end_mask =
-    acl_common::ReorderBits<int32_t>(node.param().end_mask, input_rank, frontend_layout);
+  const auto begin_mask = acl_common::ReorderBits<int32_t>(node.param().begin_mask, input_rank);
+  const auto end_mask = acl_common::ReorderBits<int32_t>(node.param().end_mask, input_rank);
   const auto shrink_axis_mask =
-    acl_common::ReorderBits<int32_t>(node.param().shrink_axis_mask, input_rank, frontend_layout);
+    acl_common::ReorderBits<int32_t>(node.param().shrink_axis_mask, input_rank);
 
   ::arm_compute::Coordinates starts_set;
   ::arm_compute::Coordinates ends_set;
@@ -559,7 +546,6 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
 
   auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx);
   auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx);
-  const auto frontend_layout = _current_layout;
 
   const auto &perms = _ctx.at(perm_idx);
   std::vector<int32_t> pv;
@@ -587,7 +573,7 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   }
   else
   {
-    auto backend_pv = acl_common::getARMComputePermutationVector(rank, pv, frontend_layout);
+    auto backend_pv = acl_common::getARMComputePermutationVector(rank, pv);
 
     fn = acl_common::generateLayer<arm_compute::CLPermute>(ifm_tensor->handle(),
                                                            ofm_tensor->handle(), backend_pv);
@@ -836,9 +822,8 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   auto onvalue_tensor = _tensor_reg->getAclTensor(onvalue_idx);
 
   const size_t output_rank = _ctx.at(output_idx).shape().rank();
-  const auto frontend_layout = _current_layout;
   int32_t axis = node.param().axis == -1 ? output_rank - 1 : node.param().axis;
-  axis = acl_common::ToARMComputeAxis(output_rank, axis, frontend_layout).value();
+  axis = acl_common::ToARMComputeAxis(output_rank, axis).value();
 
   if (output_tensor->num_dimensions() != output_tensor->info()->num_dimensions())
   {
@@ -886,11 +871,9 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
   for (const auto &input_index : input_indexes)
     inputs.emplace_back(_tensor_reg->getAclTensor(input_index)->handle());
 
-  const auto frontend_layout = _current_layout;
-
   if (axis < 0)
     axis += output_rank;
-  axis = acl_common::ToARMComputeAxis(output_rank, axis, frontend_layout).value();
+  axis = acl_common::ToARMComputeAxis(output_rank, axis).value();
 
   // Disable applied dim_correction
   for (const auto &input_index : input_indexes)
@@ -921,7 +904,7 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
 void KernelGenerator::visit(const ir::operation::Pool2D &node)
 {
   auto raw_fn = acl_common::kernelGenPool2D<::arm_compute::CLPoolingLayer>(
-    node, _ctx, _tensor_reg, _current_layout, acl_common::convertPoolType(node.param().op_type));
+    node, _ctx, _tensor_reg, acl_common::convertPoolType(node.param().op_type));
 
   const auto ofm_index{node.getOutputs().at(0)};
   auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
@@ -1168,9 +1151,9 @@ void KernelGenerator::visit(const ir::operation::TransposeConv &node)
   const auto ker_index{node.getInputs().at(ir::operation::TransposeConv::Input::KERNEL)};
   const auto ifm_index{node.getInputs().at(ir::operation::TransposeConv::Input::INPUT)};
 
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ker_shape = _ctx.at(ker_index).shape().asFeature(_current_layout);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ker_shape = _ctx.at(ker_index).shape().asFeature(ir::Layout::NHWC);
 
   const auto stride = node.param().stride;
 
@@ -1257,16 +1240,6 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
   auto indices_tensor = _tensor_reg->getAclTensor(indices_index);
 
-  // NOTE The frontend layout and backend layout must be the same for this operation.
-  //      If not the same, we have to add a stage(?) to perform permutation of output tensor. It
-  //      is not not efficient even if it works well. If so, it would be better to set the
-  //      layout of these backend tensors to the same layout.
-  //      There is also one thing we have to think about. This operation depends on the layout of
-  //      a model. For example, if a model in NHWC has this operation as output rank == 4, indices
-  //      rank == 2 and axis == 2, this operation should work as the axis W and C, but the axis W
-  //      and C are not sequential in NCHW. So the backend in NCHW cannot handle this case.
-  assert(ifm_rank < 4 || _current_layout == ir::Layout::NHWC);
-
   // input is n-D, indices k-D, output is (n + k - 1)-D
   size_t n = ifm_rank;
   assert(n == ifm_tensor->num_dimensions());
@@ -1315,7 +1288,6 @@ void KernelGenerator::visit(const ir::operation::ArgMinMax &node)
   auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
   auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
   const auto ifm_rank = _ctx.at(ifm_index).shape().rank();
-  auto frontend_layout = _current_layout;
 
   int axis_value = _ctx.at(axis_index).asScalar<int32_t>();
   if (axis_value < 0)
@@ -1323,7 +1295,7 @@ void KernelGenerator::visit(const ir::operation::ArgMinMax &node)
     axis_value += ifm_rank;
   }
 
-  auto acl_axis = acl_common::ToARMComputeAxis(ifm_rank, axis_value, frontend_layout).value();
+  auto acl_axis = acl_common::ToARMComputeAxis(ifm_rank, axis_value).value();
   auto reduce_type = node.param().is_arg_max ? ::arm_compute::ReductionOperation::ARG_IDX_MAX
                                              : ::arm_compute::ReductionOperation::ARG_IDX_MIN;
   auto fn = acl_common::generateLayer<arm_compute::CLArgMinMaxLayerEx>(
@@ -1393,11 +1365,10 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   for (const auto &ofm_ind : output_indexes)
     output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind)->handle());
 
-  const auto frontend_layout = _current_layout;
   auto axis = _ctx.at(axis_index).asScalar<int32_t>();
   if (axis < 0)
     axis += ifm_rank;
-  axis = acl_common::ToARMComputeAxis(ifm_rank, axis, frontend_layout).value();
+  axis = acl_common::ToARMComputeAxis(ifm_rank, axis).value();
 
   auto fn =
     acl_common::generateLayer<arm_compute::CLSplit>(ifm_tensor->handle(), output_tensors, axis);
@@ -1431,7 +1402,6 @@ void KernelGenerator::visit(const ir::operation::SplitV &node)
   {
     int32_t split_dim = split_dim_op.asScalar<int32_t>();
     uint32_t split_dim_revised = (split_dim < 0) ? (split_dim + ifm_rank) : split_dim;
-    const auto frontend_layout = _current_layout;
 
     if (ifm_tensor->num_dimensions() != ifm_tensor->info()->num_dimensions())
     {
@@ -1439,8 +1409,7 @@ void KernelGenerator::visit(const ir::operation::SplitV &node)
       acl_common::disableDimCorrection(ifm_tensor);
     }
 
-    split_dim_revised =
-      acl_common::ToARMComputeAxis(ifm_rank, split_dim_revised, frontend_layout).value();
+    split_dim_revised = acl_common::ToARMComputeAxis(ifm_rank, split_dim_revised).value();
     fn->configure(ifm_tensor->handle(), size_split_tensor->handle(), split_dim_revised,
                   output_tensors, node.param().num_splits);
 
@@ -1473,10 +1442,9 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
   for (const auto &output_index : output_indexes)
     outputs.emplace_back(_tensor_reg->getAclTensor(output_index)->handle());
 
-  const auto frontend_layout = _current_layout;
   if (axis < 0)
     axis += input_rank;
-  axis = acl_common::ToARMComputeAxis(input_rank, axis, frontend_layout).value();
+  axis = acl_common::ToARMComputeAxis(input_rank, axis).value();
 
   // Disable applied dim_correction
   if (input_tensor->num_dimensions() != input_tensor->info()->num_dimensions())
@@ -1515,15 +1483,13 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   auto input = _tensor_reg->getAclTensor(input_index)->handle();
   auto output = _tensor_reg->getAclTensor(output_index)->handle();
 
-  const auto frontend_layout = _current_layout;
-
   ::arm_compute::PaddingList padding_list;
   padding_list.resize(rank);
   for (int32_t n = 0; n < rank; ++n)
   {
     const int32_t *from = reinterpret_cast<const int32_t *>(pad_base) + (n * 2);
 
-    const auto axis = acl_common::ToARMComputeAxis(rank, n, frontend_layout).value();
+    const auto axis = acl_common::ToARMComputeAxis(rank, n).value();
     padding_list[axis] = ::arm_compute::PaddingInfo{from[0], from[1]};
   }
 

--- a/runtime/onert/backend/acl_cl/KernelGenerator.h
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.h
@@ -90,7 +90,6 @@ private:
 private:
   const ir::Operands &_ctx;
   const ir::Operations &_operations_ctx;
-  const ir::Layout _current_layout;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<acl_common::AclTensorRegistry<TensorManager>> _tensor_reg;
 };

--- a/runtime/onert/backend/acl_cl/Optimizer.cc
+++ b/runtime/onert/backend/acl_cl/Optimizer.cc
@@ -44,10 +44,7 @@ void Optimizer::optimize()
     acl_common::AclSubTensorAnalyzer sa{*_context->graph()};
     sa.setUsePadding();
     _context->graph()->operations().iterate(
-      [&](const ir::OperationIndex &, const ir::IOperation &op) {
-        sa.setLayout(_context->graph()->layout());
-        op.accept(sa);
-      });
+      [&](const ir::OperationIndex &, const ir::IOperation &op) { op.accept(sa); });
 
     _tensor_builder->parent_map(sa.releaseParentMap());
   }

--- a/runtime/onert/backend/acl_common/AclBackendContext.h
+++ b/runtime/onert/backend/acl_common/AclBackendContext.h
@@ -60,9 +60,8 @@ public:
       if (this->external_operands().contains(ind))
         return;
 
-      const auto frontend_layout = this->graph()->layout();
-      ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, ir::Layout::NHWC),
-                                   obj.typeInfo(), obj.info().memAllocType(), obj.isConstant()};
+      ir::OperandInfo backend_info{obj.shape(), obj.typeInfo(), obj.info().memAllocType(),
+                                   obj.isConstant()};
       this->tensor_builder->registerTensorInfo(ind, backend_info);
     });
 

--- a/runtime/onert/backend/acl_common/AclConstantInitializer.h
+++ b/runtime/onert/backend/acl_common/AclConstantInitializer.h
@@ -38,8 +38,7 @@ namespace acl_common
 {
 
 template <typename T>
-static void Init(const onert::ir::Operand &model_obj, onert::backend::ITensor &obj, const bool copy,
-                 const onert::ir::Layout frontend_layout = onert::ir::Layout::UNKNOWN)
+static void Init(const onert::ir::Operand &model_obj, onert::backend::ITensor &obj)
 {
   const auto shape = model_obj.shape();
   assert(model_obj.data());
@@ -109,25 +108,10 @@ static void Init(const onert::ir::Operand &model_obj, onert::backend::ITensor &o
           {
             for (auto k = 0; k < shape.dim(2); ++k)
             {
-              if (copy)
-              {
-                ::onert::ir::Coordinates coords{i, j, k, 0};
-                memcpy(tensor.buffer() + tensor.calcOffset(coords),
-                       base + i * height * width * copy_len + j * width * copy_len + k * copy_len,
-                       copy_len * sizeof(T));
-              }
-              else
-              {
-                for (auto l = 0; l < shape.dim(3); ++l)
-                {
-                  const auto coords =
-                    ::onert::ir::convertCoordinates({i, j, k, l}, frontend_layout, tensor.layout());
-                  T *into = reinterpret_cast<T *>(tensor.buffer() + tensor.calcOffset(coords));
-                  T value = *(base + i * height * width * copy_len + j * width * copy_len +
-                              k * copy_len + l);
-                  *into = value;
-                }
-              }
+              ::onert::ir::Coordinates coords{i, j, k, 0};
+              memcpy(tensor.buffer() + tensor.calcOffset(coords),
+                     base + i * height * width * copy_len + j * width * copy_len + k * copy_len,
+                     copy_len * sizeof(T));
             }
           }
         }
@@ -142,15 +126,7 @@ static void Init(const onert::ir::Operand &model_obj, onert::backend::ITensor &o
 template <typename T>
 void copyInit(const onert::ir::Operand &model_obj, onert::backend::ITensor &obj)
 {
-  Init<T>(model_obj, obj, true);
-}
-
-template <typename T>
-void permuteInit(const onert::ir::Operand &model_obj, onert::backend::ITensor &obj,
-                 const onert::ir::Layout frontend_layout)
-{
-  const bool copy = frontend_layout == obj.layout();
-  Init<T>(model_obj, obj, copy, frontend_layout);
+  Init<T>(model_obj, obj);
 }
 
 // Pre-defined initializer - fill reverse order
@@ -197,13 +173,11 @@ public:
 public:
   void registerDefaultInitializer(const ir::OperandIndex &index, const ir::Operand &obj)
   {
-    registerPermuteInitializer(index, obj);
+    registerCopyInitializer(index, obj);
   }
   void registerCopyInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
-  void registerPermuteInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
 
 public:
-  void setLayout(ir::Layout layout) { _current_layout = layout; }
   bool exist(const ir::OperandIndex &ind) { return _init_map.find(ind) != _init_map.end(); }
 
 public:
@@ -217,13 +191,11 @@ public:
 
 protected:
   void copyInputInitialize(const ir::Operation &node, uint32_t index);
-  void permuteInputInitialize(const ir::Operation &node, uint32_t index);
 
 protected:
   const ir::Operands &_operands;
   std::shared_ptr<ITensorRegistry> _tensor_reg;
   std::unordered_map<ir::OperandIndex, Initializer> _init_map;
-  ir::Layout _current_layout;
 };
 
 } // namespace acl_common

--- a/runtime/onert/backend/acl_common/AclSubTensorAnalyzer.h
+++ b/runtime/onert/backend/acl_common/AclSubTensorAnalyzer.h
@@ -45,8 +45,6 @@ public:
   }
 
 public:
-  void setLayout(ir::Layout layout) { _current_op_layout = layout; }
-
   void setUsePadding() { usePadding = true; }
 
   void visit(const ir::operation::Concat &node) override
@@ -95,8 +93,7 @@ public:
       }
       coordinate_info.set(axis, axis_point);
 
-      _parent_map.emplace(input_index,
-                          cl_common::ParentInfo{output_index, _current_op_layout, coordinate_info});
+      _parent_map.emplace(input_index, cl_common::ParentInfo{output_index, coordinate_info});
 
       axis_point += input_shape.dim(axis);
     }
@@ -110,7 +107,6 @@ public:
 private:
   const ir::Graph &_graph;
   std::unordered_map<ir::OperandIndex, cl_common::ParentInfo> _parent_map;
-  ir::Layout _current_op_layout{ir::Layout::UNKNOWN};
   bool usePadding{false};
 };
 

--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -142,37 +142,11 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::registerTensorInfo(
 
   _uses_count_map[ind] = _operands.at(ind).getUses().size();
 
-  if (_parent_map.count(ind) == 0)
-  {
-    // Normal Tensors
-    _tensor_info_map.emplace(ind, info);
-  }
-  else
-  {
-    // SubTensors
-    assert(!info.isConstant() && "Subtensors of constants are not supported yet.");
+  // SubTensors
+  assert((_parent_map.count(ind) == 0 || !info.isConstant()) &&
+         "Subtensors of constants are not supported yet.");
 
-    // Update offset info and emplace
-    auto &parent_info = _parent_map[ind];
-    const auto &obj = _operands.at(ind);
-    auto parent_index = parent_info.parent;
-    auto &offset = parent_info.coordinates;
-    auto frontend_layout = parent_info.frontend_layout;
-
-    assert(obj.shape().rank() <= ir::Shape::kMaxRank);
-    auto shape = obj.shape();
-    if (_operands.at(parent_index).shape().rank() >= 4 && frontend_layout == ir::Layout::NCHW)
-    {
-      // Permutation changing layout beyond 4-D is not supported yet
-      const auto parent_rank = _operands.at(parent_index).shape().rank();
-      assert(parent_rank == 4);
-      shape.extendRank(parent_rank);
-      offset = {offset[0], offset[2], offset[3], offset[1]};
-    }
-    auto new_shape = permuteShape(shape, frontend_layout, ir::Layout::NHWC);
-    auto oi = ir::OperandInfo::createStaticInfo(new_shape, obj.typeInfo());
-    _tensor_info_map.emplace(ind, oi);
-  }
+  _tensor_info_map.emplace(ind, info);
 }
 
 template <typename T_ITensor, typename T_Tensor, typename T_SubTensor>
@@ -245,7 +219,7 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::buildTensors(void)
     if (_parent_map.count(ind) > 0)
       continue;
 
-    auto tensor_info = asTensorInfo(info.shape(), info.typeInfo(), ir::Layout::UNKNOWN, true);
+    auto tensor_info = asTensorInfo(info.shape(), info.typeInfo(), true);
     _tensor_mgr->buildTensor(ind, tensor_info, info.shape().rank(), info.isConstant(),
                              _uses_count_map[ind]);
   }
@@ -306,9 +280,8 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::buildTensors(void)
              parent_tensor->info()->quantization_info().uniform().scale);
       assert(tensor_info.typeInfo().type() == parent_tensor->data_type());
 
-      auto shape = asTensorShape(tensor_info.shape(), ir::Layout::UNKNOWN, true);
-      ::arm_compute::Coordinates coordinates =
-        asTensorCoordinate(parent_info.coordinates, ir::Layout::UNKNOWN);
+      auto shape = asTensorShape(tensor_info.shape(), true);
+      ::arm_compute::Coordinates coordinates = asTensorCoordinate(parent_info.coordinates);
       _tensor_mgr->buildSubtensor(parent, current, shape, coordinates, tensor_info.shape().rank(),
                                   true);
       stack.pop();

--- a/runtime/onert/backend/acl_common/Convert.cc
+++ b/runtime/onert/backend/acl_common/Convert.cc
@@ -28,8 +28,7 @@ namespace backend
 namespace acl_common
 {
 
-::arm_compute::TensorShape asTensorShape(const ir::Shape &shape, ir::Layout frontend_layout,
-                                         bool apply_dim_correction)
+::arm_compute::TensorShape asTensorShape(const ir::Shape &shape, bool apply_dim_correction)
 {
   // If shape's rank is 0, the tensor is a scalar
   // Sometimes, some ACL kernel can use a scalar as tensor. But ACL does not allocate buffer for
@@ -51,15 +50,13 @@ namespace acl_common
     // However, if the dimension correction is applied to input_to_input_weights with input_size
     // equal to 1, it will be changed to 1-D.
     // So input_to_input_weights is not used by the weight of FullyConnected.
-    res.set(ToARMComputeAxis(rank, axis, frontend_layout).value(), tensor_shape.dim(axis),
-            apply_dim_correction);
+    res.set(ToARMComputeAxis(rank, axis).value(), tensor_shape.dim(axis), apply_dim_correction);
   }
 
   return res;
 }
 
-::arm_compute::Coordinates asTensorCoordinate(const ir::Coordinates &coord,
-                                              ir::Layout frontend_layout)
+::arm_compute::Coordinates asTensorCoordinate(const ir::Coordinates &coord)
 {
   const uint32_t rank = coord.size();
 
@@ -69,7 +66,7 @@ namespace acl_common
 
   for (uint32_t axis = 0; axis < rank; ++axis)
   {
-    res.set(ToARMComputeAxis(rank, axis, frontend_layout).value(), coord[axis]);
+    res.set(ToARMComputeAxis(rank, axis).value(), coord[axis]);
   }
 
   return res;
@@ -114,9 +111,9 @@ namespace acl_common
 }
 
 ::arm_compute::TensorInfo asTensorInfo(const ir::Shape &shape, const ir::TypeInfo &typeInfo,
-                                       ir::Layout frontend_layout, bool apply_dim_correction)
+                                       bool apply_dim_correction)
 {
-  ::arm_compute::TensorInfo info(asTensorShape(shape, frontend_layout, apply_dim_correction), 1,
+  ::arm_compute::TensorInfo info(asTensorShape(shape, apply_dim_correction), 1,
                                  asDataType(typeInfo.type()),
                                  asQuantizationInfo(typeInfo.scale(), typeInfo.zero_point()));
   info.set_data_layout(::arm_compute::DataLayout::NHWC);
@@ -211,10 +208,9 @@ asActivationLayerInfo(const ir::operation::ElementwiseActivation::Type op_type, 
   }
 }
 
-arm_compute::Coordinates asCoordinates(const ir::Operand &operand, int32_t rank,
-                                       ir::Layout frontend_layout)
+arm_compute::Coordinates asCoordinates(const ir::Operand &operand, int32_t rank)
 {
-  std::set<uint32_t> axes = asSet(operand, rank, frontend_layout);
+  std::set<uint32_t> axes = asSet(operand, rank);
 
   arm_compute::Coordinates reduce_axes;
   for (const int32_t axis : axes)
@@ -225,7 +221,7 @@ arm_compute::Coordinates asCoordinates(const ir::Operand &operand, int32_t rank,
   return reduce_axes;
 }
 
-std::set<uint32_t> asSet(const ir::Operand &operand, int32_t rank, ir::Layout frontend_layout)
+std::set<uint32_t> asSet(const ir::Operand &operand, int32_t rank)
 {
   std::set<std::uint32_t> axes;
 
@@ -245,7 +241,7 @@ std::set<uint32_t> asSet(const ir::Operand &operand, int32_t rank, ir::Layout fr
     }
     if (axis < 0)
       axis += rank;
-    axes.insert(ToARMComputeAxis(rank, axis, frontend_layout).value());
+    axes.insert(ToARMComputeAxis(rank, axis).value());
   }
 
   return axes;

--- a/runtime/onert/backend/acl_common/Convert.h
+++ b/runtime/onert/backend/acl_common/Convert.h
@@ -47,13 +47,10 @@ namespace backend
 namespace acl_common
 {
 
-::arm_compute::TensorShape asTensorShape(const ir::Shape &shape, ir::Layout frontend_layout,
-                                         bool apply_dim_correction = true);
-::arm_compute::Coordinates asTensorCoordinate(const ir::Coordinates &coord,
-                                              ir::Layout frontend_layout);
+::arm_compute::TensorShape asTensorShape(const ir::Shape &shape, bool apply_dim_correction = true);
+::arm_compute::Coordinates asTensorCoordinate(const ir::Coordinates &coord);
 ::arm_compute::DataType asDataType(ir::DataType type);
 ::arm_compute::TensorInfo asTensorInfo(const ir::Shape &shape, const ir::TypeInfo &typeInfo,
-                                       ir::Layout frontend_layout,
                                        bool apply_dim_correction = true);
 
 ::arm_compute::PadStrideInfo asPadStrideInfo(const ir::ExplicitPadding &padding,
@@ -64,10 +61,9 @@ namespace acl_common
 asActivationLayerInfo(const ir::operation::ElementwiseActivation::Type op_type, float alpha,
                       float beta);
 
-arm_compute::Coordinates asCoordinates(const ir::Operand &operand, int32_t rank,
-                                       ir::Layout frontend_layout);
+arm_compute::Coordinates asCoordinates(const ir::Operand &operand, int32_t rank);
 
-std::set<uint32_t> asSet(const ir::Operand &operand, int32_t rank, ir::Layout frontend_layout);
+std::set<uint32_t> asSet(const ir::Operand &operand, int32_t rank);
 
 std::unique_ptr<AclFunction> asAclFunction(std::unique_ptr<::arm_compute::IFunction> &&layer);
 

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -47,7 +47,7 @@ KernelGenerator::KernelGenerator(
   const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
   const std::shared_ptr<acl_common::AclTensorRegistry<TensorManager>> &tensor_reg)
   : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx(graph.operations()),
-    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg(tensor_reg)
+    _tensor_builder(tensor_builder), _tensor_reg(tensor_reg)
 {
   // DO NOTHING
 }
@@ -73,7 +73,6 @@ void KernelGenerator::visit(const ir::operation::ArgMinMax &node)
 
   auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
   auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
-  auto frontend_layout = _current_layout;
 
   int axis_value = _ctx.at(axis_index).asScalar<int32_t>();
   if (axis_value < 0)
@@ -81,8 +80,7 @@ void KernelGenerator::visit(const ir::operation::ArgMinMax &node)
     axis_value += ifm_rank;
   }
   assert(axis_value >= 0 && axis_value < ifm_rank);
-  const auto fixed_axis =
-    acl_common::ToARMComputeAxis(ifm_rank, axis_value, frontend_layout).value();
+  const auto fixed_axis = acl_common::ToARMComputeAxis(ifm_rank, axis_value).value();
   auto reduce_type = node.param().is_arg_max ? ::arm_compute::ReductionOperation::ARG_IDX_MAX
                                              : ::arm_compute::ReductionOperation::ARG_IDX_MIN;
 
@@ -190,8 +188,8 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
   const auto ker_index{node.getInputs().at(Conv2D::Input::KERNEL)};
   const auto bias_index{node.getInputs().at(Conv2D::Input::BIAS)};
 
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [depth_out, kernel_height, kernel_width, depth_in].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);
@@ -244,8 +242,8 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto ker_index{node.getInputs().at(DepthwiseConv2D::Input::KERNEL)};
   const auto bias_index{node.getInputs().at(DepthwiseConv2D::Input::BIAS)};
 
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [1, kernel_height, kernel_width, depth_out].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);
@@ -309,8 +307,7 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
   else
   {
     const auto rank = _ctx.at(ofm_index).shape().rank();
-    const auto frontend_layout = _current_layout;
-    const auto fixed_axis = acl_common::ToARMComputeAxis(rank, axis, frontend_layout).value();
+    const auto fixed_axis = acl_common::ToARMComputeAxis(rank, axis).value();
     fn = acl_common::generateLayer<arm_compute::NEConcatenateLayer>(
       input_tensors, output_tensor->handle(), fixed_axis);
   }
@@ -505,7 +502,7 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
 
   auto fn = acl_common::kernelGenFullyConnected<acl_common::AclFunction, ::arm_compute::ITensor,
                                                 ::arm_compute::NEFullyConnectedReshapingLayer>(
-    node, _ctx, _tensor_builder, _tensor_reg, _current_layout);
+    node, _ctx, _tensor_builder, _tensor_reg);
   _return_fn = std::make_unique<exec::FunctionSequence>(
     std::move(fn), ActivationBuilder::generate(activation, output_tensor->handle()));
 }
@@ -549,16 +546,6 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
   auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
   auto indices_tensor = _tensor_reg->getAclTensor(indices_index);
-
-  // NOTE The frontend layout and backend layout must be the same for this operation.
-  //      If not the same, we have to add a stage(?) to perform permutation of output tensor. It
-  //      is not not efficient even if it works well. If so, it would be better to set the
-  //      layout of these backend tensors to the same layout.
-  //      There is also one thing we have to think about. This operation depends on the layout of
-  //      a model. For example, if a model in NHWC has this operation as output rank == 4, indices
-  //      rank == 2 and axis == 2, this operation should work as the axis W and C, but the axis W
-  //      and C are not sequential in NCHW. So the backend in NCHW cannot handle this case.
-  assert(ifm_rank < 4 || _current_layout == ir::Layout::NHWC);
 
   // input is n-D, indices k-D, output is (n + k - 1)-D
   size_t n = ifm_rank;
@@ -692,11 +679,9 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
   for (const auto &input_index : input_indexes)
     inputs.emplace_back(_tensor_reg->getAclTensor(input_index)->handle());
 
-  const auto frontend_layout = _current_layout;
-
   if (axis < 0)
     axis += output_rank;
-  axis = acl_common::ToARMComputeAxis(output_rank, axis, frontend_layout).value();
+  axis = acl_common::ToARMComputeAxis(output_rank, axis).value();
 
   // Disable applied dim_correction
   for (const auto &input_index : input_indexes)
@@ -743,8 +728,7 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   {
     const int32_t *from = reinterpret_cast<const int32_t *>(pad_base) + (n * 2);
 
-    const auto frontend_layout = _current_layout;
-    const auto axis = acl_common::ToARMComputeAxis(rank, n, frontend_layout).value();
+    const auto axis = acl_common::ToARMComputeAxis(rank, n).value();
     padding_list[axis] = ::arm_compute::PaddingInfo{from[0], from[1]};
   }
 
@@ -765,7 +749,7 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
 void KernelGenerator::visit(const ir::operation::Pool2D &node)
 {
   auto raw_fn = acl_common::kernelGenPool2D<::arm_compute::NEPoolingLayer>(
-    node, _ctx, _tensor_reg, _current_layout, acl_common::convertPoolType(node.param().op_type));
+    node, _ctx, _tensor_reg, acl_common::convertPoolType(node.param().op_type));
 
   const auto ofm_index{node.getOutputs().at(0)};
   auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
@@ -838,8 +822,7 @@ void KernelGenerator::visit(const ir::operation::Reduce &node)
   // Convert to ACL axes taking into account negative values and possible duplicates.
   const auto &axes = _ctx.at(axes_index);
   const auto input_rank = _ctx.at(input_index).shape().rank();
-  const auto frontend_layout = _current_layout;
-  const auto reduce_axes = acl_common::asCoordinates(axes, input_rank, frontend_layout);
+  const auto reduce_axes = acl_common::asCoordinates(axes, input_rank);
   const auto reduce_type = node.param().reduce_type;
   const auto keep_dims = node.param().keep_dims;
 
@@ -870,11 +853,6 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
 
   auto output_tensor = _tensor_reg->getAclTensor(output_index);
   auto input_tensor = _tensor_reg->getAclTensor(input_index);
-
-  // NOTE This operation must not be changed the layout from frontend to backend
-  //      So, PermutationOperationPass makes layouts of frontend and backend the same.
-  assert((_ctx.at(input_index).shape().rank() < 4 && _ctx.at(output_index).shape().rank() < 4) ||
-         _current_layout == ir::Layout::NHWC);
 
   auto fn = acl_common::generateLayer<arm_compute::NEReshapeLayer>(input_tensor->handle(),
                                                                    output_tensor->handle());
@@ -1033,11 +1011,10 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   for (const auto &ofm_ind : output_indexes)
     output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind)->handle());
 
-  const auto frontend_layout = _current_layout;
   auto axis = _ctx.at(axis_index).asScalar<int32_t>();
   if (axis < 0)
     axis += ifm_rank;
-  axis = acl_common::ToARMComputeAxis(ifm_rank, axis, frontend_layout).value();
+  axis = acl_common::ToARMComputeAxis(ifm_rank, axis).value();
 
   auto fn =
     acl_common::generateLayer<arm_compute::NESplit>(ifm_tensor->handle(), output_tensors, axis);
@@ -1070,7 +1047,6 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
 
   auto outputData_tensor = _tensor_reg->getAclTensor(output_index);
   auto inputData_tensor = _tensor_reg->getAclTensor(input_index);
-  const auto frontend_layout = _current_layout;
 
   // Set initializers for indices data such as order of inputData
   int input_rank = _ctx.at(input_index).shape().rank();
@@ -1097,8 +1073,7 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
     assert(beginData_base != nullptr);
     for (int n = 0; n < input_rank; ++n)
     {
-      auto axis =
-        ::onert::backend::acl_common::ToARMComputeAxis(input_rank, n, frontend_layout).value();
+      auto axis = ::onert::backend::acl_common::ToARMComputeAxis(input_rank, n).value();
 
       int32_t begin_value = *(reinterpret_cast<const int32_t *>(beginData_base) + n);
       starts[axis] = begin_value;
@@ -1133,7 +1108,6 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
 
   auto outputData_tensor = _tensor_reg->getAclTensor(output_index);
   auto inputData_tensor = _tensor_reg->getAclTensor(input_index);
-  const auto frontend_layout = _current_layout;
 
   // Set initializers for indices data such as order of inputData
   int input_rank = _ctx.at(input_index).shape().rank();
@@ -1167,8 +1141,7 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
     assert(startData_base != nullptr);
     for (int n = 0; n < input_rank; ++n)
     {
-      auto axis =
-        ::onert::backend::acl_common::ToARMComputeAxis(input_rank, n, frontend_layout).value();
+      auto axis = ::onert::backend::acl_common::ToARMComputeAxis(input_rank, n).value();
 
       int32_t start_value = *(reinterpret_cast<const int32_t *>(startData_base) + n);
       starts[axis] = start_value;
@@ -1226,9 +1199,9 @@ void KernelGenerator::visit(const ir::operation::TransposeConv &node)
   const auto ker_index{node.getInputs().at(ir::operation::TransposeConv::Input::KERNEL)};
   const auto ifm_index{node.getInputs().at(ir::operation::TransposeConv::Input::INPUT)};
 
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ker_shape = _ctx.at(ker_index).shape().asFeature(_current_layout);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ker_shape = _ctx.at(ker_index).shape().asFeature(ir::Layout::NHWC);
 
   const auto stride = node.param().stride;
 
@@ -1267,7 +1240,6 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
 
   auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx);
   const auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx);
-  const auto frontend_layout = _current_layout;
   const auto rank = _ctx.at(ifm_idx).shape().rank();
 
   const auto &perms = _ctx.at(perm_idx);
@@ -1296,7 +1268,7 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   }
   else
   {
-    auto backend_pv = acl_common::getARMComputePermutationVector(rank, pv, frontend_layout);
+    auto backend_pv = acl_common::getARMComputePermutationVector(rank, pv);
 
     fn = acl_common::generateLayer<arm_compute::NEPermute>(ifm_tensor->handle(),
                                                            ofm_tensor->handle(), backend_pv);
@@ -1320,10 +1292,9 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
   for (const auto &output_index : output_indexes)
     outputs.emplace_back(_tensor_reg->getAclTensor(output_index)->handle());
 
-  const auto frontend_layout = _current_layout;
   if (axis < 0)
     axis += input_rank;
-  axis = acl_common::ToARMComputeAxis(input_rank, axis, frontend_layout).value();
+  axis = acl_common::ToARMComputeAxis(input_rank, axis).value();
 
   // Disable applied dim_correction
   if (static_cast<size_t>(input_tensor->getShape().rank()) !=
@@ -1393,9 +1364,8 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   auto offvalue_tensor = _tensor_reg->getAclTensor(offvalue_idx);
 
   const size_t output_rank = _ctx.at(out_idx).shape().rank();
-  const auto frontend_layout = _current_layout;
   int32_t axis = node.param().axis == -1 ? output_rank - 1 : node.param().axis;
-  axis = acl_common::ToARMComputeAxis(output_rank, axis, frontend_layout).value();
+  axis = acl_common::ToARMComputeAxis(output_rank, axis).value();
 
   auto fn = acl_common::generateLayer<arm_compute::NEOneHot>(
     indices_tensor->handle(), depth_tensor->handle(), onvalue_tensor->handle(),

--- a/runtime/onert/backend/acl_neon/KernelGenerator.h
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.h
@@ -85,7 +85,6 @@ private:
 private:
   const ir::Operands &_ctx;
   const ir::Operations &_operations_ctx;
-  const ir::Layout _current_layout;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<acl_common::AclTensorRegistry<TensorManager>> _tensor_reg;
 };

--- a/runtime/onert/backend/acl_neon/Optimizer.cc
+++ b/runtime/onert/backend/acl_neon/Optimizer.cc
@@ -44,10 +44,7 @@ void Optimizer::optimize()
     acl_common::AclSubTensorAnalyzer sa{*_context->graph()};
     sa.setUsePadding();
     _context->graph()->operations().iterate(
-      [&](const ir::OperationIndex &, const ir::IOperation &op) {
-        sa.setLayout(_context->graph()->layout());
-        op.accept(sa);
-      });
+      [&](const ir::OperationIndex &, const ir::IOperation &op) { op.accept(sa); });
   }
 }
 

--- a/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
+++ b/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
@@ -81,7 +81,6 @@ protected:
   void initConsts()
   {
     _data.graph->operations().iterate([&](const ir::OperationIndex &, const ir::IOperation &op) {
-      constant_initializer->setLayout(graph()->layout());
       op.accept(*constant_initializer);
     });
 

--- a/runtime/onert/backend/cl_common/include/cl_common/ParentInfo.h
+++ b/runtime/onert/backend/cl_common/include/cl_common/ParentInfo.h
@@ -33,7 +33,6 @@ namespace cl_common
 struct ParentInfo
 {
   ir::OperandIndex parent;
-  ir::Layout frontend_layout;
   ir::Coordinates coordinates;
 };
 


### PR DESCRIPTION
This commit removes frontend layout checking and permutation in ACL backend.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/12130 https://github.com/Samsung/ONE/issues/13494