### PR TITLE
[onert] Fix DepthwiseConvOp kernel condition

### DIFF
--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -81,9 +81,9 @@ void DepthwiseConvolutionLayer::convFloat32()
   op_params.float_activation_min = output_activation_min;
   op_params.float_activation_max = output_activation_max;
 
-  // Since DepthwiseConvOp does not support dilation yet, it uses the existing
-  // kernel in this case.
-  if (_dilationWidth == 1 && _dilationHeight == 1)
+  // Since DepthwiseConvOp does not support dilation and different W/H stride yet,
+  // it uses the existing kernel in this case.
+  if (_dilationWidth == 1 && _dilationHeight == 1 && _strideWidth == _strideHeight)
   {
     nnfw::cker::DepthwiseConvOp(op_params, getShape(_input), getBuffer<float>(_input),
                                 getShape(_kernel), getBuffer<float>(_kernel), getShape(_bias),

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -30,7 +30,7 @@ namespace ops
 
 void DepthwiseConvolutionLayer::prepareF32()
 {
-  if (_dilationWidth != 1 || _dilationHeight != 1)
+  if (_dilationWidth != 1 || _dilationHeight != 1 || _strideWidth != _strideHeight)
     return;
 
   // DepthwiseConvOp cpu kernel needs additional memory to perform with multi-


### PR DESCRIPTION
This commit fixes DepthwiseConvOp kernel usage condition. 
Eigen kernel is not supproting different width-height stride yet.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Resolve https://github.com/Samsung/ONE/issues/13675 and coverage test fail