### PR TITLE
[one-cmds] Set env variables when running sub-command

### DIFF
--- a/compiler/one-cmds/onelib/utils.py
+++ b/compiler/one-cmds/onelib/utils.py
@@ -149,6 +149,12 @@ def parse_cfg(config_path: Union[str, None],
         raise AssertionError('configuration file must have \'' + section_to_parse +
                              '\' section')
 
+    # set environment
+    CFG_ENV_SECTION = 'Environment'
+    if parser.has_section(CFG_ENV_SECTION):
+        for key in parser[CFG_ENV_SECTION]:
+            os.environ[key] = parser[CFG_ENV_SECTION][key]
+
     for key in parser[section_to_parse]:
         if is_accumulated_arg(key, section_to_parse):
             if not is_valid_attr(args, key):

--- a/compiler/one-cmds/tests/one-codegen_012.cfg
+++ b/compiler/one-cmds/tests/one-codegen_012.cfg
@@ -1,0 +1,9 @@
+[Environment]
+SPM_SIZE=256KB
+
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backend=dummyEnv
+command=dummy_env.bin

--- a/compiler/one-cmds/tests/one-codegen_012.test
+++ b/compiler/one-cmds/tests/one-codegen_012.test
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# one-codegen with Environment section
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+outputfile="dummy_env.bin"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummyEnv-compile
+  rm -rf ${outputfile}
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="one-codegen_012.cfg"
+
+rm -rf ${outputfile}
+rm -rf ${filename}.log
+
+# copy dummyEnv-compile to bin folder
+cp dummyEnv-compile ../bin/dummyEnv-compile
+
+# run test
+onecc codegen -C ${configfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+if grep -q "SPM_SIZE=256KB" "${outputfile}"; then
+  echo "${filename_ext} SUCCESS"
+  rm -rf ../bin/dummyEnv-compile
+  rm -rf ${outputfile}
+  exit 0
+fi
+
+trap_err_onexit


### PR DESCRIPTION
This commit sets env variables when running sub-command.

Related: #13588 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>