### PR TITLE
[res/tfl_recipes] Add new Net_FullyConnected_Mul

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_FullyConnected_Mul_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_FullyConnected_Mul_003/test.recipe
@@ -14,7 +14,7 @@ operand {
     }
 }
 operand {
-    name: "B"
+    name: "scale"
     type: FLOAT32
     shape { dim: 6 }
     filler {
@@ -50,7 +50,7 @@ operation {
         activation: RELU
     }
     input: "fc_out"
-    input: "B"
+    input: "scale"
     output: "mul_out"
 }
 input: "ifm"

--- a/res/TensorFlowLiteRecipes/Net_FullyConnected_Mul_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_FullyConnected_Mul_003/test.recipe
@@ -1,0 +1,57 @@
+operand {
+    name: "ifm"
+    type: FLOAT32
+    shape { dim: 3 dim: 1 dim: 4 }
+}
+operand {
+    name: "fc_wgt"
+    type: FLOAT32
+    shape { dim: 6 dim: 4 }
+    filler {
+        tag: "gaussian"
+        arg: "0.0"
+        arg: "1.0"
+    }
+}
+operand {
+    name: "B"
+    type: FLOAT32
+    shape { dim: 6 }
+    filler {
+        tag: "gaussian"
+        arg: "0.0"
+        arg: "1.0"
+    }
+}
+operand {
+    name: "fc_out"
+    type: FLOAT32
+    shape: { dim: 3 dim: 1 dim: 6 }
+}
+operand {
+    name: "mul_out"
+    type: FLOAT32
+    shape: { dim: 3 dim: 1 dim: 6 }
+}
+operation {
+    type: "FullyConnected"
+    fullyconnected_options {
+        activation: NONE
+        keep_num_dims: true
+    }
+    input: "ifm"
+    input: "fc_wgt"
+    input: ""
+    output: "fc_out"
+}
+operation {
+    type: "Mul"
+    mul_options {
+        activation: RELU
+    }
+    input: "fc_out"
+    input: "B"
+    output: "mul_out"
+}
+input: "ifm"
+output: "mul_out"

--- a/res/TensorFlowLiteRecipes/Net_FullyConnected_Mul_003/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_FullyConnected_Mul_003/test.rule
@@ -1,0 +1,13 @@
+# This checks if:
+#   Mul(FC(input, weights, _), other)
+# is converted to:
+#   FC(input, Mul(weights, other), _)
+# and then Mul is fused to:
+#   FC(input, weights', _)
+# Here the bias is empty/excluded "_".
+# Thus Mul is only fused with weights.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "NO_MUL"                  $(op_count MUL) '=' 0
+RULE    "FC_EXIST"                $(op_count FULLY_CONNECTED) '=' 1


### PR DESCRIPTION
This commit extends Net_FullyConnectedMul tflite recipes with 'no bias' case.

ONE-DCO-1.0-Signed-off-by: Jan Iwaszkiewicz <j.iwaszkiewi@samsung.com>