### PR TITLE
[onert] Fix wrong allocation of optimizer variables

### DIFF
--- a/runtime/onert/backend/train/MemoryManager.cc
+++ b/runtime/onert/backend/train/MemoryManager.cc
@@ -29,13 +29,13 @@ namespace backend
 namespace train
 {
 
-GradientMemoryManager::GradientMemoryManager(uint32_t optim_vars_count)
+TrainableMemoryManager::TrainableMemoryManager(uint32_t optim_vars_count)
   : _optim_vars_count{optim_vars_count}
 {
   // DO NOTHING
 }
 
-void GradientMemoryManager::allocate(void)
+void TrainableMemoryManager::allocate(void)
 {
   _mem_alloc = std::make_shared<basic::Allocator>(_mem_planner->capacity());
   assert(_mem_alloc->base());
@@ -44,7 +44,8 @@ void GradientMemoryManager::allocate(void)
   _var_mem_alloc = std::make_shared<basic::Allocator>(vars_capacity);
 }
 
-uint8_t *GradientMemoryManager::getOptVarBuffer(const ir::OperandIndex &ind, uint32_t pos_var) const
+uint8_t *TrainableMemoryManager::getOptVarBuffer(const ir::OperandIndex &ind,
+                                                 uint32_t pos_var) const
 {
   assert(_mem_planner->memory_plans().find(ind) != _mem_planner->memory_plans().end());
   const auto var_offset = pos_var * _mem_planner->capacity();

--- a/runtime/onert/backend/train/MemoryManager.h
+++ b/runtime/onert/backend/train/MemoryManager.h
@@ -30,11 +30,11 @@ namespace train
 
 using MemoryManager = backend::basic::MemoryManager;
 
-class GradientMemoryManager : public MemoryManager
+class TrainableMemoryManager : public MemoryManager
 {
 public:
-  GradientMemoryManager(uint32_t optimizer_vars_count);
-  virtual ~GradientMemoryManager() = default;
+  TrainableMemoryManager(uint32_t optimizer_vars_count);
+  virtual ~TrainableMemoryManager() = default;
 
   void allocate(void);
   uint8_t *getOptVarBuffer(const ir::OperandIndex &ind, uint32_t pos_var) const;

--- a/runtime/onert/backend/train/TensorManager.cc
+++ b/runtime/onert/backend/train/TensorManager.cc
@@ -54,8 +54,9 @@ namespace train
 {
 
 TensorManager::TensorManager(const std::shared_ptr<TensorRegistry> &reg, uint32_t optim_vars_count)
-  : _nonconst_mgr{new MemoryManager()}, _trainable_mgr{new MemoryManager()},
-    _back_prop_mgr{new MemoryManager()}, _gradient_mgr{new GradientMemoryManager(optim_vars_count)},
+  : _nonconst_mgr{new MemoryManager()},
+    _trainable_mgr{new TrainableMemoryManager(optim_vars_count)},
+    _back_prop_mgr{new MemoryManager()}, _gradient_mgr{new MemoryManager()},
     // TODO Find a suitable planner of disposable tensors to reduce peak memory usage
     _disposable_back_prop_mgr{new DisposableMemoryManager()}, _tensors{reg}
 {
@@ -72,6 +73,19 @@ void TensorManager::allocateTrainableTensors()
 {
   allocateMemory(_trainable_mgr.get(), _tensors->trainable_tensors(),
                  std::string{"     TRAINABLE TENSOR "});
+
+  // Set buffers of optimizer variables
+  // Allocating optimizer variables has been done when calling allocate() of TrainableMemoryManager
+  for (const auto &[index, trainable_tensor] : _tensors->trainable_tensors())
+  {
+    for (uint32_t var_pos = 0; var_pos < trainable_tensor->optVars().size(); ++var_pos)
+    {
+      auto *buffer = _trainable_mgr.get()->getOptVarBuffer(index, var_pos);
+      trainable_tensor->setOptVarBuffer(buffer, var_pos);
+      VERBOSE(TensorManager) << std::string{"     OPTIM_VAR TENSOR "} << index << " : "
+                             << static_cast<void *>(buffer) << std::endl;
+    }
+  }
 }
 
 void TensorManager::allocateBackPropTensors()
@@ -84,21 +98,6 @@ void TensorManager::allocateGradientTensors()
 {
   allocateMemory(_gradient_mgr.get(), _tensors->gradient_tensors(),
                  std::string{"     GRADIENT TENSOR "});
-
-  // Set buffers of optimizer variables
-  // Allocating optimizer variables has been done when calling allocate() of GradientMemoryManager
-  for (const auto &pair : _tensors->gradient_tensors())
-  {
-    const auto &index = pair.first;
-    const auto trainable_tensor = _tensors->trainable_tensors().at(index).get();
-    for (uint32_t var_pos = 0; var_pos < trainable_tensor->optVars().size(); ++var_pos)
-    {
-      auto *buffer = _gradient_mgr.get()->getOptVarBuffer(index, var_pos);
-      trainable_tensor->setOptVarBuffer(buffer, var_pos);
-      VERBOSE(TensorManager) << std::string{"     OPTIM_VAR TENSOR "} << index << " : "
-                             << static_cast<void *>(buffer) << std::endl;
-    }
-  }
 }
 
 void TensorManager::allocateDisposableBackPropTensors()

--- a/runtime/onert/backend/train/TensorManager.h
+++ b/runtime/onert/backend/train/TensorManager.h
@@ -64,9 +64,9 @@ public:
 
 private:
   std::unique_ptr<MemoryManager> _nonconst_mgr;
-  std::unique_ptr<MemoryManager> _trainable_mgr;
+  std::unique_ptr<TrainableMemoryManager> _trainable_mgr;
   std::unique_ptr<MemoryManager> _back_prop_mgr;
-  std::unique_ptr<GradientMemoryManager> _gradient_mgr;
+  std::unique_ptr<MemoryManager> _gradient_mgr;
   std::unique_ptr<DisposableMemoryManager> _disposable_back_prop_mgr;
   const std::shared_ptr<TensorRegistry> _tensors;
 };


### PR DESCRIPTION
This commit moves the memory management of optimizer variables into TrainableMemoryManager. Optimizer variables have the same characteristic as TrainableTensor in that memory must not be released during training. The such fact makes it easier for TrainableMemoryManager, rather than GradientMemoryManager, to manage optimizer variables.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>