### PR TITLE
[onert] Introduce ExtraTensor

### DIFF
--- a/runtime/onert/core/include/backend/train/ExtraTensor.h
+++ b/runtime/onert/core/include/backend/train/ExtraTensor.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_EXTRA_H__
+#define __ONERT_BACKEND_EXTRA_H__
+
+#include <backend/basic/Tensor.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+
+// ExtraTensor is a tensor that is accessed only by one opeartion layer.
+// In other word, Extra tensor's scope is limited into a specific layer.
+class ExtraTensor final : public basic::Tensor
+{
+public:
+  ExtraTensor() = delete;
+
+public:
+  ExtraTensor(const ir::OperandInfo &info) : basic::Tensor(info, nullptr)
+  {
+    // DO NOTHING
+  }
+};
+
+} // namespace train
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_EXTRA_TENSOR_H__

--- a/runtime/onert/core/include/backend/train/ExtraTensor.h
+++ b/runtime/onert/core/include/backend/train/ExtraTensor.h
@@ -26,8 +26,8 @@ namespace backend
 namespace train
 {
 
-// ExtraTensor is a tensor that is accessed only by one opeartion layer.
-// In other word, Extra tensor's scope is limited into a specific layer.
+// ExtraTensor is a tensor that is accessed only within one opeartion layer.
+// In other word, the scope of the extra tensor is confined to one specific layer.
 class ExtraTensor final : public basic::Tensor
 {
 public:

--- a/runtime/onert/core/include/backend/train/ExtraTensor.h
+++ b/runtime/onert/core/include/backend/train/ExtraTensor.h
@@ -26,8 +26,8 @@ namespace backend
 namespace train
 {
 
-// ExtraTensor is a tensor that is accessed only within one opeartion layer.
-// In other word, the scope of the extra tensor is confined to one specific layer.
+// ExtraTensor is a tensor that is accessed within one operation layer.
+// In other words, the scope of the extra tensor is confined to one specific layer.
 class ExtraTensor final : public basic::Tensor
 {
 public:


### PR DESCRIPTION
This PR introduces ExtraTensor.
ExtraTensor means that the tensor is only used by one operation.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>
draft : https://github.com/Samsung/ONE/pull/13486 
related : https://github.com/Samsung/ONE/issues/13282 