### PR TITLE
[onert] Remove layout info in BackendContext

### DIFF
--- a/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
+++ b/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
@@ -120,7 +120,6 @@ protected:
       {
         // These tensors do not exist in any operation (No use and def)
         const auto &info = obj.info();
-        assert(_data.operand_layouts.at(ind) == ir::Layout::NHWC);
         registerTensorInfo(ind, info);
       }
     });

--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -42,8 +42,6 @@ struct ContextData
   std::vector<onert::ir::OperationIndex> op_order;
   /* Operands that are defined by other backends */
   util::Set<ir::OperandIndex> external_operands;
-  /* Operand layout info */
-  ir::OperandIndexMap<ir::Layout> operand_layouts;
   /* Custom kernel builder */
   std::shared_ptr<custom::IKernelBuilder> custom_kernel_builder;
   /* Is linear executor or not */
@@ -64,7 +62,6 @@ public:
   const Backend *backend() const { return _backend; }
   const ir::Graph *graph() const { return _data.graph.get(); }
   const util::Set<ir::OperandIndex> &external_operands() const { return _data.external_operands; }
-  const ir::OperandIndexMap<ir::Layout> &operand_layouts() const { return _data.operand_layouts; }
   const ContextData &data() const { return _data; }
 
   virtual ITensorRegistry *genTensors() = 0;

--- a/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
@@ -61,11 +61,6 @@ template <typename T_BackendContext> void planTensors(const T_BackendContext &ct
     {
       // These tensors do not exist in any  (No use and def)
       const auto &info = obj.info();
-      // NOTE Currently we only support NHWC tensors for cpu-common tensors.
-      //      There is no way to get the layout info from the backend context for now.
-      //      When we support NCHW tensors as well, we also need to change tensor info to be
-      //      permuted shape.
-      assert(ctx.operand_layouts().at(ind) == ir::Layout::NHWC);
       tensor_builder->registerTensorInfo(ind, info);
     }
   });

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -169,9 +169,6 @@ createBackendContexts(compiler::ILoweredGraph &lgraph, bool linear_executor,
       init_context_data(backend);
 
     auto &partial_graph = *context_data_map[backend].graph;
-    auto &operand_layouts = context_data_map[backend].operand_layouts;
-    assert(operand_layouts.find(operand_ind) == operand_layouts.end());
-    operand_layouts[operand_ind] = ir::Layout::NHWC;
 
     // Copy the operand and insert it to the partial graph
     auto new_operand = std::make_unique<ir::Operand>(operand);
@@ -191,7 +188,6 @@ createBackendContexts(compiler::ILoweredGraph &lgraph, bool linear_executor,
 
       auto &partial_graph = *context_data_map[backend].graph;
       auto &external_operands = context_data_map[backend].external_operands;
-      auto &operand_layouts = context_data_map[backend].operand_layouts;
 
       {
         // Add missing operands (externals)
@@ -210,8 +206,6 @@ createBackendContexts(compiler::ILoweredGraph &lgraph, bool linear_executor,
           UNUSED_RELEASE(new_operand_ind);
           assert(new_operand_ind == operand_ind);
 
-          assert(operand_layouts.find(operand_ind) == operand_layouts.end());
-          operand_layouts[operand_ind] = ir::Layout::NHWC;
           external_operands.add(operand_ind);
         }
 
@@ -708,7 +702,6 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
     tdata.tgraph = std::move(tgraph);
     tdata.op_order = std::move(data.op_order);
     tdata.external_operands = std::move(external_operands);
-    tdata.operand_layouts = std::move(data.operand_layouts);
     tdata.custom_kernel_builder = std::move(data.custom_kernel_builder);
     tdata.is_linear_executor = data.is_linear_executor;
     tdata.optim_info = training_info.optimizerInfo();


### PR DESCRIPTION
This commit removes layout info in BackendContext. Layout is always NHWC.
If not, other backend and core assume that layout is NHWC and backend has responsibility for correctness.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/12130 https://github.com/Samsung/ONE/issues/13494