### PR TITLE
[onert] Remove Permute IR handling in general backend

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.h
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.h
@@ -64,7 +64,6 @@ private:
   void visit(const ir::operation::OneHot &) override;
   void visit(const ir::operation::Pack &) override;
   void visit(const ir::operation::Pad &) override;
-  void visit(const ir::operation::Permute &) override;
   void visit(const ir::operation::Pool2D &) override;
   void visit(const ir::operation::PReLU &) override;
   void visit(const ir::operation::Reduce &) override;

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -759,41 +759,6 @@ void KernelGenerator::visit(const ir::operation::Pool2D &node)
     ActivationBuilder::generate(activation, ofm_tensor->handle()));
 }
 
-void KernelGenerator::visit(const ir::operation::Permute &node)
-{
-  const auto ofm_idx{node.getOutputs().at(0)};
-  const auto ifm_idx{node.getInputs().at(0)};
-  const auto permute_type = node.getPermuteType();
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx);
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx);
-  const auto rank = _ctx.at(ofm_idx).shape().rank();
-  assert(_ctx.at(ifm_idx).shape().rank() == _ctx.at(ofm_idx).shape().rank());
-
-  std::unique_ptr<::arm_compute::IFunction> fn;
-  arm_compute::PermutationVector pv;
-  if (permute_type == ir::operation::Permute::Type::NCHW_TO_NHWC && rank == 4)
-  {
-    // WHCN -> CWHN
-    pv = arm_compute::PermutationVector{2, 0, 1};
-
-    fn = acl_common::generateLayer<arm_compute::NEPermute>(ifm_tensor->handle(),
-                                                           ofm_tensor->handle(), pv);
-  }
-  else if (permute_type == ir::operation::Permute::Type::NHWC_TO_NCHW && rank == 4)
-  {
-    // CWHN -> WHCN
-    pv = arm_compute::PermutationVector{1, 2, 0};
-
-    fn = acl_common::generateLayer<arm_compute::NEPermute>(ifm_tensor->handle(),
-                                                           ofm_tensor->handle(), pv);
-  }
-  else
-  {
-    fn = acl_common::generateLayer<arm_compute::NECopy>(ifm_tensor->handle(), ofm_tensor->handle());
-  }
-  _return_fn = asAclFunction(std::move(fn));
-}
-
 void KernelGenerator::visit(const ir::operation::PReLU &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};

--- a/runtime/onert/backend/acl_neon/KernelGenerator.h
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.h
@@ -63,7 +63,6 @@ private:
   void visit(const ir::operation::OneHot &) override;
   void visit(const ir::operation::Pack &) override;
   void visit(const ir::operation::Pad &) override;
-  void visit(const ir::operation::Permute &) override;
   void visit(const ir::operation::Pool2D &) override;
   void visit(const ir::operation::PReLU &) override;
   void visit(const ir::operation::Reduce &) override;

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -129,14 +129,10 @@ ir::OperationIndex PermutationInsertionPass::insertPermute(const ir::OperandInde
 
   // Find Permute information
   auto input_backend = operand_li_map.getRawPtr(operand_index)->def_backends().getOnlyElement();
-  auto output_backend = backend;
   const backend::Backend *permute_node_backend = compiler::BackendManager::get().getBuiltin();
   assert(permute_node_backend->config()->id() == onert::backend::builtin::Config::ID);
+  assert(input_backend != backend);
 
-  if (input_backend == output_backend)
-  {
-    permute_node_backend = input_backend;
-  }
   // Update LowerInfo of input operand
   auto operand_lower_info = operand_li_map.getRawPtr(operand_index);
   operand_lower_info->removeUseBackend(backend);


### PR DESCRIPTION
This commit removes Permute IR handling in acl backends. 
This IR is handled on builtin backend only because layout changes in backend is not available feature any more.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/12130 #13494