### PR TITLE
[onert] Revisits python API 

### DIFF
--- a/docs/howto/how-to-use-nnfw-python-api.md
+++ b/docs/howto/how-to-use-nnfw-python-api.md
@@ -17,11 +17,11 @@ Please see [nnfw python api](https://github.com/SAMSUNG/ONE/tree/master/infra/nn
 1. Initialize nnfw_session
 
 ```python
-import nnfw_onert
+import onert
 
 # Create session and load nnpackage
 # The default value of backends is "cpu".
-session = nnfw_onert.onert.session(nnpackage_path, backends)
+session = onert.infer.session(nnpackage_path, backends)
 ```
 
 2. Prepare Input

--- a/docs/howto/how-to-use-nnfw-python-api.md
+++ b/docs/howto/how-to-use-nnfw-python-api.md
@@ -17,13 +17,11 @@ Please see [nnfw python api](https://github.com/SAMSUNG/ONE/tree/master/infra/nn
 1. Initialize nnfw_session
 
 ```python
+import nnfw_onert
+
 # Create session and load nnpackage
-# operations is optional to assign a specific backends to each operation.
 # The default value of backends is "cpu".
-if operations:
-    session = nnfw_session(nnpackage_path, backends, operations)
-else:
-    session = nnfw_session(nnpackage_path, backends)
+session = nnfw_onert.onert.session(nnpackage_path, backends)
 ```
 
 2. Prepare Input

--- a/infra/nnfw/python/.gitignore
+++ b/infra/nnfw/python/.gitignore
@@ -1,4 +1,4 @@
 build/
 dist/
-nnfwapi/
-nnfwapi.egg-info/
+onert/
+onert.egg-info/

--- a/infra/nnfw/python/README.md
+++ b/infra/nnfw/python/README.md
@@ -1,12 +1,12 @@
-# nnfwapi package
+# onert package
 
-`nnfwapi` is a package to run `nnpackage` with the nnfw python API.
+`onert` is a package to run `nnpackage` with the nnfw onert's python API.
 
-This package includes the nnfw python API module resulting from runtime build.
+This package includes the nnfw-onert python API module resulting from runtime build.
 
 It is provided separate package for each architecture(x86_64, armv7l, aarch64).
 
-It uses `nnfwapi/libnnfw_api_pybind.py` interface.
+It uses `onert/infer.py` interface.
 
 ## Packaging
 Execute this command, then the tasks such as copying modules, and packaging.
@@ -39,17 +39,25 @@ $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 You can install the package as follows:
 
 ```
-$ pip install -i https://test.pypi.org/simple/ nnfwapi
+$ pip install -i https://test.pypi.org/simple/ nnfw-onert
 ```
 
 By specifying the version, you can use a specific version of the package. (recommended)
 
 ```
-$ pip install -i https://test.pypi.org/simple/ nnfwapi==0.1.1
+$ pip install -i https://test.pypi.org/simple/ nnfw-onert==0.1.1
 ```
 
 This definition has to be set at the top of the script using nnfw python API.
 
 ```
-from nnfwapi.libnnfw_api_pybind import *
+import onert
 ```
+
+Or you can import the onert module directly.
+
+```
+from onert.infer import *
+```
+
+This can be use onert session directly.

--- a/infra/nnfw/python/setup.py
+++ b/infra/nnfw/python/setup.py
@@ -4,7 +4,8 @@ import shutil
 import sys
 
 architecture_directory = ['x86_64', 'armv7l', 'aarch64']
-package_directory = 'nnfwapi'
+package_name = 'onert'
+package_directory = 'onert'
 packaging_directory = ['build', package_directory + '.egg-info']
 THIS_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_PRODUCT_DIR = "../../../Product"
@@ -66,7 +67,7 @@ try:
             shutil.rmtree(arch_path)
 
         # make architecture_directory and copy .so files to the directories
-        arch_path = os.path.join(package_directory, 'onert')
+        arch_path = os.path.join(package_directory, 'native')
         os.makedirs(arch_path)
         print(f"Created directory '{arch_path}'")
 
@@ -81,7 +82,7 @@ try:
 
         for so in os.listdir(so_core_dir):
             if so.endswith(".so"):
-                so_list.append('onert/' + so)
+                so_list.append('native/' + so)
                 src_path = os.path.join(so_core_dir, so)
                 tgt_path = os.path.join(arch_path, so)
                 shutil.copy(src_path, tgt_path)
@@ -94,7 +95,7 @@ try:
             os.makedirs(so_backend_tgt_dir)
             for so in os.listdir(so_backend_dir):
                 if so.endswith(".so"):
-                    so_list.append('onert/nnfw/backend/' + so)
+                    so_list.append('native/nnfw/backend/' + so)
                     src_path = os.path.join(so_backend_dir, so)
                     tgt_path = os.path.join(so_backend_tgt_dir, so)
                     shutil.copy(src_path, tgt_path)
@@ -107,7 +108,7 @@ try:
             os.makedirs(so_odc_tgt_dir)
             for so in os.listdir(so_odc_dir):
                 if so.endswith(".so"):
-                    so_list.append('onert/nnfw/odc/' + so)
+                    so_list.append('native/nnfw/odc/' + so)
                     src_path = os.path.join(so_odc_dir, so)
                     tgt_path = os.path.join(so_odc_tgt_dir, so)
                     shutil.copy(src_path, tgt_path)
@@ -121,7 +122,7 @@ except Exception as e:
 # copy .so files to architecture directories
 
 setup(
-    name=package_directory,
+    name=package_name,
     version='0.1.0',
     description='nnfw_api binding',
     long_description='It provides nnfw Python api',

--- a/runtime/onert/api/python/package/__init__.py
+++ b/runtime/onert/api/python/package/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ['libnnfw_api_pybind']
-from . import libnnfw_api_pybind
+__all__ = ['infer']
+from . import infer

--- a/runtime/onert/api/python/package/infer.py
+++ b/runtime/onert/api/python/package/infer.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import shutil
 
-from .onert import libnnfw_api_pybind
+from .native import libnnfw_api_pybind
 
 
 def num_elems(tensor_info):
@@ -13,7 +13,7 @@ def num_elems(tensor_info):
     return n
 
 
-class nnfw_session(libnnfw_api_pybind.nnfw_session):
+class session(libnnfw_api_pybind.nnfw_session):
     """Class inherited nnfw_session for easily processing input/output"""
 
     def __init__(self, nnpackage_path, backends="cpu"):

--- a/runtime/onert/sample/minimal-python/src/minimal.py
+++ b/runtime/onert/sample/minimal-python/src/minimal.py
@@ -1,15 +1,11 @@
-from nnfwapi.libnnfw_api_pybind import *
+from onert import infer
 import sys
 
 
-def main(nnpackage_path, backends="cpu", operations=""):
+def main(nnpackage_path, backends="cpu"):
     # Create session and load nnpackage
-    # operations is optional to assign a specific backends to each operation.
     # The default value of backends is "cpu".
-    if operations:
-        session = nnfw_session(nnpackage_path, backends, operations)
-    else:
-        session = nnfw_session(nnpackage_path, backends)
+    session = infer.session(nnpackage_path, backends)
 
     # Prepare input. Here we just allocate dummy input arrays.
     input_size = session.input_size()


### PR DESCRIPTION
- Rename python package: nnfwapi -> onert
- Native library install path: "nnfwapi/onert" -> "nnfw_onert/natvie"
- Rename binding script: "libnnfw_api_pybind.py" -> "infer.py"
- Rename binding session class: "nnfw_session" -> "session"
- Update documentation
- Update example

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>