### PR TITLE
[onert] Use maybe_unused attribute for local variable in bias_op kernel

### DIFF
--- a/compute/cker/include/cker/eigen/bias_op.h
+++ b/compute/cker/include/cker/eigen/bias_op.h
@@ -97,7 +97,7 @@ template <typename T>
 void biasHelper(const Shape &bias_shape, const T *bias_data, const Shape &input_shape,
                 T *input_data, T activation_min, T activation_max)
 {
-  int channel_dim = input_shape.DimensionsCount() - 1;
+  [[maybe_unused]] int channel_dim = input_shape.DimensionsCount() - 1;
 
   assert(input_shape.Dims(channel_dim) == bias_shape.Dims(0));
   assert(input_data);


### PR DESCRIPTION
To remove an unused variable warning in release build, this commit uses
maybe_unused attribute for local variable.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>