### PR TITLE
[onert] Remove frontend layout usage in non-ACL backend

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -232,8 +232,8 @@ KernelGenerator::KernelGenerator(
   const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
   const std::shared_ptr<ExternalContext> &external_context)
   : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
-    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg{tensor_reg},
-    _kernel_builder(kernel_builder), _external_context(external_context)
+    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _kernel_builder(kernel_builder),
+    _external_context(external_context)
 {
   // DO NOTHING
 }
@@ -325,8 +325,8 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
     _return_fn = std::move(fn);
     return;
   }
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [depth_out, kernel_height, kernel_width, depth_in].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);
@@ -354,8 +354,8 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto bias_index{node.getInputs().at(DepthwiseConv2D::Input::BIAS)};
 
   const auto stride = node.param().stride;
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [1, kernel_height, kernel_width, depth_out].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);
@@ -386,7 +386,7 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
   const auto ofm_index{node.getOutputs().at(0)};
 
   const auto rank = _ctx.at(ofm_index).shape().rank();
-  const auto axis = ops::getAxis(rank, node.param().axis, _current_layout);
+  const auto axis = ops::getAxis(rank, node.param().axis);
 
   auto output_tensor = _tensor_reg->getPortableTensor(ofm_index);
 
@@ -572,24 +572,12 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   auto input_tensor = _tensor_reg->getPortableTensor(input_index);
   auto indices_tensor = _tensor_reg->getPortableTensor(indices_index);
 
-  // NOTE The frontend layout and backend layout must be the same for this operation.
-  //      If not the same, we have to add a stage(?) to perform permutation of output tensor. It
-  //      is not not efficient even if it works well. If so, it would be better to set the
-  //      layout of these backend tensors to the same layout.
-  //      There is also one thing we have to think about. This operation depends on the layout of
-  //      a model. For example, if a model in NHWC has this operation as output rank == 4, indices
-  //      rank == 2 and axis == 2, this operation should work as the axis W and C, but the axis W
-  //      and C are not sequential in NCHW. So the backend in NCHW cannot handle this case.
-  const auto &input_shape = _ctx.at(input_index).shape();
-  UNUSED_RELEASE(input_shape);
-  assert(input_shape.rank() < 4 || _current_layout == ir::Layout::NHWC);
-
-  const auto axis_raw = node.param().axis;
-  const auto axis_value = (axis_raw < 0 ? (input_shape.rank() + axis_raw) : axis_raw);
+  const auto rank = _ctx.at(input_index).shape().rank();
+  const auto axis = ops::getAxis(rank, node.param().axis);
 
   auto fn = std::make_unique<ops::GatherLayer>();
 
-  fn->configure(input_tensor, indices_tensor, output_tensor, axis_value);
+  fn->configure(input_tensor, indices_tensor, output_tensor, axis);
 
   _return_fn = std::move(fn);
 }
@@ -646,7 +634,6 @@ void KernelGenerator::visit(const ir::operation::Custom &node)
     for (const auto &idx : opSeq)
     {
       const auto &operand = _ctx.at(idx);
-      // TODO make sure using `_current_layout` is correct for custom operations
       types.emplace_back(custom::TypeInfo{operand.shape(), operand.typeInfo().type()});
       auto in_tensor = _tensor_reg->getPortableTensor(idx);
       tensors.emplace_back(in_tensor);
@@ -743,7 +730,7 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
   const auto ofm_index{node.getOutputs().at(0)};
 
   const auto rank = _ctx.at(ofm_index).shape().rank();
-  const auto axis = ops::getAxis(rank, node.param().axis, _current_layout);
+  const auto axis = ops::getAxis(rank, node.param().axis);
 
   assert(-rank <= axis && axis < rank);
 
@@ -765,7 +752,7 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
   const auto input_index{node.getInputs().at(0)};
 
   const auto rank = _ctx.at(input_index).shape().rank();
-  const auto axis = ops::getAxis(rank, node.param().axis, _current_layout);
+  const auto axis = ops::getAxis(rank, node.param().axis);
 
   assert(rank == 0 || (-rank <= axis && axis < rank));
 
@@ -1037,8 +1024,8 @@ void KernelGenerator::visit(const ir::operation::Pool2D &node)
   const auto kh = node.param().kh;
   const auto kw = node.param().kw;
   const auto stride = node.param().stride;
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   const auto padding =
     ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, kw, kh);
   const auto activation = node.param().activation;

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -100,7 +100,6 @@ public:
 private:
   const ir::Operands &_ctx;
   const ir::Operations &_operations_ctx;
-  ir::Layout _current_layout;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<basic::TensorRegistry> _tensor_reg;
   std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;

--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -132,20 +132,13 @@ convertActivationType(const ir::Activation activation)
   }
 }
 
-inline int32_t getAxis(uint32_t rank, int32_t axis, ir::Layout frontend_layout)
+inline int32_t getAxis(uint32_t rank, int32_t axis)
 {
   auto ret = axis;
 
   if (axis < 0)
   {
     ret += rank;
-  }
-
-  // NCHW -> NHWC
-  if (frontend_layout == ir::Layout::NCHW)
-  {
-    int32_t permutation[4] = {0, 3, 1, 2};
-    ret = permutation[ret];
   }
 
   return ret;

--- a/runtime/onert/backend/ruy/KernelGenerator.cc
+++ b/runtime/onert/backend/ruy/KernelGenerator.cc
@@ -78,8 +78,8 @@ KernelGenerator::KernelGenerator(
   const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
   const std::shared_ptr<ExternalContext> &external_context)
   : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
-    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg{tensor_reg},
-    _kernel_builder(kernel_builder), _external_context(external_context)
+    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _kernel_builder(kernel_builder),
+    _external_context(external_context)
 {
   // DO NOTHING
 }
@@ -114,8 +114,8 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
     _return_fn = std::move(fn);
     return;
   }
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [depth_out, kernel_height, kernel_width, depth_in].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);

--- a/runtime/onert/backend/ruy/KernelGenerator.h
+++ b/runtime/onert/backend/ruy/KernelGenerator.h
@@ -51,7 +51,6 @@ private:
 private:
   const ir::Operands &_ctx;
   const ir::Operations &_operations_ctx;
-  const ir::Layout _current_layout;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<basic::TensorRegistry> _tensor_reg;
   std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;

--- a/runtime/onert/backend/train/BackendContext.cc
+++ b/runtime/onert/backend/train/BackendContext.cc
@@ -121,8 +121,6 @@ backend::train::ITensorRegistry *BackendContext::genTrainingTensors()
         continue;
       if (external_operands().contains(ind))
         continue;
-      // NOTE Assuming there is no layout changes (Always assume NHWC or UNKNOWN)
-      assert(tgraph.layout() != ir::Layout::NCHW);
 
       const auto &operand = tgraph.operands().at(ind);
       tensor_builder->registerBackwardTensorInfo(ind, createBackwardTensorInfo(operand));

--- a/runtime/onert/backend/train/KernelGenerator.h
+++ b/runtime/onert/backend/train/KernelGenerator.h
@@ -64,7 +64,6 @@ private:
   IPortableTensor *getBackPropOut(const ir::OperandIndex &index);
 
 private:
-  ir::Layout _current_layout;
   std::shared_ptr<TensorRegistry> _tensor_reg;
   const std::shared_ptr<ExternalContext> _external_context;
   const exec::train::optimizer::Optimizer *_optimizer;

--- a/runtime/onert/backend/trix/KernelGenerator.cc
+++ b/runtime/onert/backend/trix/KernelGenerator.cc
@@ -39,8 +39,7 @@ KernelGenerator::KernelGenerator(const ir::Graph &graph,
                                  const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
                                  const std::shared_ptr<DevContext> &dev_context)
   : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
-    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg{tensor_reg},
-    _dev_context{dev_context}
+    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _dev_context{dev_context}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/trix/KernelGenerator.h
+++ b/runtime/onert/backend/trix/KernelGenerator.h
@@ -48,7 +48,6 @@ private:
 private:
   const ir::Operands &_ctx;
   const ir::Operations &_operations_ctx;
-  ir::Layout _current_layout;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<basic::TensorRegistry> _tensor_reg;
   const std::shared_ptr<DevContext> _dev_context;

--- a/runtime/onert/backend/xnnpack/KernelGenerator.cc
+++ b/runtime/onert/backend/xnnpack/KernelGenerator.cc
@@ -42,8 +42,8 @@ KernelGenerator::KernelGenerator(
   const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
   const std::shared_ptr<ExternalContext> &external_context)
   : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
-    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg{tensor_reg},
-    _kernel_builder(kernel_builder), _external_context(external_context)
+    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _kernel_builder(kernel_builder),
+    _external_context(external_context)
 {
   // DO NOTHING
 }
@@ -105,8 +105,8 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
   const auto dilation = node.param().dilation;
   auto fn = std::make_unique<ops::ConvolutionLayer>(_external_context);
 
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [depth_out, kernel_height, kernel_width, depth_in].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);
@@ -133,8 +133,8 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto bias_index{node.getInputs().at(DepthwiseConv2D::Input::BIAS)};
 
   const auto stride = node.param().stride;
-  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(_current_layout);
-  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(_current_layout);
+  const auto ifm_shape = _ctx.at(ifm_index).shape().asFeature(ir::Layout::NHWC);
+  const auto ofm_shape = _ctx.at(ofm_index).shape().asFeature(ir::Layout::NHWC);
   // Kernel format is [1, kernel_height, kernel_width, depth_out].
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);

--- a/runtime/onert/backend/xnnpack/KernelGenerator.h
+++ b/runtime/onert/backend/xnnpack/KernelGenerator.h
@@ -52,7 +52,6 @@ private:
 private:
   const ir::Operands &_ctx;
   const ir::Operations &_operations_ctx;
-  ir::Layout _current_layout;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<basic::TensorRegistry> _tensor_reg;
   std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;


### PR DESCRIPTION
This commit removes frontend layout checking and permutation in CPU, RUY, Train, Trix, XNNPack backend.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

https://github.com/Samsung/ONE/issues/12130 https://github.com/Samsung/ONE/issues/13494