### PR TITLE
[github] Run onecc-build only in Samsung Org.

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -38,6 +38,7 @@ jobs:
   onecc-test:
     # Tested ubuntu version is decided by docker image, not runner
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'Samsung'
     strategy:
       matrix:
         type: [ Debug, Release ]


### PR DESCRIPTION
This will revuse to run onecc-build only in Samsung Org.
