### PR TITLE
[onnx-tools] Support onnx model over 2GB

### DIFF
--- a/compiler/onnx-tools/onnx-dump.py
+++ b/compiler/onnx-tools/onnx-dump.py
@@ -136,8 +136,8 @@ def main():
     if len(sys.argv) < 2:
         _help_exit(os.path.basename(sys.argv[0]))
 
+    onnx.checker.check_model(sys.argv[1])
     onnx_model = onnx.load(sys.argv[1])
-    onnx.checker.check_model(onnx_model)
 
     _dump_graph(onnx_model)
 

--- a/compiler/onnx-tools/onnx-ops.py
+++ b/compiler/onnx-tools/onnx-ops.py
@@ -35,8 +35,8 @@ def main():
     if len(sys.argv) < 2:
         _help_exit(os.path.basename(sys.argv[0]))
 
+    onnx.checker.check_model(sys.argv[1])
     onnx_model = onnx.load(sys.argv[1])
-    onnx.checker.check_model(onnx_model)
 
     _dump_operators(onnx_model)
 


### PR DESCRIPTION
This commit fixes onnx.checker.check_model usage in onnx-dump.py and onnx-ops.py to support models with size greater than 2GB.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>