### PR TITLE
Draft: Add Permute OP for layout and data type conversion

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw.h
+++ b/runtime/onert/api/nnfw/include/nnfw.h
@@ -405,23 +405,6 @@ NNFW_STATUS nnfw_output_size(nnfw_session *session, uint32_t *number);
 NNFW_STATUS nnfw_set_input_layout(nnfw_session *session, uint32_t index, NNFW_LAYOUT layout);
 
 /**
- * @brief Set the type of an input
- *
- * User can call this function to set the type of an input. Then user can pass input data of that
- * type. If it is not called, runtime will infer the type from the model.
- * This function should be called after {@link nnfw_load_model_from_file} and
- * before {@link nnfw_prepare}.
- * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
- *
- * @param[in] session session from input is to be extracted
- * @param[in] index   index of input to be set (0-indexed)
- * @param[in] type    type to set to target input. This can be NNFW_TYPE_FLOAT32 only.
- *
- * @return    @c NNFW_STATUS_NO_ERROR if successful
- */
-NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
-
-/**
  * @brief Set the layout of an output
  *
  * The output that does not call this has NNFW_LAYOUT_NHWC layout.
@@ -435,23 +418,6 @@ NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE
  * @return    @c NNFW_STATUS_NO_ERROR if successful
  */
 NNFW_STATUS nnfw_set_output_layout(nnfw_session *session, uint32_t index, NNFW_LAYOUT layout);
-
-/**
- * @brief Set the type of an output
- *
- * User can call this function to set the type of an output. Then user can pass output data of that
- * type. If it is not called, runtime will output the type from the model.
- * This function should be called after {@link nnfw_load_model_from_file} and
- * before {@link nnfw_prepare}.
- * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
- *
- * @param[in] session session from output is to be extracted
- * @param[in] index   index of output to be set (0-indexed)
- * @param[in] type    type to set to target output. This can be NNFW_TYPE_FLOAT32 only.
- *
- * @return    @c NNFW_STATUS_NO_ERROR if successful
- */
-NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
 
 /**
  * @brief       Get i-th input tensor info

--- a/runtime/onert/api/nnfw/include/nnfw.h
+++ b/runtime/onert/api/nnfw/include/nnfw.h
@@ -332,13 +332,10 @@ NNFW_STATUS nnfw_await(nnfw_session *session);
  * reused for many inferences. \p length must be greater or equal than the operand requires. To
  * specify an optional input, you can either not call this for that input or call this with \p
  * buffer of NULL and \p length of 0.
- * If you set {@link NNFW_TYPE_TENSOR_FLOAT32} type and model has quantized input type on given
- * index, runtime will set quantized data type model input by converting from float buffer data
- * internally.
  *
  * @param[in] session Session to the input is to be set
  * @param[in] index   Index of input to be set (0-indexed)
- * @param[in] type    Type of the input
+ * @param[in] type    Type of the input (deprecated)
  * @param[in] buffer  Raw buffer for input
  * @param[in] length  Size of bytes of input buffer
  *
@@ -354,13 +351,10 @@ NNFW_STATUS nnfw_set_input(nnfw_session *session, uint32_t index, NNFW_TYPE type
  * reused for many inferences. \p length must be greater or equal than the operand requires. An
  * output operand can have unspecified shape and deduced dynamically during the execution. You must
  * provide \p buffer large enough.
- * If you set {@link NNFW_TYPE_TENSOR_FLOAT32} type and model has quantized output type on given
- * index, runtime will set dequantized float buffer data from quantize data type model output
- * internally.
  *
  * @param[in]   session Session from inference output is to be extracted
  * @param[in]   index   Index of output to be set (0-indexed)
- * @param[in]   type    Type of the output
+ * @param[in]   type    Type of the output (deprecated)
  * @param[out]  buffer  Raw buffer for output
  * @param[in]   length  Size of bytes of output buffer
  *
@@ -398,9 +392,11 @@ NNFW_STATUS nnfw_output_size(nnfw_session *session, uint32_t *number);
 /**
  * @brief Set the layout of an input
  *
- * The input that does not call this has NNFW_LAYOUT_NHWC layout
+ * The input that does not call this has NNFW_LAYOUT_NHWC layout.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
  *
- * @param[in] session session from inference input is to be extracted
+ * @param[in] session session from input is to be extracted
  * @param[in] index   index of input to be set (0-indexed)
  * @param[in] layout  layout to set to target input
  *
@@ -409,26 +405,62 @@ NNFW_STATUS nnfw_output_size(nnfw_session *session, uint32_t *number);
 NNFW_STATUS nnfw_set_input_layout(nnfw_session *session, uint32_t index, NNFW_LAYOUT layout);
 
 /**
+ * @brief Set the type of an input
+ *
+ * User can call this function to set the type of an input. Then user can pass input data of that
+ * type. If it is not called, runtime will infer the type from the model.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
+ * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
+ *
+ * @param[in] session session from input is to be extracted
+ * @param[in] index   index of input to be set (0-indexed)
+ * @param[in] type    type to set to target input. This can be NNFW_TYPE_FLOAT32 only.
+ *
+ * @return    @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
+
+/**
  * @brief Set the layout of an output
  *
- * The output that does not call this has NNFW_LAYOUT_NHWC layout
+ * The output that does not call this has NNFW_LAYOUT_NHWC layout.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
  *
- * @param[in] session session from inference output is to be extracted
+ * @param[in] session session from output is to be extracted
  * @param[in] index   index of output to be set (0-indexed)
  * @param[in] layout  layout to set to target output
  *
- * @return NNFW_STATUS_NO_ERROR if successful
+ * @return    @c NNFW_STATUS_NO_ERROR if successful
  */
 NNFW_STATUS nnfw_set_output_layout(nnfw_session *session, uint32_t index, NNFW_LAYOUT layout);
+
+/**
+ * @brief Set the type of an output
+ *
+ * User can call this function to set the type of an output. Then user can pass output data of that
+ * type. If it is not called, runtime will output the type from the model.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
+ * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
+ *
+ * @param[in] session session from output is to be extracted
+ * @param[in] index   index of output to be set (0-indexed)
+ * @param[in] type    type to set to target output. This can be NNFW_TYPE_FLOAT32 only.
+ *
+ * @return    @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
 
 /**
  * @brief       Get i-th input tensor info
  *
  * <p>Before {@link nnfw_prepare} is invoked, this function return tensor info in model,
- * so updated tensor info by {@link nnfw_apply_tensorinfo} is not returned.</p>
+ * so updated tensor info by {@link nnfw_set_input_tensorinfo} is not returned.</p>
  *
  * <p>After {@link nnfw_prepare} is invoked, this function return updated tensor info
- * if tensor info is updated by {@link nnfw_apply_tensorinfo}.</p>
+ * if tensor info is updated by {@link nnfw_set_input_tensorinfo}.</p>
  *
  * @param[in]   session     Session from input information is to be extracted
  * @param[in]   index       Index of input

--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -164,6 +164,40 @@ NNFW_STATUS nnfw_push_pipeline_input(nnfw_session *session, void *inputs, void *
 NNFW_STATUS nnfw_pop_pipeline_output(nnfw_session *session, void *outputs);
 
 /**
+ * @brief Set the type of an input
+ *
+ * User can call this function to set the type of an input. Then user can pass input data of that
+ * type. If it is not called, runtime will infer the type from the model.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
+ * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
+ *
+ * @param[in] session session from input is to be extracted
+ * @param[in] index   index of input to be set (0-indexed)
+ * @param[in] type    type to set to target input. This can be NNFW_TYPE_FLOAT32 only.
+ *
+ * @return    @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
+
+/**
+ * @brief Set the type of an output
+ *
+ * User can call this function to set the type of an output. Then user can pass output data of that
+ * type. If it is not called, runtime will output the type from the model.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
+ * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
+ *
+ * @param[in] session session from output is to be extracted
+ * @param[in] index   index of output to be set (0-indexed)
+ * @param[in] type    type to set to target output. This can be NNFW_TYPE_FLOAT32 only.
+ *
+ * @return    @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
+
+/**
  *  Training C APIs
  *
  * Training APIs are designed to be used in the following order for training

--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -616,24 +616,33 @@ NNFW_STATUS nnfw_odc_delete_minmax_file(nnfw_session *session);
 /**
  * @brief  Run inference with auto compilation
  *
- * <p>This function runs inference with automatic compilation and replaces
- *  the original model with a quantized or compiled model inside.
- * During the inference the minmax statistics is collected and after that quantization is performed.
- * If quantization was successful, try to code generating for target backend, otherwise run original
- float model.
- * If compilation was successful, run compiled model, otherwise run quantized model.
- * On-device compiler (ODC) provides quantization and compilation functionality.
- * Function should be called after model is loaded by {@link nnfw_load_model_from_file},
- * session is prepared for inference by {@link nnfw_prepare}, set input and output buffers
- * by {@link nnfw_set_input} and {@link nnfw_set_output}.
+ * This function runs inference float model with automatic compilation and
+ * replaces the original model with a quantized or compiled model inside.
  *
- * Additionally the following parameters should be set up :
+ * During the inference, the minmax statistics is collected and after that quantization is
+ performed.
+ * If quantization was successful, try to code generating for target backend,
+ * otherwise run original float model.
+ *
+ * If compilation was successful, run compiled model, otherwise run quantized model.
+ *
+ * Auto compilation uses on-device compiler (ODC), and ODC provides
+ * quantization and compilation functionality.
+ * ODC functions should be called after model is loaded by {@link nnfw_load_model_from_file}.
+ * Belows are ODC functions to set parameters :
+ *
  * 1. Quantization type {@link nnfw_set_quantization_type }
- * 2. Quantizated model path {@link  nnfw_set_quantized_model_path }
+ * 2. Quantizated model path {@link nnfw_set_quantized_model_path }
  * 3. Minmax records threshold for quantization {@link nnfw_set_odc_param_minmax_records_count }
  * 3. File with minMax statistics can be removed by {@link nnfw_odc_delete_minmax_file}
- * 4. Compiled model path {@link  nnfw_set_codegen_model_path}
- * </p>
+ * 4. Compiled model path {@link nnfw_set_codegen_model_path}
+ *
+ * Session is prepared for inference by {@link nnfw_prepare}, set input and output float buffers
+ * by {@link nnfw_set_input} and {@link nnfw_set_output}. This function should be called after those
+ * functions.
+ *
+ * After auto compilation, quantized model uses float input/output buffer
+ * and cast them to quantized type in runtime automatically.
  *
  * @param[in] session nnfw_session
  * @param[in] target  Target backend to generate code as in {@link nnfw_codegen}

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -125,10 +125,22 @@ NNFW_STATUS nnfw_set_input_layout(nnfw_session *session, uint32_t index, NNFW_LA
   return session->set_input_layout(index, layout);
 }
 
+NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE type)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_input_type(index, type);
+}
+
 NNFW_STATUS nnfw_set_output_layout(nnfw_session *session, uint32_t index, NNFW_LAYOUT layout)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->set_output_layout(index, layout);
+}
+
+NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYPE type)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_output_type(index, type);
 }
 
 NNFW_STATUS nnfw_input_tensorinfo(nnfw_session *session, uint32_t index,

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -668,7 +668,8 @@ NNFW_STATUS nnfw_session::set_input_type(uint32_t index, NNFW_TYPE type)
       return NNFW_STATUS_ERROR;
     }
 
-    _coptions->input_float.insert(index);
+    _coptions->input_type.insert_or_assign(index,
+                                           onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
   }
   catch (const std::exception &e)
   {
@@ -726,7 +727,8 @@ NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
       return NNFW_STATUS_ERROR;
     }
 
-    _coptions->output_float.insert(index);
+    _coptions->output_type.insert_or_assign(index,
+                                            onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
   }
   catch (const std::exception &e)
   {

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -2278,7 +2278,7 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
       std::vector<const void *> _input_buffers;
       std::vector<void *> _output_buffers;
 
-      // Save Inputs buffers
+      // Save Inputs buffers, set compile option to use float type
       for (size_t input_index = 0; input_index < input_size; input_index++)
       {
         auto io_input_index = onert::ir::IOIndex(input_index);
@@ -2286,6 +2286,8 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         auto input_buffer = _execution->getInputBuffer(io_input_index);
 
         _input_buffers.push_back(input_buffer);
+        _coptions->input_type.insert_or_assign(input_index,
+                                               onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
       }
 
       // Save Outputs buffers
@@ -2297,6 +2299,8 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         auto output_buffer = _execution->getOutputBuffer(io_output_index);
 
         _output_buffers.push_back(output_buffer);
+        _coptions->output_type.insert_or_assign(output_index,
+                                                onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
       }
 
       // Save execution options
@@ -2355,9 +2359,7 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         if (status != NNFW_STATUS_NO_ERROR)
           return status;
 
-        ti.dtype = NNFW_TYPE_TENSOR_FLOAT32;
         auto input_size_in_bytes = getBufSize(&ti);
-
         status = set_input(input_index, ti.dtype, _input_buffers[input_index], input_size_in_bytes);
 
         if (status != NNFW_STATUS_NO_ERROR)
@@ -2373,10 +2375,7 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         if (status != NNFW_STATUS_NO_ERROR)
           return status;
 
-        ti.dtype = NNFW_TYPE_TENSOR_FLOAT32;
-
         uint64_t output_size_in_bytes = getBufSize(&ti);
-
         status =
           set_output(output_index, ti.dtype, _output_buffers[output_index], output_size_in_bytes);
         if (status != NNFW_STATUS_NO_ERROR)

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -641,7 +641,7 @@ NNFW_STATUS nnfw_session::set_input_layout(uint32_t index, NNFW_LAYOUT layout)
     }
 
     // Insert if not exists, otherwise update the value
-    _coptions->input_layout[index] = convertLayout(layout);
+    _coptions->input_layout[onert::ir::IOIndex{index}] = convertLayout(layout);
   }
   catch (const std::exception &e)
   {
@@ -668,7 +668,7 @@ NNFW_STATUS nnfw_session::set_input_type(uint32_t index, NNFW_TYPE type)
       return NNFW_STATUS_ERROR;
     }
 
-    _coptions->input_type.insert_or_assign(index,
+    _coptions->input_type.insert_or_assign(onert::ir::IOIndex{index},
                                            onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
   }
   catch (const std::exception &e)
@@ -700,7 +700,7 @@ NNFW_STATUS nnfw_session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
     }
 
     // Insert if not exists, otherwise update the value
-    _coptions->output_layout[index] = convertLayout(layout);
+    _coptions->output_layout[onert::ir::IOIndex{index}] = convertLayout(layout);
   }
   catch (const std::exception &e)
   {
@@ -727,7 +727,7 @@ NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
       return NNFW_STATUS_ERROR;
     }
 
-    _coptions->output_type.insert_or_assign(index,
+    _coptions->output_type.insert_or_assign(onert::ir::IOIndex{index},
                                             onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
   }
   catch (const std::exception &e)
@@ -2278,29 +2278,25 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
       std::vector<const void *> _input_buffers;
       std::vector<void *> _output_buffers;
 
+      using namespace onert::ir;
       // Save Inputs buffers, set compile option to use float type
-      for (size_t input_index = 0; input_index < input_size; input_index++)
+      for (auto input_index = IOIndex{0}; input_index < IOIndex{input_size}; input_index++)
       {
-        auto io_input_index = onert::ir::IOIndex(input_index);
-        auto input_Shape = _execution->getInputShape(io_input_index);
-        auto input_buffer = _execution->getInputBuffer(io_input_index);
+        auto input_Shape = _execution->getInputShape(input_index);
+        auto input_buffer = _execution->getInputBuffer(input_index);
 
         _input_buffers.push_back(input_buffer);
-        _coptions->input_type.insert_or_assign(input_index,
-                                               onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
+        _coptions->input_type.insert_or_assign(input_index, TypeInfo(DataType::FLOAT32));
       }
 
       // Save Outputs buffers
-      for (size_t output_index = 0; output_index < output_size; output_index++)
+      for (auto output_index = IOIndex{0}; output_index < IOIndex{output_size}; output_index++)
       {
-        auto io_output_index = onert::ir::IOIndex(output_index);
-
-        auto output_Shape = _execution->getOutputShape(io_output_index);
-        auto output_buffer = _execution->getOutputBuffer(io_output_index);
+        auto output_Shape = _execution->getOutputShape(output_index);
+        auto output_buffer = _execution->getOutputBuffer(output_index);
 
         _output_buffers.push_back(output_buffer);
-        _coptions->output_type.insert_or_assign(output_index,
-                                                onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
+        _coptions->output_type.insert_or_assign(output_index, TypeInfo(DataType::FLOAT32));
       }
 
       // Save execution options

--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -119,7 +119,9 @@ public:
   NNFW_STATUS output_size(uint32_t *number);
 
   NNFW_STATUS set_input_layout(uint32_t index, NNFW_LAYOUT layout);
+  NNFW_STATUS set_input_type(uint32_t index, NNFW_TYPE type);
   NNFW_STATUS set_output_layout(uint32_t index, NNFW_LAYOUT layout);
+  NNFW_STATUS set_output_type(uint32_t index, NNFW_TYPE type);
 
   NNFW_STATUS set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti);
 

--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -89,7 +89,7 @@ private:
   {
     INITIAL_STATE,          //< Initial state
     QUANTIZED_MODEL_LOADED, //< Qunatized model is loaded
-    COMPILED_MODEL_LOADED   //< Compiled model is loaded
+    COMPILED_MODEL_LOADED,  //< Compiled model is loaded
   };
 
 public:

--- a/runtime/onert/backend/cpu/SharedMemoryOperands.test.cc
+++ b/runtime/onert/backend/cpu/SharedMemoryOperands.test.cc
@@ -34,7 +34,7 @@ namespace
 {
 void addNotOptimizedNode(Graph *graph, const OperandIndex &input, const OperandIndex &output)
 {
-  graph->addOperation(std::make_unique<operation::Permute>(input, output, PermuteType::COPY));
+  graph->addOperation(std::make_unique<operation::Permute>(input, output, PermuteType::SAME));
 }
 } // namespace
 

--- a/runtime/onert/backend/cpu/SharedMemoryOperands.test.cc
+++ b/runtime/onert/backend/cpu/SharedMemoryOperands.test.cc
@@ -34,7 +34,7 @@ namespace
 {
 void addNotOptimizedNode(Graph *graph, const OperandIndex &input, const OperandIndex &output)
 {
-  graph->addOperation(std::make_unique<operation::Permute>(input, output));
+  graph->addOperation(std::make_unique<operation::Permute>(input, output, PermuteType::COPY));
 }
 } // namespace
 

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -20,6 +20,7 @@
 #include "ir/OpCode.h"
 #include "ir/Index.h"
 #include "ir/Layout.h"
+#include "ir/TypeInfo.h"
 
 #include <memory>
 #include <set>
@@ -67,8 +68,8 @@ struct CompilerOptions
   std::vector<std::string> backend_list;
   std::unordered_map<uint32_t, ir::Layout> input_layout;
   std::unordered_map<uint32_t, ir::Layout> output_layout;
-  std::set<uint32_t> input_float;
-  std::set<uint32_t> output_float;
+  std::unordered_map<uint32_t, ir::TypeInfo> input_type;
+  std::unordered_map<uint32_t, ir::TypeInfo> output_type;
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   int graph_dump_level; //< Graph dump level, values between 0 and 2 are valid

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -19,8 +19,10 @@
 
 #include "ir/OpCode.h"
 #include "ir/Index.h"
+#include "ir/Layout.h"
 
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -63,6 +65,10 @@ struct CompilerOptions
 
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
+  std::unordered_map<uint32_t, ir::Layout> input_layout;
+  std::unordered_map<uint32_t, ir::Layout> output_layout;
+  std::set<uint32_t> input_float;
+  std::set<uint32_t> output_float;
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   int graph_dump_level; //< Graph dump level, values between 0 and 2 are valid

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -66,10 +66,10 @@ struct CompilerOptions
 
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
-  std::unordered_map<uint32_t, ir::Layout> input_layout;
-  std::unordered_map<uint32_t, ir::Layout> output_layout;
-  std::unordered_map<uint32_t, ir::TypeInfo> input_type;
-  std::unordered_map<uint32_t, ir::TypeInfo> output_type;
+  std::unordered_map<ir::IOIndex, ir::Layout> input_layout;
+  std::unordered_map<ir::IOIndex, ir::Layout> output_layout;
+  std::unordered_map<ir::IOIndex, ir::TypeInfo> input_type;
+  std::unordered_map<ir::IOIndex, ir::TypeInfo> output_type;
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   int graph_dump_level; //< Graph dump level, values between 0 and 2 are valid

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -95,30 +95,7 @@ public:
    * @param[in] length  Output data's length
    */
   void setOutput(const ir::IOIndex &index, const ir::Shape &shape, void *buffer, size_t length);
-  /**
-   * @brief     Set input data's data format
-   * @param[in] index   Input index
-   * @param[in] layout  Input data's data format
-   */
-  void setInputLayout(const ir::IOIndex &index, ir::Layout layout);
-  /**
-   * @brief     Set output data's data format
-   * @param[in] index   Output index
-   * @param[in] layout  Output data's data format
-   */
-  void setOutputLayout(const ir::IOIndex &index, ir::Layout layout);
-  /**
-   * @brief     Set input type information
-   * @param[in] index     Input index
-   * @param[in] typeInfo  Input type information
-   */
-  void setInputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo);
-  /**
-   * @brief     Set output type information
-   * @param[in] index     Output index
-   * @param[in] typeInfo  Output type information
-   */
-  void setOutputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo);
+
   /**
    * @brief  Execution
    * @note   It should be called after setting input and output buffer

--- a/runtime/onert/core/include/exec/ExecutionContext.h
+++ b/runtime/onert/core/include/exec/ExecutionContext.h
@@ -32,13 +32,9 @@ struct InputDesc
   ir::OperandInfo info;
   const void *buffer;
   size_t size;
-  ir::Layout layout;
 
   InputDesc(void) = delete;
-  InputDesc(const ir::OperandInfo &info)
-    : info(info), buffer(nullptr), size(0), layout(ir::Layout::NHWC)
-  {
-  }
+  InputDesc(const ir::OperandInfo &info) : info(info), buffer(nullptr), size(0) {}
 };
 
 struct OutputDesc
@@ -46,13 +42,9 @@ struct OutputDesc
   ir::OperandInfo info;
   void *buffer;
   size_t size;
-  ir::Layout layout;
 
   OutputDesc(void) = delete;
-  OutputDesc(const ir::OperandInfo &info)
-    : info(info), buffer(nullptr), size(0), layout(ir::Layout::NHWC)
-  {
-  }
+  OutputDesc(const ir::OperandInfo &info) : info(info), buffer(nullptr), size(0) {}
 };
 
 struct IODescription

--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -101,20 +101,6 @@ struct IExecutor
   virtual const ir::OperandInfo &outputInfo(uint32_t index) const = 0;
 
   /**
-   * @brief     Get input layout at index
-   * @param[in] index Index of input
-   * @return    Input operand layout
-   */
-  virtual ir::Layout inputLayout(uint32_t index) const = 0;
-
-  /**
-   * @brief     Get output layout at index
-   * @param[in] index Index of output
-   * @return    Output operand layout
-   */
-  virtual ir::Layout outputLayout(uint32_t index) const = 0;
-
-  /**
    * @brief     Get output buffer at index
    * @param[in] index Index of output
    * @return    Output buffer

--- a/runtime/onert/core/include/ir/Layout.h
+++ b/runtime/onert/core/include/ir/Layout.h
@@ -31,11 +31,12 @@ enum class Layout
   NCHW
 };
 
+// PermuteType::SAME is used for data forwarding and type conversion
 enum class PermuteType
 {
   NHWC_TO_NCHW,
   NCHW_TO_NHWC,
-  COPY
+  SAME
 };
 
 inline std::string to_string(Layout layout)

--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_IR_SHAPE_H__
 #define __ONERT_IR_SHAPE_H__
 
-#include "ir/Layout.h"
+#include "Layout.h"
 
 #include <cassert>
 #include <cstdint>

--- a/runtime/onert/core/include/ir/operation/Permute.h
+++ b/runtime/onert/core/include/ir/operation/Permute.h
@@ -30,19 +30,19 @@ namespace onert::ir::operation
 
 /**
  * @brief Class to represent Permute operation
- * @note  Permute operation reorders the dimensions of a tensor.
+ * @note  Permute operation reorders the dimensions of a tensor and convert data types if needed
  *
  *        This operation is virtual operation, which is not used on real model, but used internally.
- *        It was introduced to support various model layout (NHWC, NCHW, etc) and backend layout.
- *        But currently, model layout and backend layout are always same as NHWC.
- *        So this operation is used for below cases.
+ *        This operation is used for below cases.
  *        1) Handle model output buffer's special case
  *          1-1) Model output is comes from model constant
  *          1-2) Model output is comes from model input
  *          1-3) Model output shares tensor with other model output(s)
- *        2) Handle shared tensor between different backend
- *        3) Handle when input and/or output layouts are different with model layout
- *        4) Handle when input and/or output data type is different with model data type
+ *        2) Handle when tensor defining backend is different with tensor using backend
+ *        3) Handle when actual input and/or output layouts are different with model layout
+ *           by user setting
+ *        4) Handle when actual input and/or output data type is different with model data type
+ *           by user setting or model connection
  *
  */
 class Permute : public Operation
@@ -52,13 +52,13 @@ public:
   OpCode opcode() const final { return OpCode::Permute; }
 
 public:
-  Permute(const OperandIndex &input, const OperandIndex &output, ir::PermuteType type);
+  Permute(const OperandIndex &input, const OperandIndex &output, PermuteType type);
 
 public:
-  ir::PermuteType getPermuteType() const { return _type; }
+  PermuteType getPermuteType() const { return _type; }
 
 private:
-  ir::PermuteType _type;
+  PermuteType _type;
 };
 
 } // namespace onert::ir::operation

--- a/runtime/onert/core/include/ir/operation/Permute.h
+++ b/runtime/onert/core/include/ir/operation/Permute.h
@@ -18,6 +18,7 @@
 #define __ONERT_IR_OPERATION_PERMUTE_H__
 
 #include "ir/Operation.h"
+#include "ir/Layout.h"
 
 namespace onert::backend
 {
@@ -40,10 +41,9 @@ namespace onert::ir::operation
  *          1-2) Model output is comes from model input
  *          1-3) Model output shares tensor with other model output(s)
  *        2) Handle shared tensor between different backend
+ *        3) Handle when input and/or output layouts are different with model layout
+ *        4) Handle when input and/or output data type is different with model data type
  *
- *        Q) Why name is still 'Permute'?
- *        A) It is handled as copy operation on compile phase,
- *           but it can be permute operation if output buffer layout is changed by API call
  */
 class Permute : public Operation
 {
@@ -52,7 +52,13 @@ public:
   OpCode opcode() const final { return OpCode::Permute; }
 
 public:
-  Permute(const OperandIndex &input, const OperandIndex &output);
+  Permute(const OperandIndex &input, const OperandIndex &output, ir::PermuteType type);
+
+public:
+  ir::PermuteType getPermuteType() const { return _type; }
+
+private:
+  ir::PermuteType _type;
 };
 
 } // namespace onert::ir::operation

--- a/runtime/onert/core/src/backend/builtin/IOTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.cc
@@ -27,8 +27,7 @@ IOTensor::~IOTensor() {}
 
 IOTensor::IOTensor(const ir::OperandInfo &info)
   : IPortableTensor{info}, _tensor{nullptr},
-    _orig{std::make_unique<UserTensor>(info, ir::Layout::NHWC, (uint8_t *)nullptr, 0)},
-    _has_backend_tensor{false}
+    _orig{std::make_unique<UserTensor>(info, (uint8_t *)nullptr, 0)}, _has_backend_tensor{false}
 {
   _tensor = _orig.get();
 }

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -54,7 +54,6 @@ public:
 
 public:
   uint8_t *buffer() const override { return _tensor->buffer(); }
-  ir::Layout layout() const { return _orig->layout(); }
   void set_dynamic() override
   {
     _info.setDynamic();

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -96,11 +96,7 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   // Add PermuteLayer
   std::vector<ITensor *> output_tensors{getTensor(output_index)};
   std::vector<ITensor *> input_tensors{getTensor(input_index)};
-  std::vector<ir::PermuteType> permute_types;
-
-  // Layout in graph is always NHWC, so layout is not changed
-  for (uint32_t i = 0; i < input_tensors.size(); i++)
-    permute_types.emplace_back(ir::PermuteType::COPY);
+  std::vector<ir::PermuteType> permute_types{node.getPermuteType()};
 
   auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, permute_types,
                                                    _external_context);

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -34,20 +34,18 @@ namespace onert::backend::builtin
 class UserTensor : public IPortableTensor
 {
 public:
-  UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
-    : IPortableTensor{info}, _layout{layout}, _buffer{buffer}, _size{size}
+  UserTensor(const ir::OperandInfo &info, uint8_t *buffer, size_t size)
+    : IPortableTensor{info}, _buffer{buffer}, _size{size}
   {
   }
 
 public:
   uint8_t *buffer() const override { return _buffer; }
-  ir::Layout layout() const { return _layout; }
   void set_dynamic() override { _info.setDynamic(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
   bool applyShape(const ir::Shape &) override;
 
 private:
-  ir::Layout _layout;
   uint8_t *_buffer;
   size_t _size;
 };

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
@@ -61,9 +61,16 @@ void PermuteLayer::optimize()
       auto dst = *dst_it;
       src_offsets_it->resize(0);
       dst_offsets_it->resize(0);
+      const auto permute_type = *type_it;
+
+      src_it++;
+      dst_it++;
+      src_offsets_it++;
+      dst_offsets_it++;
+      type_it++;
+
       if (underlying_type(src->data_type()) != underlying_type(dst->data_type()))
         continue;
-      const auto permute_type = *type_it;
 
       // TODO Support different types
       auto fn = [&](backend::ITensor &src_tensor) {
@@ -118,11 +125,6 @@ void PermuteLayer::optimize()
         });
       };
       src->access(fn);
-      src_it++;
-      dst_it++;
-      src_offsets_it++;
-      dst_offsets_it++;
-      type_it++;
     }
   }
 }

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
@@ -78,7 +78,7 @@ void PermuteLayer::optimize()
           // NOTE The buffer of both tensor can be nullptr in this step
           const auto data_size = ir::sizeOfDataType(src_tensor.data_type());
 
-          if (permute_type == ir::PermuteType::COPY)
+          if (permute_type == ir::PermuteType::SAME)
           {
             if ((!src_tensor.has_padding() && !dst_tensor.has_padding()))
             {
@@ -135,7 +135,7 @@ void PermuteLayer::appendPermuteTasks(const ITensor *src_tensor, ITensor *dst_te
 {
   size_t distributed_dim = 0;
   auto src_shape = src_tensor->getShape();
-  if (permute_type == ir::PermuteType::COPY)
+  if (permute_type == ir::PermuteType::SAME)
   {
     for (int i = 1; i < src_shape.rank() - 1; ++i)
     {
@@ -261,7 +261,7 @@ void PermuteLayer::run()
         // If dst is subtensor, we have to use clEnqueueMapBuffer instead of clEnqueueWirteBuffer
         else if (dst->needMemoryMap() && !dst->is_subtensor())
         {
-          if (!src->has_padding() && !dst->has_padding() && permute_type == ir::PermuteType::COPY)
+          if (!src->has_padding() && !dst->has_padding() && permute_type == ir::PermuteType::SAME)
           {
             // This is more effective than multi-threading
             src->access([&](backend::ITensor &) { dst->enqueueWriteBuffer(src->buffer(), false); });
@@ -277,7 +277,7 @@ void PermuteLayer::run()
           }
         }
         else if (src->needMemoryMap() && !src->is_subtensor() && !src->has_padding() &&
-                 !dst->has_padding() && permute_type == ir::PermuteType::COPY)
+                 !dst->has_padding() && permute_type == ir::PermuteType::SAME)
         {
           // This is more effective than multi-threading
           assert(!dst->needMemoryMap());

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
@@ -67,7 +67,7 @@ private:
                       uint32_t dst_start_offset, size_t size)
       : _src_buffer{src_buffer}, _dst_buffer{dst_buffer}, _src_start_offset{src_start_offset},
         _dst_start_offset{dst_start_offset}, _src_strides{0}, _dst_strides{0}, _loop_shape{1},
-        _size{size}, _permute_type{ir::PermuteType::COPY}
+        _size{size}, _permute_type{ir::PermuteType::SAME}
     {
       // DO NOTHING
     }
@@ -83,7 +83,7 @@ private:
         size_t dst_offset = _dst_start_offset;
         assert(static_cast<size_t>(_loop_shape.rank()) == coords.size());
         ir::Coordinates dst_coords = coords;
-        if (_permute_type != ir::PermuteType::COPY && _loop_shape.rank() == 4)
+        if (_permute_type != ir::PermuteType::SAME && _loop_shape.rank() == 4)
         {
           dst_coords = ir::convertCoordinates(coords, _permute_type);
         }

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -81,7 +81,7 @@ void WhileLayer::run()
   std::vector<ir::PermuteType> permute_types;
   // Layout in graph is always NHWC, so layout is not changed
   for (uint32_t i = 0; i < op_outputs.size(); i++)
-    permute_types.emplace_back(ir::PermuteType::COPY);
+    permute_types.emplace_back(ir::PermuteType::SAME);
   // Copying body inputs to outputs when the loop body is never executed
   if (!getResultCond(cond_output_tensor.get()))
   {

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -55,16 +55,12 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
 
   std::vector<ITensor *> output_back_prop_tensors;
   std::vector<ITensor *> input_back_prop_tensors;
-  std::vector<ir::PermuteType> permute_types;
+  std::vector<ir::PermuteType> permute_types{node.getPermuteType()};
 
   auto input_back_prop_tensor = getBackPropTensor(input_index);
   auto output_back_prop_tensor = getBackPropTensor(output_index);
   output_back_prop_tensors.emplace_back(output_back_prop_tensor);
   input_back_prop_tensors.emplace_back(input_back_prop_tensor);
-
-  // Layout in graph is always NHWC, so layout is not changed
-  for (uint32_t i = 0; i < input_tensors.size(); i++)
-    permute_types.emplace_back(ir::PermuteType::COPY);
 
   // NOTE The output buffers of IOTensors are not essential for training. If there
   //      is no output buffer provided by the user, permute is not performed.

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -22,6 +22,7 @@
 #include "pass/ConstantOutputPass.h"
 #include "pass/OddOutputPass.h"
 #include "pass/PassRunner.h"
+#include "pass/PermutationIOPass.h"
 #include "pass/UnusedOperandEliminationPass.h"
 #include "../dumper/dot/DotDumper.h"
 #include "../exec/SingleModelExecutors.h"
@@ -85,6 +86,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
     pass::PassRunner{}
       .append(std::make_unique<pass::ConstantOutputPass>(subg))
       .append(std::make_unique<pass::OddOutputPass>(subg))
+      .append(std::make_unique<pass::PermutationIOPass>(subg, *_options))
       .run();
 
     // Optimizations

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -23,6 +23,7 @@
 #include "pass/PassRunner.h"
 #include "pass/PermutationEliminationPass.h"
 #include "pass/PermutationInsertionPass.h"
+#include "pass/PermutationIOPass.h"
 #include "../dumper/text/GraphDumper.h"
 #include "../ir/verifier/Verifier.h"
 
@@ -88,6 +89,7 @@ void LoweredGraph::lowerGraph(const CompilerOptions &options)
     .append(std::make_unique<pass::ConstantInsertionPass>(*this))
     .append(std::make_unique<pass::ConstantLoweringPass>(*this))
     .append(std::make_unique<pass::PermutationInsertionPass>(*this))
+    .append(std::make_unique<pass::PermutationIOPass>(*this, options))
     .run();
 
   // Optimization passes (optional)

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -23,7 +23,6 @@
 #include "pass/PassRunner.h"
 #include "pass/PermutationEliminationPass.h"
 #include "pass/PermutationInsertionPass.h"
-#include "pass/PermutationIOPass.h"
 #include "../dumper/text/GraphDumper.h"
 #include "../ir/verifier/Verifier.h"
 
@@ -89,7 +88,6 @@ void LoweredGraph::lowerGraph(const CompilerOptions &options)
     .append(std::make_unique<pass::ConstantInsertionPass>(*this))
     .append(std::make_unique<pass::ConstantLoweringPass>(*this))
     .append(std::make_unique<pass::PermutationInsertionPass>(*this))
-    .append(std::make_unique<pass::PermutationIOPass>(*this, options))
     .run();
 
   // Optimization passes (optional)

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -164,7 +164,7 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
       dot_dumper.dump(subg,
                       nnfw::misc::str("before_lower_model-", i, "-subg-", subg_index.value()));
       // Lower: Assign backend
-      model_options[model_index] = std::move(optionForSingleModel(model_index));
+      model_options[model_index] = optionForSingleModel(model_index);
       lowered_subgs[model_index][subg_index] =
         std::make_unique<compiler::LoweredGraph>(subg, model_options[model_index]);
       // Set tracing_ctx for copied graph

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -53,30 +53,30 @@ CompilerOptions MultiModelCompiler::optionForSingleModel(const ir::ModelIndex &m
 
   for (const auto &[index, layout] : _options->input_layout)
   {
-    const auto &io_desc = _nnpkg->input(index);
+    const auto &io_desc = _nnpkg->input(index.value());
     if (std::get<ir::ModelIndex>(io_desc) == model_index)
-      opts.input_layout.insert_or_assign(std::get<ir::IOIndex>(io_desc).value(), layout);
+      opts.input_layout.insert_or_assign(std::get<ir::IOIndex>(io_desc), layout);
   }
 
   for (const auto &[index, layout] : _options->output_layout)
   {
-    const auto &io_desc = _nnpkg->output(index);
+    const auto &io_desc = _nnpkg->output(index.value());
     if (std::get<ir::ModelIndex>(io_desc) == model_index)
-      opts.output_layout.insert_or_assign(std::get<ir::IOIndex>(io_desc).value(), layout);
+      opts.output_layout.insert_or_assign(std::get<ir::IOIndex>(io_desc), layout);
   }
 
   for (const auto &[index, type] : _options->input_type)
   {
-    const auto &io_desc = _nnpkg->input(index);
+    const auto &io_desc = _nnpkg->input(index.value());
     if (std::get<ir::ModelIndex>(io_desc) == model_index)
-      opts.input_type.insert_or_assign(std::get<ir::IOIndex>(io_desc).value(), type);
+      opts.input_type.insert_or_assign(std::get<ir::IOIndex>(io_desc), type);
   }
 
   for (const auto &[index, type] : _options->output_type)
   {
-    const auto &io_desc = _nnpkg->output(index);
+    const auto &io_desc = _nnpkg->output(index.value());
     if (std::get<ir::ModelIndex>(io_desc) == model_index)
-      opts.output_type.insert_or_assign(std::get<ir::IOIndex>(io_desc).value(), type);
+      opts.output_type.insert_or_assign(std::get<ir::IOIndex>(io_desc), type);
   }
 
   return opts;

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.h
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.h
@@ -56,6 +56,9 @@ public:
   std::shared_ptr<CompilerArtifact> compile(void);
 
 private:
+  CompilerOptions optionForSingleModel(const ir::ModelIndex &model_index);
+
+private:
   std::shared_ptr<ir::NNPkg> _nnpkg;
   CompilerOptions *_options;
 };

--- a/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
@@ -37,7 +37,7 @@ void ConstantOutputPass::callback(const ir::OperandIndex &ind, ir::Operand &obj)
   obj.info().setAsNonConst();
 
   using ir::operation::Permute;
-  auto permute_obj = std::make_unique<Permute>(permute_input_ind, ind, ir::PermuteType::COPY);
+  auto permute_obj = std::make_unique<Permute>(permute_input_ind, ind, ir::PermuteType::SAME);
   auto permute_ind = _graph.operations().push(std::move(permute_obj));
 
   permute_input_obj.insertUse(permute_ind);

--- a/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
@@ -37,7 +37,7 @@ void ConstantOutputPass::callback(const ir::OperandIndex &ind, ir::Operand &obj)
   obj.info().setAsNonConst();
 
   using ir::operation::Permute;
-  auto permute_obj = std::make_unique<Permute>(permute_input_ind, ind);
+  auto permute_obj = std::make_unique<Permute>(permute_input_ind, ind, ir::PermuteType::COPY);
   auto permute_ind = _graph.operations().push(std::move(permute_obj));
 
   permute_input_obj.insertUse(permute_ind);

--- a/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
@@ -65,7 +65,7 @@ ir::OperandIndex OddOutputPass::insertPermute(ir::OperandIndex ind)
   auto &output_obj = _graph.operands().at(output_ind);
 
   using ir::operation::Permute;
-  auto permute_obj = std::make_unique<Permute>(ind, output_ind);
+  auto permute_obj = std::make_unique<Permute>(ind, output_ind, ir::PermuteType::COPY);
   auto permute_ind = _graph.operations().push(std::move(permute_obj));
 
   output_obj.setDef(permute_ind);

--- a/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
@@ -65,7 +65,7 @@ ir::OperandIndex OddOutputPass::insertPermute(ir::OperandIndex ind)
   auto &output_obj = _graph.operands().at(output_ind);
 
   using ir::operation::Permute;
-  auto permute_obj = std::make_unique<Permute>(ind, output_ind, ir::PermuteType::COPY);
+  auto permute_obj = std::make_unique<Permute>(ind, output_ind, ir::PermuteType::SAME);
   auto permute_ind = _graph.operations().push(std::move(permute_obj));
 
   output_obj.setDef(permute_ind);

--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
@@ -35,7 +35,7 @@ void PermutationEliminationPass::visit(const ir::operation::Permute &node)
   auto out_operand = node.getOutputs().at(0);
 
   // If permutation type is not COPY, we don't need to do anything here.
-  if (node.getPermuteType() != ir::PermuteType::COPY)
+  if (node.getPermuteType() != ir::PermuteType::SAME)
     return;
 
   // Check if the input and output are the same type

--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
@@ -34,6 +34,14 @@ void PermutationEliminationPass::visit(const ir::operation::Permute &node)
   auto in_operand = node.getInputs().at(0);
   auto out_operand = node.getOutputs().at(0);
 
+  // If permutation type is not COPY, we don't need to do anything here.
+  if (node.getPermuteType() != ir::PermuteType::COPY)
+    return;
+
+  // Check if the input and output are the same type
+  if (_graph.operands().at(in_operand).typeInfo() != _graph.operands().at(out_operand).typeInfo())
+    return;
+
   // Check if two tensors are both portable if not, we can't eliminate the node
   {
     auto &operand_li_map = _lowered_graph.lower_info().operand;

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
@@ -92,15 +92,6 @@ void PermutationIOPass::insertInputPermute(const ir::OperandIndex &index, const 
   new_input.insertUse(node_index);
   _graph.operands().at(index).setDef(node_index);
 
-  // Update LowerInfo
-  const backend::Backend *builtin_backend = compiler::BackendManager::get().getBuiltin();
-  auto input_operand_li = std::make_unique<compiler::OperandLowerInfo>();
-  input_operand_li->addDefBackend(builtin_backend);
-  input_operand_li->addUseBackend(builtin_backend);
-  auto &lower_info = _lowered_graph.lower_info();
-  lower_info.operand.set(input_operand_index, std::move(input_operand_li));
-  lower_info.operation.emplace(node_index, builtin_backend);
-
   VERBOSE(PermuteIOPass) << "Permute Op inserted for a input, node index : " << node_index
                          << std::endl;
   VERBOSE(PermuteIOPass) << "  - Input (inserted) Operand : " << input_operand_index << std::endl;
@@ -136,15 +127,6 @@ void PermutationIOPass::insertOutputPermute(const ir::OperandIndex &index, const
   new_output.setDef(node_index);
   assert(_graph.operands().at(index).getUses().size() == 0);
   origin_operand.insertUse(node_index);
-
-  // Update LowerInfo
-  const backend::Backend *builtin_backend = compiler::BackendManager::get().getBuiltin();
-  auto input_operand_li = std::make_unique<compiler::OperandLowerInfo>();
-  input_operand_li->addDefBackend(builtin_backend);
-  input_operand_li->addUseBackend(builtin_backend);
-  auto &lower_info = _lowered_graph.lower_info();
-  lower_info.operand.set(output_operand_index, std::move(input_operand_li));
-  lower_info.operation.emplace(node_index, builtin_backend);
 
   VERBOSE(PermuteIOPass) << "Permute Op inserted for a output, node index : " << node_index
                          << std::endl;

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
@@ -82,7 +82,7 @@ void PermutationIOPass::insertInputPermute(const ir::OperandIndex &index, const 
   // Update graph operation
   using Permute = ir::operation::Permute;
   auto permute_type =
-    from_layout == ir::Layout::NCHW ? ir::PermuteType::NCHW_TO_NHWC : ir::PermuteType::COPY;
+    from_layout == ir::Layout::NCHW ? ir::PermuteType::NCHW_TO_NHWC : ir::PermuteType::SAME;
   auto permute_node = std::make_unique<Permute>(input_operand_index, index, permute_type);
   auto node_index = _graph.operations().push(std::move(permute_node));
 
@@ -127,7 +127,7 @@ void PermutationIOPass::insertOutputPermute(const ir::OperandIndex &index, const
   // Update graph operation
   using Permute = ir::operation::Permute;
   auto permute_type =
-    to_layout == ir::Layout::NCHW ? ir::PermuteType::NHWC_TO_NCHW : ir::PermuteType::COPY;
+    to_layout == ir::Layout::NCHW ? ir::PermuteType::NHWC_TO_NCHW : ir::PermuteType::SAME;
   auto permute_node = std::make_unique<Permute>(index, output_operand_index, permute_type);
   auto node_index = _graph.operations().push(std::move(permute_node));
 

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PermutationIOPass.h"
+
+#include "compiler/BackendManager.h"
+#include "util/Utils.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace pass
+{
+
+void PermutationIOPass::run()
+{
+  if (_options.input_layout.size() == 0 && _options.output_layout.size() == 0 &&
+      _options.input_float.size() == 0 && _options.output_float.size() == 0)
+    return;
+
+  for (uint32_t i = 0; i < _graph.getInputs().size(); i++)
+  {
+    if (_options.input_layout.count(i) == 0 && _options.input_float.count(i) == 0)
+      continue;
+
+    const auto index = _graph.getInputs().at(i);
+    const bool use_float = _options.input_float.count(i) > 0;
+    const auto layout =
+      _options.input_layout.count(i) > 0 ? _options.input_layout.at(i) : ir::Layout::NHWC;
+
+    insertInputPermute(index, use_float, layout);
+  }
+
+  for (uint32_t i = 0; i < _graph.getOutputs().size(); i++)
+  {
+    if (_options.input_layout.count(i) == 0 && _options.input_float.count(i) == 0)
+      continue;
+
+    const auto index = _graph.getOutputs().at(i);
+    const bool use_float = _options.output_float.count(i) > 0;
+    const auto layout =
+      _options.output_layout.count(i) > 0 ? _options.output_layout.at(i) : ir::Layout::NHWC;
+
+    insertOutputPermute(index, use_float, layout);
+  }
+}
+
+void PermutationIOPass::insertInputPermute(const ir::OperandIndex &index, const bool use_float,
+                                           const ir::Layout &from_layout)
+{
+  assert(from_layout == ir::Layout::NCHW || from_layout == ir::Layout::NHWC);
+  const auto &origin_operand = _graph.operands().at(index);
+  if (origin_operand.typeInfo().type() == ir::DataType::FLOAT32 && from_layout == ir::Layout::NHWC)
+    return;
+
+  // Update graph operand
+  auto input_typeinfo = use_float ? ir::TypeInfo{ir::DataType::FLOAT32} : origin_operand.typeInfo();
+  auto input_shape = from_layout == ir::Layout::NCHW
+                       ? ir::convertShape(origin_operand.shape(), ir::PermuteType::NHWC_TO_NCHW)
+                       : origin_operand.shape();
+  auto input_operand_index = _graph.addOperand(input_shape, input_typeinfo);
+  _graph.getInputs().replace(index, input_operand_index);
+
+  // Update graph operation
+  using Permute = ir::operation::Permute;
+  auto permute_type =
+    from_layout == ir::Layout::NCHW ? ir::PermuteType::NCHW_TO_NHWC : ir::PermuteType::COPY;
+  auto permute_node = std::make_unique<Permute>(input_operand_index, index, permute_type);
+  auto node_index = _graph.operations().push(std::move(permute_node));
+
+  // Update use/def info
+  auto &new_input = _graph.operands().at(input_operand_index);
+  new_input.setDef(origin_operand.getDef());
+  new_input.insertUse(node_index);
+  _graph.operands().at(index).setDef(node_index);
+
+  // Update LowerInfo
+  const backend::Backend *builtin_backend = compiler::BackendManager::get().getBuiltin();
+  auto input_operand_li = std::make_unique<compiler::OperandLowerInfo>();
+  input_operand_li->addDefBackend(builtin_backend);
+  input_operand_li->addUseBackend(builtin_backend);
+  auto &lower_info = _lowered_graph.lower_info();
+  lower_info.operand.set(input_operand_index, std::move(input_operand_li));
+  lower_info.operation.emplace(node_index, builtin_backend);
+
+  VERBOSE(PermuteIOPass) << "Permute Op inserted for a input, node index : " << node_index
+                         << std::endl;
+  VERBOSE(PermuteIOPass) << "  - Input (inserted) Operand : " << input_operand_index << std::endl;
+  VERBOSE(PermuteIOPass) << "  - Output(original) Operand : " << index << std::endl;
+}
+
+void PermutationIOPass::insertOutputPermute(const ir::OperandIndex &index, const bool use_float,
+                                            const ir::Layout &to_layout)
+{
+  assert(to_layout == ir::Layout::NCHW || to_layout == ir::Layout::NHWC);
+  auto &origin_operand = _graph.operands().at(index);
+  if (origin_operand.typeInfo().type() == ir::DataType::FLOAT32 && to_layout == ir::Layout::NHWC)
+    return;
+
+  // Update graph operand
+  auto output_typeinfo =
+    use_float ? ir::TypeInfo{ir::DataType::FLOAT32} : origin_operand.typeInfo();
+  auto output_shape = to_layout == ir::Layout::NCHW
+                        ? ir::convertShape(origin_operand.shape(), ir::PermuteType::NHWC_TO_NCHW)
+                        : origin_operand.shape();
+  auto output_operand_index = _graph.addOperand(output_shape, output_typeinfo);
+  _graph.getOutputs().replace(index, output_operand_index);
+
+  // Update graph operation
+  using Permute = ir::operation::Permute;
+  auto permute_type =
+    to_layout == ir::Layout::NCHW ? ir::PermuteType::NHWC_TO_NCHW : ir::PermuteType::COPY;
+  auto permute_node = std::make_unique<Permute>(index, output_operand_index, permute_type);
+  auto node_index = _graph.operations().push(std::move(permute_node));
+
+  // Update use/def info
+  auto &new_output = _graph.operands().at(output_operand_index);
+  new_output.setDef(node_index);
+  assert(_graph.operands().at(index).getUses().size() == 0);
+  origin_operand.insertUse(node_index);
+
+  // Update LowerInfo
+  const backend::Backend *builtin_backend = compiler::BackendManager::get().getBuiltin();
+  auto input_operand_li = std::make_unique<compiler::OperandLowerInfo>();
+  input_operand_li->addDefBackend(builtin_backend);
+  input_operand_li->addUseBackend(builtin_backend);
+  auto &lower_info = _lowered_graph.lower_info();
+  lower_info.operand.set(output_operand_index, std::move(input_operand_li));
+  lower_info.operation.emplace(node_index, builtin_backend);
+
+  VERBOSE(PermuteIOPass) << "Permute Op inserted for a output, node index : " << node_index
+                         << std::endl;
+  VERBOSE(PermuteIOPass) << "  - Input (original) Operand : " << index << std::endl;
+  VERBOSE(PermuteIOPass) << "  - Output(inserted) Operand : " << output_operand_index << std::endl;
+}
+
+} // namespace pass
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
@@ -33,7 +33,7 @@ void PermutationIOPass::run()
       _options.input_type.size() == 0 && _options.output_type.size() == 0)
     return;
 
-  for (uint32_t i = 0; i < _graph.getInputs().size(); i++)
+  for (auto i = ir::IOIndex{0}; i < ir::IOIndex{_graph.getInputs().size()}; i++)
   {
     if (_options.input_layout.count(i) == 0 && _options.input_type.count(i) == 0)
       continue;
@@ -47,7 +47,7 @@ void PermutationIOPass::run()
     insertInputPermute(index, type, layout);
   }
 
-  for (uint32_t i = 0; i < _graph.getOutputs().size(); i++)
+  for (auto i = ir::IOIndex{0}; i < ir::IOIndex{_graph.getOutputs().size()}; i++)
   {
     if (_options.output_layout.count(i) == 0 && _options.output_type.count(i) == 0)
       continue;

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.h
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.h
@@ -41,9 +41,9 @@ public:
   void run() override;
 
 private:
-  void insertInputPermute(const ir::OperandIndex &index, const bool use_float,
+  void insertInputPermute(const ir::OperandIndex &index, const ir::TypeInfo &type,
                           const ir::Layout &from_layout);
-  void insertOutputPermute(const ir::OperandIndex &index, const bool use_float,
+  void insertOutputPermute(const ir::OperandIndex &index, const ir::TypeInfo &type,
                            const ir::Layout &to_layout);
 
 private:

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.h
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.h
@@ -30,9 +30,10 @@ namespace pass
 
 class PermutationIOPass : public Pass
 {
+
 public:
-  PermutationIOPass(ILoweredGraph &lowered_graph, const CompilerOptions &options)
-    : Pass{lowered_graph.graph()}, _lowered_graph(lowered_graph), _options(options)
+  PermutationIOPass(ir::Graph &graph, const CompilerOptions &options)
+    : Pass(graph), _options(options)
   {
   }
 
@@ -47,7 +48,6 @@ private:
                            const ir::Layout &to_layout);
 
 private:
-  compiler::ILoweredGraph &_lowered_graph;
   const compiler::CompilerOptions &_options;
 };
 

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.h
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_PASS_PERMUTATION_IO_PASS_H__
+#define __ONERT_COMPILER_PASS_PERMUTATION_IO_PASS_H__
+
+#include "Pass.h"
+#include "compiler/ILoweredGraph.h"
+#include "compiler/CompilerOptions.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace pass
+{
+
+class PermutationIOPass : public Pass
+{
+public:
+  PermutationIOPass(ILoweredGraph &lowered_graph, const CompilerOptions &options)
+    : Pass{lowered_graph.graph()}, _lowered_graph(lowered_graph), _options(options)
+  {
+  }
+
+public:
+  std::string id() override { return "PermutationIOPass"; }
+  void run() override;
+
+private:
+  void insertInputPermute(const ir::OperandIndex &index, const bool use_float,
+                          const ir::Layout &from_layout);
+  void insertOutputPermute(const ir::OperandIndex &index, const bool use_float,
+                           const ir::Layout &to_layout);
+
+private:
+  compiler::ILoweredGraph &_lowered_graph;
+  const compiler::CompilerOptions &_options;
+};
+
+} // namespace pass
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_PASS_PERMUTATION_INSERTION_PASS_H__

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -146,7 +146,8 @@ ir::OperationIndex PermutationInsertionPass::insertPermute(const ir::OperandInde
 
   // Insert permute operation to the graph
   using Permute = ir::operation::Permute;
-  auto insert_node = std::make_unique<Permute>(operand_index, out_operand_index);
+  auto insert_node =
+    std::make_unique<Permute>(operand_index, out_operand_index, ir::PermuteType::COPY);
 
   auto node_index = _graph.operations().push(std::move(insert_node));
 

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -147,7 +147,7 @@ ir::OperationIndex PermutationInsertionPass::insertPermute(const ir::OperandInde
   // Insert permute operation to the graph
   using Permute = ir::operation::Permute;
   auto insert_node =
-    std::make_unique<Permute>(operand_index, out_operand_index, ir::PermuteType::COPY);
+    std::make_unique<Permute>(operand_index, out_operand_index, ir::PermuteType::SAME);
 
   auto node_index = _graph.operations().push(std::move(insert_node));
 

--- a/runtime/onert/core/src/exec/EdgeTensor.h
+++ b/runtime/onert/core/src/exec/EdgeTensor.h
@@ -27,14 +27,12 @@ namespace onert::exec
 class EdgeTensor : public backend::IPortableTensor
 {
 public:
-  EdgeTensor(const ir::OperandInfo &info, ir::Layout layout)
-    : IPortableTensor(info), _layout{layout}, _buffer{nullptr}, _ref_count{0}
+  EdgeTensor(const ir::OperandInfo &info) : IPortableTensor(info), _buffer{nullptr}, _ref_count{0}
   {
   }
   ~EdgeTensor() = default;
 
   uint8_t *buffer() const override { return _buffer.get(); }
-  ir::Layout layout() const { return _layout; }
   void set_dynamic() override { _info.setDynamic(); }
   bool applyShape(const ir::Shape &new_shape) override;
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
@@ -59,7 +57,6 @@ public:
   }
 
 private:
-  ir::Layout _layout;
   std::unique_ptr<uint8_t[]> _buffer;
   int32_t _ref_count;
 };

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -107,28 +107,6 @@ void Execution::setOutput(const ir::IOIndex &index, const ir::Shape &shape, void
   setOutput(index, buffer, length);
 }
 
-void Execution::setInputLayout(const ir::IOIndex &index, ir::Layout layout)
-{
-  _ctx.desc.inputs.at(index.value())->layout = layout;
-}
-
-void Execution::setOutputLayout(const ir::IOIndex &index, ir::Layout layout)
-{
-  _ctx.desc.outputs.at(index.value())->layout = layout;
-}
-
-void Execution::setInputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo)
-{
-  _ctx.desc.inputs.at(index.value())->info.typeInfo(typeInfo);
-  _ctx.shape_updated = true;
-}
-
-void Execution::setOutputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo)
-{
-  _ctx.desc.outputs.at(index.value())->info.typeInfo(typeInfo);
-  _ctx.shape_updated = true;
-}
-
 void Execution::execute()
 {
   VERBOSE(Execution) << "Start execution" << std::endl;

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -515,18 +515,20 @@ TEST(ExecInstance, quantModel_floatIO)
 {
   auto mockup = MockUpModel();
   auto compile_option = onert::compiler::CompilerOptions::fromGlobalConfig();
-  compile_option->input_type.insert_or_assign(0, onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
-  compile_option->input_type.insert_or_assign(1, onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
-  compile_option->output_type.insert_or_assign(0,
+  auto input1 = IOIndex{0};
+  auto input2 = IOIndex{1};
+  auto output = IOIndex{0};
+
+  compile_option->input_type.insert_or_assign(input1,
+                                              onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
+  compile_option->input_type.insert_or_assign(input2,
+                                              onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
+  compile_option->output_type.insert_or_assign(output,
                                                onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
   auto artifact = onert::compiler::Compiler{mockup.model, compile_option.get()}.compile();
 
   auto graph = mockup.graph;
   auto executors = artifact->_executors;
-
-  auto input1 = IOIndex{0};
-  auto input2 = IOIndex{1};
-  auto output = IOIndex{0};
 
   const float input1_buffer[4] = {1, 0, -1, -2};
   const float input2_buffer[4] = {1, -3, 2, -4};
@@ -786,21 +788,20 @@ TEST(ExecInstance, multi_model_dequant_input_quant_output)
 {
   auto mockup = MockUpMultiModel();
   auto compile_option = onert::compiler::CompilerOptions::fromGlobalConfig();
+  auto input1 = IOIndex{0};
+  auto input2 = IOIndex{1};
+  auto output = IOIndex{0};
 
   float scale = 0.1;
   int32_t zero_point = 128;
   onert::ir::TypeInfo type_info{onert::ir::DataType::QUANT_UINT8_ASYMM, scale, zero_point};
-  compile_option->input_type.insert_or_assign(0, type_info);
-  compile_option->input_type.insert_or_assign(1, type_info);
-  compile_option->output_type.insert_or_assign(0, type_info);
+  compile_option->input_type.insert_or_assign(input1, type_info);
+  compile_option->input_type.insert_or_assign(input2, type_info);
+  compile_option->output_type.insert_or_assign(output, type_info);
   auto compiler =
     onert::compiler::CompilerFactory::get().create(mockup.nnpkg, compile_option.get());
   auto artifact = compiler->compile();
   auto executors = artifact->_executors;
-
-  auto input1 = IOIndex{0};
-  auto input2 = IOIndex{1};
-  auto output = IOIndex{0};
 
   const uint8_t input1_buffer[4] = {138, 128, 118, 108}; // {1, 0, -1, -2}
   const uint8_t input2_buffer[4] = {138, 98, 148, 88};   // {1, -3, 2, -4}

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -69,13 +69,6 @@ public:
     return _output_tensors[index]->get_info();
   }
 
-  ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
-
-  ir::Layout outputLayout(uint32_t index) const override
-  {
-    return _output_tensors[index]->layout();
-  }
-
   const uint8_t *outputBuffer(uint32_t index) const final
   {
     return _output_tensors[index]->buffer();

--- a/runtime/onert/core/src/exec/IPermuteFunction.cc
+++ b/runtime/onert/core/src/exec/IPermuteFunction.cc
@@ -58,7 +58,7 @@ void elementwiseQuantize(const backend::ITensor *src_tensor, backend::ITensor *d
   int max_val = std::numeric_limits<OutputT>::max();
 
   auto loop_shape = src_tensor->getShape();
-  const bool is_permutation = type != ir::PermuteType::COPY && loop_shape.rank() == 4;
+  const bool is_permutation = type != ir::PermuteType::SAME && loop_shape.rank() == 4;
   ShapeLoop(loop_shape, [&](const onert::ir::Coordinates &coords) {
     const InputT *input_data =
       reinterpret_cast<const InputT *>(src_tensor->buffer() + src_tensor->calcOffset(coords));
@@ -77,7 +77,7 @@ template <typename InputT, typename OutputT>
 void quantize(const backend::ITensor *src_tensor, backend::ITensor *dst_tensor,
               const ir::PermuteType &type)
 {
-  if (!src_tensor->has_padding() && !dst_tensor->has_padding() && type == ir::PermuteType::COPY &&
+  if (!src_tensor->has_padding() && !dst_tensor->has_padding() && type == ir::PermuteType::SAME &&
       !src_tensor->is_dynamic())
   {
     assert(!dst_tensor->is_dynamic());
@@ -103,7 +103,7 @@ void elementwiseDequantize(const backend::ITensor *src_tensor, backend::ITensor 
   const auto zero_point = src_tensor->data_zero_point();
 
   auto loop_shape = src_tensor->getShape();
-  const bool is_permutation = type != ir::PermuteType::COPY && loop_shape.rank() == 4;
+  const bool is_permutation = type != ir::PermuteType::SAME && loop_shape.rank() == 4;
   ShapeLoop(loop_shape, [&](const onert::ir::Coordinates &coords) {
     const InputT *input_data =
       reinterpret_cast<const InputT *>(src_tensor->buffer() + src_tensor->calcOffset(coords));
@@ -121,7 +121,7 @@ template <typename InputT, typename OutputT>
 void dequantize(const backend::ITensor *src_tensor, backend::ITensor *dst_tensor,
                 const ir::PermuteType &type)
 {
-  if (!src_tensor->has_padding() && !dst_tensor->has_padding() && type == ir::PermuteType::COPY &&
+  if (!src_tensor->has_padding() && !dst_tensor->has_padding() && type == ir::PermuteType::SAME &&
       !src_tensor->is_dynamic())
   {
     assert(!dst_tensor->is_dynamic());

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -91,7 +91,7 @@ private:
       // Now there is no case where both src and dst have cl buffer.
       assert(!src->needMemoryMap());
 
-      if (!src->has_padding() && !dst->has_padding() && permute_type == ir::PermuteType::COPY)
+      if (!src->has_padding() && !dst->has_padding() && permute_type == ir::PermuteType::SAME)
       {
         src->access([&](backend::ITensor &) { dst->enqueueWriteBuffer(src->buffer(), false); });
       }
@@ -108,7 +108,7 @@ private:
       }
     }
     else if (src->needMemoryMap() && !src->is_subtensor() && !src->has_padding() &&
-             !dst->has_padding() && permute_type == ir::PermuteType::COPY)
+             !dst->has_padding() && permute_type == ir::PermuteType::SAME)
     {
       assert(!dst->needMemoryMap());
       dst->access([&](backend::ITensor &) { src->enqueueReadBuffer(dst->buffer(), true); });
@@ -133,7 +133,7 @@ private:
     assert(dst_buffer != nullptr);
     assert(dst_size == dst->total_size());
 
-    if (rank == 4 && permute_type != ir::PermuteType::COPY)
+    if (rank == 4 && permute_type != ir::PermuteType::SAME)
     {
       switch (permute_type)
       {

--- a/runtime/onert/core/src/exec/IPermuteFunction.test.cc
+++ b/runtime/onert/core/src/exec/IPermuteFunction.test.cc
@@ -111,7 +111,7 @@ public:
       _src_tensors[i] = inputs[i].get();
       _dst_tensors[i] = outputs[i].get();
       if (inputs[i]->layout() == outputs[i]->layout())
-        _permute_types[i] = ir::PermuteType::COPY;
+        _permute_types[i] = ir::PermuteType::SAME;
       else if (inputs[i]->layout() == ir::Layout::NHWC)
         _permute_types[i] = ir::PermuteType::NHWC_TO_NCHW;
       else

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -211,7 +211,7 @@ void MultiModelExecutors::createEdgeQuantLayers()
             outputs.emplace_back(type_aware_quant_tensor.get());
 
             // No layout change on edge
-            permute_types.emplace_back(ir::PermuteType::COPY);
+            permute_types.emplace_back(ir::PermuteType::SAME);
 
             _edge_quant_tensors[to_iodesc] = std::move(type_aware_quant_tensor);
           }

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -176,8 +176,7 @@ void MultiModelExecutors::createEdgeQuantLayers()
 
     const auto from_executor = _executors.at({from_model_index, from_subg_index}).get();
     const auto &from_info = from_executor->outputInfo(from_io_index.value());
-    const auto from_layout = from_executor->outputLayout(from_io_index.value());
-    _edge_tensors[from_iodesc] = std::make_unique<EdgeTensor>(from_info, from_layout);
+    _edge_tensors[from_iodesc] = std::make_unique<EdgeTensor>(from_info);
   }
 
   // Append type-aware quantization layer for edges between executors
@@ -201,7 +200,6 @@ void MultiModelExecutors::createEdgeQuantLayers()
 
           const auto to_executor = _executors.at({to_model_index, to_subg_index}).get();
           const auto &to_info = to_executor->inputInfo(to_io_index.value());
-          const auto to_layout = to_executor->inputLayout(to_io_index.value());
 
           // TODO Unify tensors with the same `from` tensor and same type
           if (from_tensor->data_type() != to_info.typeInfo().type())
@@ -209,7 +207,7 @@ void MultiModelExecutors::createEdgeQuantLayers()
             assert(inputs.size() == outputs.size());
             inputs.emplace_back(from_tensor);
 
-            auto type_aware_quant_tensor = std::make_unique<EdgeTensor>(to_info, to_layout);
+            auto type_aware_quant_tensor = std::make_unique<EdgeTensor>(to_info);
             outputs.emplace_back(type_aware_quant_tensor.get());
 
             // No layout change on edge
@@ -242,7 +240,7 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
     auto input_desc = desc.inputs[input_pkg_index].get();
     // TODO Remove const_cast (we need const_cast as ITensor is writable)
     _pkg_input_tensors[pkg_input] = std::make_unique<backend::builtin::UserTensor>(
-      input_desc->info, input_desc->layout,
+      input_desc->info,
       const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(input_desc->buffer)),
       input_desc->size);
   }
@@ -257,112 +255,7 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
       throw std::runtime_error{"Cannot find multi model output index"};
     auto output_desc = desc.outputs[output_pkg_index].get();
     _pkg_output_tensors[pkg_output] = std::make_unique<backend::builtin::UserTensor>(
-      output_desc->info, output_desc->layout, reinterpret_cast<uint8_t *>(output_desc->buffer),
-      output_desc->size);
-  }
-}
-
-void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
-{
-  // Append type-aware quantization layer for nnpkg inputs/outputs between executors
-  for (const auto &[executor_index, executor] : _executors)
-  {
-    const auto &[model_index, subg_index] = executor_index;
-
-    // Find pkg inputs of current executor
-    std::vector<ir::IODesc> pkg_inputs;
-    for (const auto &pkg_input : _model_edges->pkg_inputs)
-    {
-      if (std::get<ir::ModelIndex>(pkg_input) == model_index &&
-          std::get<ir::SubgraphIndex>(pkg_input) == subg_index)
-      {
-        pkg_inputs.emplace_back(pkg_input);
-      }
-    }
-    std::vector<backend::ITensor *> src_tensors;
-    std::vector<backend::ITensor *> dst_tensors;
-    std::vector<ir::PermuteType> permute_types;
-    for (const auto &pkg_input : pkg_inputs)
-    {
-      const auto &io_index = std::get<ir::IOIndex>(pkg_input);
-      const auto input_pkg_index =
-        find_input_index(_model_edges->pkg_inputs, model_index, subg_index, io_index);
-      if (input_pkg_index == -1)
-        throw std::runtime_error{"Cannot find multi model input index"};
-      auto input_desc = desc.inputs[input_pkg_index].get();
-
-      // Create EdgeTensor for nnpkg input if type is different
-      const auto &orig_info = executor->inputInfo(io_index.value());
-      const auto orig_layout = executor->inputLayout(io_index.value());
-      if ((input_desc->info.typeInfo().type() != orig_info.typeInfo().type()) ||
-          (input_desc->layout == ir::Layout::NCHW))
-      {
-        auto pkg_input_edge_tensor = std::make_unique<EdgeTensor>(orig_info, orig_layout);
-        _pkg_input_quant_tensors[pkg_input] = std::move(pkg_input_edge_tensor);
-
-        // Append type-aware quantization layer's inputs/outputs
-        src_tensors.emplace_back(_pkg_input_tensors[pkg_input].get());
-        dst_tensors.emplace_back(_pkg_input_quant_tensors[pkg_input].get());
-
-        if (input_desc->layout == ir::Layout::NCHW)
-          permute_types.emplace_back(ir::PermuteType::NCHW_TO_NHWC);
-        else
-          permute_types.emplace_back(ir::PermuteType::COPY);
-      }
-    }
-
-    // Create type-aware quantization layer for nnpkg inputs
-    auto pkg_input_layer = std::make_unique<PermuteLayer>(src_tensors, dst_tensors, permute_types);
-    pkg_input_layer->prepare();
-    _pkg_input_quant_layers[{model_index, subg_index}] = std::move(pkg_input_layer);
-
-    // Find pkg outputs of current executor
-    std::vector<ir::IODesc> pkg_outputs;
-    for (const auto &pkg_output : _model_edges->pkg_outputs)
-    {
-      if (std::get<ir::ModelIndex>(pkg_output) == model_index &&
-          std::get<ir::SubgraphIndex>(pkg_output) == subg_index)
-      {
-        pkg_outputs.emplace_back(pkg_output);
-      }
-    }
-    src_tensors.clear();
-    dst_tensors.clear();
-    permute_types.clear();
-    // Create Tensors of nnpkg outputs for type-aware quantization
-    for (const auto &pkg_output : pkg_outputs)
-    {
-      const auto &io_index = std::get<ir::IOIndex>(pkg_output);
-      const auto output_pkg_index =
-        find_output_index(_model_edges->pkg_outputs, model_index, subg_index, io_index);
-      if (output_pkg_index == -1)
-        throw std::runtime_error{"Cannot find multi model output index"};
-      auto output_desc = desc.outputs[output_pkg_index].get();
-
-      // Create EdgeTensor for nnpkg output if type is different
-      const auto &orig_info = executor->outputInfo(io_index.value());
-      const auto orig_layout = executor->outputLayout(io_index.value());
-      if ((output_desc->info.typeInfo().type() != orig_info.typeInfo().type()) ||
-          (output_desc->layout == ir::Layout::NCHW))
-      {
-        auto pkg_output_edge_tensor = std::make_unique<EdgeTensor>(orig_info, orig_layout);
-        _pkg_output_quant_tensors[pkg_output] = std::move(pkg_output_edge_tensor);
-
-        // Append type-aware quantization layer's inputs/outputs
-        src_tensors.emplace_back(_pkg_output_quant_tensors[pkg_output].get());
-        dst_tensors.emplace_back(_pkg_output_tensors[pkg_output].get());
-
-        if (output_desc->layout == ir::Layout::NCHW)
-          permute_types.emplace_back(ir::PermuteType::NHWC_TO_NCHW);
-        else
-          permute_types.emplace_back(ir::PermuteType::COPY);
-      }
-    }
-
-    // Create type-aware quantization layer for nnpkg outputs
-    auto pkg_output_layer = std::make_unique<PermuteLayer>(src_tensors, dst_tensors, permute_types);
-    pkg_output_layer->prepare();
-    _pkg_output_quant_layers[{model_index, subg_index}] = std::move(pkg_output_layer);
+      output_desc->info, reinterpret_cast<uint8_t *>(output_desc->buffer), output_desc->size);
   }
 }
 
@@ -390,9 +283,6 @@ void MultiModelExecutors::execute(const ExecutionContext &ctx)
 
   // TODO Create IOTensors only once and recreate them only if nnpkg info changes
   CreatePkgIOTensors(desc);
-
-  // TODO Create type-aware quantization layers only once and recreate them only if type changes
-  createPkgIOQuantLayers(desc);
 
   // TODO Find better way to schedule order of executors
   auto const model_count = modelCount();
@@ -435,17 +325,7 @@ void MultiModelExecutors::execute(const ExecutionContext &ctx)
       const auto input_io_desc = ir::IODesc{model_index, ir::SubgraphIndex{0}, ir::IOIndex{i}};
       if (input_pkg_index != -1)
       {
-        // Allocate type-aware quantization tensors for nnpkg inputs and set internal tensors
-        if (_pkg_input_quant_tensors.find(input_io_desc) != _pkg_input_quant_tensors.end())
-        {
-          _pkg_input_quant_tensors[input_io_desc]->allocate_buffer();
-
-          inputs_inter[i] = _pkg_input_quant_tensors[input_io_desc].get();
-        }
-        else
-        {
-          inputs_inter[i] = _pkg_input_tensors[input_io_desc].get();
-        }
+        inputs_inter[i] = _pkg_input_tensors[input_io_desc].get();
       }
       else
       {
@@ -475,17 +355,7 @@ void MultiModelExecutors::execute(const ExecutionContext &ctx)
       const auto output_io_desc = ir::IODesc{model_index, ir::SubgraphIndex{0}, ir::IOIndex{i}};
       if (output_pkg_index != -1)
       {
-        // Allocate type-aware quantization tensors for nnpkg outputs and set internal tensors
-        if (_pkg_output_quant_tensors.find(output_io_desc) != _pkg_output_quant_tensors.end())
-        {
-          _pkg_output_quant_tensors[output_io_desc]->allocate_buffer();
-
-          outputs_inter[i] = _pkg_output_quant_tensors[output_io_desc].get();
-        }
-        else
-        {
-          outputs_inter[i] = _pkg_output_tensors[output_io_desc].get();
-        }
+        outputs_inter[i] = _pkg_output_tensors[output_io_desc].get();
       }
       else
       {
@@ -509,12 +379,9 @@ void MultiModelExecutors::execute(const ExecutionContext &ctx)
       }
     }
 
-    _pkg_input_quant_layers[{model_index, ir::SubgraphIndex{0}}]->run();
-
     executor->execute(inputs_inter, outputs_inter, ctx.options);
 
     _edge_quant_layers[{model_index, ir::SubgraphIndex{0}}]->run();
-    _pkg_output_quant_layers[{model_index, ir::SubgraphIndex{0}}]->run();
 
     // Release input buffers that are no longer needed
     for (uint32_t i = 0; i < input_size; i++)
@@ -540,12 +407,6 @@ void MultiModelExecutors::execute(const ExecutionContext &ctx)
           // Decrease reference count of `from` tensor if input tensor is the `from` tensor
           const auto from_iodesc = find_from(model_index, ir::SubgraphIndex{0}, ir::IOIndex{i});
           _edge_tensors[from_iodesc]->decrease_ref();
-
-          // Decrease reference count of nnpkg inputs
-          if (_pkg_input_quant_tensors.find(to_iodesc) != _pkg_input_quant_tensors.end())
-          {
-            _pkg_input_quant_tensors[to_iodesc]->decrease_ref();
-          }
         }
       }
     }
@@ -576,12 +437,6 @@ void MultiModelExecutors::execute(const ExecutionContext &ctx)
         // This edge tensor's buffer won't be used in other executors
         // Tensors for type-aware quantization take over the role of this edge tensor instead
         _edge_tensors[from_iodesc]->decrease_ref();
-      }
-
-      // Decrease reference count of nnpkg outputs
-      if (_pkg_output_quant_tensors.find(from_iodesc) != _pkg_output_quant_tensors.end())
-      {
-        _pkg_output_quant_tensors[from_iodesc]->decrease_ref();
       }
     }
   }

--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -51,8 +51,7 @@ public:
   MultiModelExecutors(std::unique_ptr<ir::ModelEdges> model_edges)
     : _executors{}, _model_edges{std::move(model_edges)}, _edge_quant_layers{},
       _edge_quant_tensors{}, _edge_tensors{}, _is_created_edge_quant_layers{false},
-      _pkg_input_quant_layers{}, _pkg_output_quant_layers{}, _pkg_input_quant_tensors{},
-      _pkg_output_quant_tensors{}, _pkg_input_tensors{}, _pkg_output_tensors{}
+      _pkg_input_tensors{}, _pkg_output_tensors{}
   {
     for (const auto &edge : _model_edges->edges)
     {
@@ -88,7 +87,6 @@ private:
   void checkSupportedMultimodel() const;
   void createEdgeQuantLayers();
   void CreatePkgIOTensors(const IODescription &desc);
-  void createPkgIOQuantLayers(const IODescription &desc);
   uint16_t modelCount() const;
 
 private:
@@ -135,15 +133,6 @@ private:
   //      is moved into compilation stage
   bool _is_created_edge_quant_layers;
 
-  // TODO Replace PermuteLayer with backend::builtin::kernel::PermuteLayer
-  std::unordered_map<std::pair<ir::ModelIndex, ir::SubgraphIndex>, std::unique_ptr<PermuteLayer>>
-    _pkg_input_quant_layers;
-  // TODO Replace PermuteLayer with backend::builtin::kernel::PermuteLayer
-  std::unordered_map<std::pair<ir::ModelIndex, ir::SubgraphIndex>, std::unique_ptr<PermuteLayer>>
-    _pkg_output_quant_layers;
-  // Edge tensors of nnpkg inputs/outputs for type-aware quantization
-  std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _pkg_input_quant_tensors;
-  std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _pkg_output_quant_tensors;
   // IOTensors for user buffer
   std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::UserTensor>> _pkg_input_tensors;
   std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::UserTensor>> _pkg_output_tensors;

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -82,7 +82,7 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   std::vector<backend::ITensor *> output_tensors;
   std::vector<ir::PermuteType> output_permute_types;
 
-  // Prepare UserTensor and EdgeTensor for input quantization
+  // Prepare UserTensor
   for (uint32_t i = 0; i < inputs.size(); i++)
   {
     auto &desc = ctx.desc.inputs[i];
@@ -93,34 +93,12 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
 
     // TODO: Create UserTensor only that will be set into IOTensor
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, desc->layout, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)),
-      desc->size));
+      desc->info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)), desc->size));
 
-    auto user_type = desc->info.typeInfo().type();
-    auto &model_info = entryExecutor()->inputInfo(i).typeInfo();
-    auto model_type = model_info.type();
-    if ((user_type != model_type && user_type == ir::DataType::FLOAT32) ||
-        (desc->layout == ir::Layout::NCHW))
-    {
-      auto quantized_info = desc->info;
-      quantized_info.typeInfo(model_info);
-      qtensorpool.emplace_back(
-        std::make_unique<EdgeTensor>(quantized_info, entryExecutor()->inputLayout(i)));
-      qtensorpool.back()->allocate_buffer();
-
-      input_tensors.push_back(tensorpool.back().get());
-      input_qtensors.push_back(qtensorpool.back().get());
-      inputs[i] = qtensorpool.back().get();
-      if (desc->layout == ir::Layout::NCHW)
-        input_permute_types.push_back(ir::PermuteType::NCHW_TO_NHWC);
-      else
-        input_permute_types.push_back(ir::PermuteType::COPY);
-    }
-    else
-      inputs[i] = tensorpool.back().get();
+    inputs[i] = tensorpool.back().get();
   }
 
-  // Prepare UserTensor and EdgeTensor for output dequantization
+  // Prepare UserTensor
   for (uint32_t i = 0; i < outputs.size(); i++)
   {
     auto &desc = ctx.desc.outputs[i];
@@ -136,55 +114,13 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, desc->layout, static_cast<uint8_t *>(desc->buffer), desc->size));
+      desc->info, static_cast<uint8_t *>(desc->buffer), desc->size));
 
-    auto user_type = desc->info.typeInfo().type();
-    auto &model_info = entryExecutor()->outputInfo(i).typeInfo();
-    auto model_type = model_info.type();
-    if ((user_type != model_type && user_type == ir::DataType::FLOAT32) ||
-        (desc->layout == ir::Layout::NCHW))
-    {
-      if (skip_set_output)
-        std::runtime_error("When outputs are allocated internally, backend-aware quantization is "
-                           "not yet supported.");
-
-      auto quantized_info = desc->info;
-      quantized_info.typeInfo(model_info);
-      qtensorpool.emplace_back(
-        std::make_unique<EdgeTensor>(quantized_info, entryExecutor()->outputLayout(i)));
-      qtensorpool.back()->allocate_buffer();
-
-      output_qtensors.push_back(qtensorpool.back().get());
-      output_tensors.push_back(tensorpool.back().get());
-      outputs[i] = qtensorpool.back().get();
-      if (desc->layout == ir::Layout::NCHW)
-        output_permute_types.push_back(ir::PermuteType::NHWC_TO_NCHW);
-      else
-        output_permute_types.push_back(ir::PermuteType::COPY);
-    }
-    else
-      outputs[i] = tensorpool.back().get();
-  }
-
-  // Run quantization
-  if (input_tensors.size() > 0)
-  {
-    auto input_quantize_layer = PermuteLayer(input_tensors, input_qtensors, input_permute_types);
-    input_quantize_layer.prepare();
-    input_quantize_layer.run();
+    outputs[i] = tensorpool.back().get();
   }
 
   // Executor
   entryExecutor()->execute(inputs, outputs, ctx.options);
-
-  // Run dequantization
-  if (output_tensors.size() != 0)
-  {
-    auto output_dequantize_layer =
-      PermuteLayer(output_qtensors, output_tensors, output_permute_types);
-    output_dequantize_layer.prepare();
-    output_dequantize_layer.run();
-  }
 
   // Get dynamic shape inference result
   for (uint32_t i = 0; i < outputs.size(); i++)

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -73,13 +73,6 @@ public:
     return _output_tensors[index]->get_info();
   }
 
-  ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
-
-  ir::Layout outputLayout(uint32_t index) const override
-  {
-    return _output_tensors[index]->layout();
-  }
-
   const uint8_t *outputBuffer(uint32_t index) const final
   {
     return _output_tensors[index]->buffer();

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -108,8 +108,7 @@ void TrainableExecutors::forward(
       throw std::runtime_error{"Input " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, desc->layout, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)),
-      desc->size));
+      desc->info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)), desc->size));
     inputs[i] = tensorpool.back().get();
   }
 
@@ -121,7 +120,7 @@ void TrainableExecutors::forward(
     // If training, output buffer may not be used
     // So don't check optional
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, desc->layout, static_cast<uint8_t *>(desc->buffer), desc->size));
+      desc->info, static_cast<uint8_t *>(desc->buffer), desc->size));
     outputs[i] = tensorpool.back().get();
   }
 

--- a/runtime/onert/core/src/ir/Coordinates.cc
+++ b/runtime/onert/core/src/ir/Coordinates.cc
@@ -25,7 +25,7 @@ Coordinates convertCoordinates(const Coordinates &coords, const PermuteType &typ
 {
   assert(coords.size() == 4);
   Coordinates to{coords};
-  if (type == PermuteType::COPY)
+  if (type == PermuteType::SAME)
     return to;
 
   if (type == PermuteType::NHWC_TO_NCHW)

--- a/runtime/onert/core/src/ir/OperationDumper.cc
+++ b/runtime/onert/core/src/ir/OperationDumper.cc
@@ -273,7 +273,7 @@ void OperationDumper::visit(const Permute &node)
 
   switch (node.getPermuteType())
   {
-    case ir::PermuteType::COPY:
+    case ir::PermuteType::SAME:
       permute_type = "Same Layout";
       break;
     case ir::PermuteType::NHWC_TO_NCHW:

--- a/runtime/onert/core/src/ir/OperationDumper.cc
+++ b/runtime/onert/core/src/ir/OperationDumper.cc
@@ -271,7 +271,20 @@ void OperationDumper::visit(const Permute &node)
 {
   std::string permute_type = "Unknown";
 
-  VERBOSE(LIR) << "* " << node.name() << std::endl;
+  switch (node.getPermuteType())
+  {
+    case ir::PermuteType::COPY:
+      permute_type = "Same Layout";
+      break;
+    case ir::PermuteType::NHWC_TO_NCHW:
+      permute_type = "NHWC to NCHW";
+      break;
+    case ir::PermuteType::NCHW_TO_NHWC:
+      permute_type = "NCHW to NHWC";
+      break;
+  }
+
+  VERBOSE(LIR) << "* " << node.name() + "(" + permute_type + ")" << std::endl;
   VERBOSE(LIR) << "  - Inputs : Input(" << node.getInputs().at(0) << ")" << std::endl;
   VERBOSE(LIR) << "  - Output : Output(" << node.getOutputs().at(0) << ")" << std::endl;
 }

--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -64,7 +64,7 @@ Shape convertShape(const Shape &shape, const PermuteType &type)
   assert(shape.rank() <= Shape::kMaxRank);
   Shape ret{shape};
 
-  if (type == ir::PermuteType::COPY || shape.rank() < 4)
+  if (type == ir::PermuteType::SAME || shape.rank() < 4)
     return ret;
 
   // Permutation changing layout beyond 4-D is not supported yet

--- a/runtime/onert/core/src/ir/TypeInfo.cc
+++ b/runtime/onert/core/src/ir/TypeInfo.cc
@@ -26,14 +26,20 @@ bool operator==(const TypeInfo &lhs, const TypeInfo &rhs)
     return false;
   }
 
-  if (lhs.zero_point() != rhs.zero_point())
-  {
+  if (lhs.zero_points().size() != rhs.zero_points().size())
     return false;
-  }
 
-  if (lhs.scale() != rhs.scale())
+  if (lhs.zero_points().size() != 0)
   {
-    return false;
+    if (lhs.zero_point() != rhs.zero_point())
+    {
+      return false;
+    }
+
+    if (lhs.scale() != rhs.scale())
+    {
+      return false;
+    }
   }
 
   return true;

--- a/runtime/onert/core/src/ir/TypeInfo.cc
+++ b/runtime/onert/core/src/ir/TypeInfo.cc
@@ -26,22 +26,17 @@ bool operator==(const TypeInfo &lhs, const TypeInfo &rhs)
     return false;
   }
 
-  if (lhs.zero_points().size() != rhs.zero_points().size())
+  if (!lhs.quantized() && !rhs.quantized())
+    return true;
+
+  if (lhs.quantized() ^ rhs.quantized())
     return false;
 
-  if (lhs.zero_points().size() != 0)
-  {
-    if (lhs.zero_point() != rhs.zero_point())
-    {
-      return false;
-    }
+  if (lhs.scales().size() != rhs.scales().size())
+    return false;
 
-    if (lhs.scale() != rhs.scale())
-    {
-      return false;
-    }
-  }
-
+  // Assume zero_points are same as scales.size() or symmetric
+  // Don't check values of scale and zero_points here
   return true;
 }
 

--- a/runtime/onert/core/src/ir/operation/Permute.cc
+++ b/runtime/onert/core/src/ir/operation/Permute.cc
@@ -22,8 +22,8 @@ namespace onert::ir::operation
 
 void Permute::accept(OperationVisitor &v) const { v.visit(*this); }
 
-Permute::Permute(const OperandIndex &input, const OperandIndex &output)
-  : Operation{OperandConstraint::createExact(1u)}
+Permute::Permute(const OperandIndex &input, const OperandIndex &output, ir::PermuteType type)
+  : Operation{OperandConstraint::createExact(1u)}, _type{type}
 {
   setInputs({input});
   setOutputs({output});

--- a/runtime/onert/core/src/ir/train/operation/Permute.cc
+++ b/runtime/onert/core/src/ir/train/operation/Permute.cc
@@ -32,7 +32,8 @@ void Permute::accept(OperationVisitor &v) const { v.visit(*this); }
 void Permute::accept(TrainableOperationVisitor &v) const { v.visit(*this); }
 
 Permute::Permute(const OperationType &operation)
-  : OperationType{operation.getInputs().at(0), operation.getOutputs().at(0)}
+  : OperationType{operation.getInputs().at(0), operation.getOutputs().at(0),
+                  operation.getPermuteType()}
 {
   // DO NOTHING
 }

--- a/runtime/onert/core/src/ir/train/operation/UntrainableOperation.test.cc
+++ b/runtime/onert/core/src/ir/train/operation/UntrainableOperation.test.cc
@@ -319,7 +319,7 @@ operation::Pad generatePad()
 
 operation::Permute generatePermute()
 {
-  return operation::Permute{OperandIndex{1}, OperandIndex{0}, PermuteType::COPY};
+  return operation::Permute{OperandIndex{1}, OperandIndex{0}, PermuteType::SAME};
 }
 
 operation::Pool2D generatePool2D()

--- a/runtime/onert/core/src/ir/train/operation/UntrainableOperation.test.cc
+++ b/runtime/onert/core/src/ir/train/operation/UntrainableOperation.test.cc
@@ -319,7 +319,7 @@ operation::Pad generatePad()
 
 operation::Permute generatePermute()
 {
-  return operation::Permute{OperandIndex{1}, OperandIndex{0}};
+  return operation::Permute{OperandIndex{1}, OperandIndex{0}, PermuteType::COPY};
 }
 
 operation::Pool2D generatePool2D()

--- a/runtime/onert/core/src/loader/BaseLoader.h
+++ b/runtime/onert/core/src/loader/BaseLoader.h
@@ -456,7 +456,6 @@ void BaseLoader<LoaderDomain>::loadQuantization(const Tensor *tensor, ir::TypeIn
   auto q_params = tensor->quantization();
   if (q_params == nullptr || q_params->scale() == nullptr || q_params->scale()->size() == 0)
   {
-    typeInfo.quantization(0., 0);
     return;
   }
   if (q_params->zero_point() == nullptr)

--- a/runtime/tests/scripts/command/unittest
+++ b/runtime/tests/scripts/command/unittest
@@ -74,6 +74,7 @@ echo "Unittest start"
 echo "============================================"
 
 num_unittest=0
+FAILED_LIST=()
 # Run all executables in unit test directory
 for TEST_BIN in `find $UNITTEST_TEST_DIR -maxdepth 1 -type f -executable`; do
     num_unittest=$((num_unittest+1))
@@ -87,6 +88,7 @@ for TEST_BIN in `find $UNITTEST_TEST_DIR -maxdepth 1 -type f -executable`; do
     if [[ $TEMP_UNITTEST_RESULT -ne 0 ]]; then
         UNITTEST_RESULT=$TEMP_UNITTEST_RESULT
         echo "$TEST_BIN failed... return code: $TEMP_UNITTEST_RESULT"
+        FAILED_LIST=("${FAILED_LIST[@]}" "$TEST_BIN")
     fi
     echo "============================================"
     echo "Finishing set $num_unittest: $TEST_BIN..."
@@ -96,6 +98,10 @@ done
 if [[ $UNITTEST_RESULT -ne 0 ]]; then
     echo "============================================"
     echo "Failed unit test... exit code: $UNITTEST_RESULT"
+    echo "Failed test:"
+    for failed_test in "${FAILED_LIST[@]}"; do
+        echo "  - $failed_test"
+    done
     echo "============================================"
     exit $UNITTEST_RESULT
 fi


### PR DESCRIPTION
- Introduce and change API to set layout and data type
- Add compile pass to insert permute OP for input and output layout and data type conversion
- Add permute type again to permute op for layout conversion
- Don't use tensor's layout in PermuteLayer kernel, instead, use permute type field
- Support quant type casting, but cannot use nnfw API
  - Use compiler option directly on unittest
- Support multimodel
- Remove meaningless APIs in executor
- Remove layout in tensor - just use permutation type on operator

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13645