### PR TITLE
[luci/pass] new pattern to SubstituteStridedSliceToReshape

### DIFF
--- a/compiler/luci/pass/src/SubstituteStridedSliceToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteStridedSliceToReshapePass.cpp
@@ -131,7 +131,7 @@ bool substitute_strided_slice_to_reshape(luci::CircleStridedSlice *ss_node)
       return false;
 
     auto begin_dim = value_from_circle_const(begin_const, i);
-    if (begin_dim != 0 and begin_mask.test(i) == false)
+    if (begin_dim != 0 and begin_mask.test(i) == false && shrink_axis_mask.test(i) == false)
       return false;
 
     // NOTE:
@@ -139,7 +139,7 @@ bool substitute_strided_slice_to_reshape(luci::CircleStridedSlice *ss_node)
     //    strided_slice.end = [10,20] (larger value than actual dim)
     //    is treated as strided_slice.end = [2,3]
     int64_t end_dim = value_from_circle_const(end_const, i);
-    if (end_dim < input_node->dim(i).value() and end_mask.test(i) == false)
+    if (end_dim < input_node->dim(i).value() and end_mask.test(i) == false && shrink_axis_mask.test(i) == false)
       return false;
 
     int64_t strides_value = value_from_circle_const(strides_const, i);

--- a/compiler/luci/pass/src/SubstituteStridedSliceToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteStridedSliceToReshapePass.cpp
@@ -139,7 +139,8 @@ bool substitute_strided_slice_to_reshape(luci::CircleStridedSlice *ss_node)
     //    strided_slice.end = [10,20] (larger value than actual dim)
     //    is treated as strided_slice.end = [2,3]
     int64_t end_dim = value_from_circle_const(end_const, i);
-    if (end_dim < input_node->dim(i).value() and end_mask.test(i) == false && shrink_axis_mask.test(i) == false)
+    if (end_dim < input_node->dim(i).value() and end_mask.test(i) == false &&
+        shrink_axis_mask.test(i) == false)
       return false;
 
     int64_t strides_value = value_from_circle_const(strides_const, i);

--- a/compiler/luci/pass/src/SubstituteStridedSliceToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteStridedSliceToReshapePass.test.cpp
@@ -211,8 +211,8 @@ TEST_F(SubstituteStridedSliceToReshapeTest, with_large_end_mask)
 TEST_F(SubstituteStridedSliceToReshapeTest, with_wrong_begin_end_mask_with_shrink_axis_mask)
 {
   buildGraph({1, 1, 20}, // input shape
-             {1, 0, 0},  // begin with -1 at 0th dim
-             {0, 1, 20}, // end with 0 at 0th dim
+             {1, 0, 0},  // begin with 1 at 0th dim, which break previous pattern
+             {0, 1, 20}, // end with 0 at 0th dim, which break previous pattern
              {1, 1, 1},  // strides
              0b110,      // begin mask
              0b110,      // end mask

--- a/compiler/luci/pass/src/SubstituteStridedSliceToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteStridedSliceToReshapePass.test.cpp
@@ -208,6 +208,33 @@ TEST_F(SubstituteStridedSliceToReshapeTest, with_large_end_mask)
   ASSERT_EQ(new_shape->at<loco::DataType::S32>(1), 9);
 }
 
+TEST_F(SubstituteStridedSliceToReshapeTest, with_wrong_begin_end_mask_with_shrink_axis_mask)
+{
+  buildGraph({1, 1, 20}, // input shape
+             {1, 0, 0},  // begin with -1 at 0th dim
+             {0, 1, 20}, // end with 0 at 0th dim
+             {1, 1, 1},  // strides
+             0b110,      // begin mask
+             0b110,      // end mask
+             0,          // ellipsis axis mask
+             0,          // new axis mask
+             0b001       // shrink axis mask, 0th dim will be shrunk
+  );
+
+  luci::SubstituteStridedSliceToReshapePass pass;
+  while (pass.run(&g))
+    ;
+
+  auto reshape_node = dynamic_cast<luci::CircleReshape *>(output->from());
+  ASSERT_TRUE(reshape_node != nullptr);
+
+  auto new_shape = loco::must_cast<luci::CircleConst *>(reshape_node->shape());
+  ASSERT_EQ(new_shape->rank(), 1);
+  ASSERT_EQ(new_shape->dim(0).value(), 2);
+  ASSERT_EQ(new_shape->at<loco::DataType::S32>(0), 1);
+  ASSERT_EQ(new_shape->at<loco::DataType::S32>(1), 20);
+}
+
 TEST_F(SubstituteStridedSliceToReshapeTest, not_matching_begin_index_NEG)
 {
   buildGraph({1, 3, 5, 7}, // input shape


### PR DESCRIPTION
This PR covers arbitrary begin/end range with shrink_axis_mask pattern. That is, we ignore 0 for begin and 1 for end condition if shrink_axis_mask is on for that dimension.

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>