### PR TITLE
[onert] Reallocated tensor when size becomes larger

### DIFF
--- a/runtime/onert/core/include/backend/basic/Tensor.h
+++ b/runtime/onert/core/include/backend/basic/Tensor.h
@@ -41,8 +41,8 @@ public:
 
 public:
   Tensor(const ir::OperandInfo &info, DynamicMemoryManager *dynamic_mem_mgr)
-    : IPortableTensor(info), _layout(ir::Layout::NHWC), _buffer(nullptr), _num_references(0),
-      _dynamic_mem_mgr(dynamic_mem_mgr), _allocator(nullptr)
+    : IPortableTensor(info), _layout(ir::Layout::NHWC), _buffer(nullptr), _size(info.total_size()),
+      _num_references(0), _dynamic_mem_mgr(dynamic_mem_mgr), _allocator(nullptr)
   {
     // DO NOTHING
   }
@@ -128,6 +128,7 @@ public:
 protected:
   const ir::Layout _layout;
   uint8_t *_buffer;
+  size_t _size;
   int32_t _num_references;
   DynamicMemoryManager *_dynamic_mem_mgr;
 


### PR DESCRIPTION
This commit updates dynamic allocator usage on basic tensor to reallocate when shape is changed to larger size. 
It will improve performance and reduce memory usage when tensor size is lesser by dynamic shape on inference than prepare phase.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>