### PR TITLE
[tflchef] Add ext_offset field to recipe proto

### DIFF
--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -951,6 +951,9 @@ bool ModelChef::finalize_ext_buffer(void)
 
 void ModelChef::cook(const ::tflchef::ModelRecipe &model_recipe)
 {
+  // use Custom/Buffer offset
+  _ext_offset = model_recipe.has_ext_offset() ? model_recipe.ext_offset() : false;
+
   prepare_initial_buffer();
 
   gather_operator_codes(model_recipe);

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -719,4 +719,6 @@ message ModelRecipe {
   optional uint32 version = 6 [default = 1];
   repeated Graph graph = 7;
   repeated SignatureDef signature_def = 8;
+  // store to external and use (Buffer) offset
+  optional bool ext_offset = 9 [default = false];
 }


### PR DESCRIPTION
This will add ext_offset field to recipe proto to generate
Buffer data outside of flatbuffer region.