### PR TITLE
[github] Use cache for android externals

### DIFF
--- a/.github/workflows/run-onert-android-build.yml
+++ b/.github/workflows/run-onert-android-build.yml
@@ -41,6 +41,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Caching externals
+        uses: actions/cache@v4
+        with:
+          path: externals
+          key: external-onert-ndk26
+          restore-keys: |
+            external-onert-ndk
+            external-onert-
+            external-
+
       # numpy: test build
       # scons: arm compute library build
       - name: Install packages


### PR DESCRIPTION
This commit updates android build workflow to use cache for externals directory.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>