### PR TITLE
[github] Enable onecc test workflow trigger on push evnet

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -1,6 +1,20 @@
 name: Run ONECC Ubuntu Build
 
 on:
+  push:
+    branches:
+      - master
+      - release/*
+    paths:
+      - '.github/workflows/run-onecc-build.yml'
+      - 'nnas'
+      - 'nncc'
+      - 'compiler/**'
+      - 'infra/cmake/**'
+      - 'infra/nncc/**'
+      - 'nnpackage/schema/**'
+      - 'res/**'
+      - '!**/*.md'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This commit adds the onecc workflow trigger to run on commit push.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>