### PR TITLE
[circledump] Fix namespace closing comment

### DIFF
--- a/compiler/circledump/include/circledump/Dump.h
+++ b/compiler/circledump/include/circledump/Dump.h
@@ -25,7 +25,8 @@ namespace circledump
 {
 
 void dump_model(std::ostream &os, const circle::Model *model);
-}
+
+} // namespace circledump
 
 std::ostream &operator<<(std::ostream &os, const circle::Model *model);
 


### PR DESCRIPTION
This will fix namespace closing comment and insert empty space like others.
