### PR TITLE
[onert] Plan disposable tensors on train backend

### DIFF
--- a/runtime/onert/backend/train/TensorPlanner.h
+++ b/runtime/onert/backend/train/TensorPlanner.h
@@ -47,6 +47,10 @@ public:
   void planDisposableBackPropTensors(TensorBuilder *tensor_builder);
 
 private:
+  ir::OperandIndexSequence getOutgoingBackPropSeq(const ir::OperationIndex &op_index,
+                                                  const TensorBuilder *tensor_builder);
+
+private:
   const ir::train::TrainableGraph &_tgraph;
   const util::Set<ir::OperandIndex> &_external_operands;
 };


### PR DESCRIPTION
This commit adds planning disposable tensors used on train backend.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>