### PR TITLE
[onert] Use default cpu planner for training

### DIFF
--- a/runtime/onert/backend/train/Backend.h
+++ b/runtime/onert/backend/train/Backend.h
@@ -54,7 +54,7 @@ public:
     const auto &tgraph = *tdata.tgraph;
     auto optimizer = createOptimizer(tdata.optim_info);
     auto tr = std::make_shared<TensorRegistry>();
-    auto tb = std::make_shared<TensorBuilder>(tr, optimizer.get(), "Bump");
+    auto tb = std::make_shared<TensorBuilder>(tr, optimizer.get());
     auto tdata_ptr = std::make_unique<backend::train::TrainableContextData>(std::move(tdata));
     auto context = std::make_unique<train::BackendContext>(this, std::move(tdata_ptr), tr, tb,
                                                            std::move(optimizer));

--- a/runtime/onert/backend/train/MemoryManager.cc
+++ b/runtime/onert/backend/train/MemoryManager.cc
@@ -29,9 +29,8 @@ namespace backend
 namespace train
 {
 
-GradientMemoryManager::GradientMemoryManager(const std::string planner_id,
-                                             uint32_t optim_vars_count)
-  : MemoryManager{planner_id}, _optim_vars_count{optim_vars_count}
+GradientMemoryManager::GradientMemoryManager(uint32_t optim_vars_count)
+  : _optim_vars_count{optim_vars_count}
 {
   // DO NOTHING
 }
@@ -54,12 +53,6 @@ uint8_t *GradientMemoryManager::getOptVarBuffer(const ir::OperandIndex &ind, uin
 }
 
 DisposableMemoryManager::DisposableMemoryManager() : _mem_planner{createMemoryPlanner()}
-{
-  // DO NOTHING
-}
-
-DisposableMemoryManager::DisposableMemoryManager(const std::string planner_id)
-  : _mem_planner{createMemoryPlanner(planner_id)}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/train/MemoryManager.h
+++ b/runtime/onert/backend/train/MemoryManager.h
@@ -33,7 +33,7 @@ using MemoryManager = backend::basic::MemoryManager;
 class GradientMemoryManager : public MemoryManager
 {
 public:
-  GradientMemoryManager(const std::string planner_id, uint32_t optimizer_vars_count);
+  GradientMemoryManager(uint32_t optimizer_vars_count);
   virtual ~GradientMemoryManager() = default;
 
   void allocate(void);
@@ -48,7 +48,6 @@ class DisposableMemoryManager
 {
 public:
   DisposableMemoryManager();
-  DisposableMemoryManager(const std::string planner_id);
 
   void allocate(void);
   uint8_t *getBuffer(const DisposableTensorIndex &ind) const;

--- a/runtime/onert/backend/train/TensorBuilder.cc
+++ b/runtime/onert/backend/train/TensorBuilder.cc
@@ -26,10 +26,8 @@ namespace train
 {
 
 TensorBuilder::TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg,
-                             const exec::train::optimizer::Optimizer *optimizer,
-                             const std::string planner_id)
-  : _tensor_reg{tensor_reg},
-    _tensor_mgr{new TensorManager(tensor_reg, planner_id, optimizer->getVarCount())},
+                             const exec::train::optimizer::Optimizer *optimizer)
+  : _tensor_reg{tensor_reg}, _tensor_mgr{new TensorManager(tensor_reg, optimizer->getVarCount())},
     _optimizer{optimizer}
 {
   /* empty */

--- a/runtime/onert/backend/train/TensorBuilder.h
+++ b/runtime/onert/backend/train/TensorBuilder.h
@@ -36,7 +36,7 @@ class TensorBuilder
 {
 public:
   TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg,
-                const exec::train::optimizer::Optimizer *optimizer, const std::string planner_id);
+                const exec::train::optimizer::Optimizer *optimizer);
 
   /**
    * @brief     Register tensor information to allocate on train backend

--- a/runtime/onert/backend/train/TensorManager.cc
+++ b/runtime/onert/backend/train/TensorManager.cc
@@ -53,13 +53,11 @@ namespace backend
 namespace train
 {
 
-TensorManager::TensorManager(const std::shared_ptr<TensorRegistry> &reg,
-                             const std::string planner_id, uint32_t optim_vars_count)
-  : _nonconst_mgr{new MemoryManager(planner_id)}, _trainable_mgr{new MemoryManager(planner_id)},
-    _back_prop_mgr{new MemoryManager(planner_id)},
-    _gradient_mgr{new GradientMemoryManager(planner_id, optim_vars_count)},
+TensorManager::TensorManager(const std::shared_ptr<TensorRegistry> &reg, uint32_t optim_vars_count)
+  : _nonconst_mgr{new MemoryManager()}, _trainable_mgr{new MemoryManager()},
+    _back_prop_mgr{new MemoryManager()}, _gradient_mgr{new GradientMemoryManager(optim_vars_count)},
     // TODO Find a suitable planner of disposable tensors to reduce peak memory usage
-    _disposable_back_prop_mgr{new DisposableMemoryManager(std::string("WIC"))}, _tensors{reg}
+    _disposable_back_prop_mgr{new DisposableMemoryManager()}, _tensors{reg}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/train/TensorManager.h
+++ b/runtime/onert/backend/train/TensorManager.h
@@ -41,8 +41,7 @@ public:
   static constexpr uint64_t _align = 16;
 
 public:
-  TensorManager(const std::shared_ptr<TensorRegistry> &reg, const std::string planner_id,
-                uint32_t optim_vars_count);
+  TensorManager(const std::shared_ptr<TensorRegistry> &reg, uint32_t optim_vars_count);
   virtual ~TensorManager() = default;
 
   void allocateNonConstTensors();


### PR DESCRIPTION
This commit make train backend use default cpu planner to be configured by user.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>