### PR TITLE
[onert/onert_train] Use arser for onert_train

### DIFF
--- a/tests/tools/onert_train/CMakeLists.txt
+++ b/tests/tools/onert_train/CMakeLists.txt
@@ -14,7 +14,6 @@ list(APPEND ONERT_TRAIN_SRCS "src/rawformatter.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/rawdataloader.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/metrics.cc")
 
-nnfw_find_package(Boost REQUIRED program_options)
 nnfw_find_package(HDF5 QUIET)
 
 if (HDF5_FOUND)
@@ -32,11 +31,10 @@ else()
 endif(HDF5_FOUND)
 
 target_include_directories(onert_train PRIVATE src)
-target_include_directories(onert_train PRIVATE ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(onert_train nnfw_lib_tflite jsoncpp)
 target_link_libraries(onert_train nnfw-dev)
-target_link_libraries(onert_train ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(onert_train arser)
 target_link_libraries(onert_train nnfw_lib_benchmark)
 
 install(TARGETS onert_train DESTINATION bin)

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -22,12 +22,10 @@
 #include <unordered_map>
 #include <vector>
 #include <set>
-#include <boost/program_options.hpp>
+#include <arser/arser.h>
 
 #include "nnfw_experimental.h"
 #include "types.h"
-
-namespace po = boost::program_options;
 
 namespace onert_train
 {
@@ -97,8 +95,7 @@ private:
   };
 
 private:
-  po::positional_options_description _positional;
-  po::options_description _options;
+  arser::Arser _arser;
 
   std::string _package_filename;
   std::string _model_filename;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -28,7 +28,6 @@
 #include "rawdataloader.h"
 #include "metrics.h"
 
-#include <boost/program_options.hpp>
 #include <cassert>
 #include <chrono>
 #include <cstdlib>
@@ -383,11 +382,6 @@ int main(const int argc, char **argv)
     measure.printResult();
 
     return 0;
-  }
-  catch (boost::program_options::error &e)
-  {
-    std::cerr << "E: " << e.what() << std::endl;
-    exit(-1);
   }
   catch (std::runtime_error &e)
   {


### PR DESCRIPTION
This commit updates onert_train to use arser for argument parsing instead of boost::program_options.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>