### PR TITLE
[tfldump] Reivse to support Buffer offset

### DIFF
--- a/compiler/tfldump/driver/Driver.cpp
+++ b/compiler/tfldump/driver/Driver.cpp
@@ -49,7 +49,11 @@ int entry(int argc, char **argv)
 
   std::cout << "Dump: " << tflite_path << std::endl << std::endl;
 
-  std::cout << tflmodel << std::endl;
+  tfldump::ModelEx modelex;
+  modelex.model = tflmodel;
+  modelex.rawdata = &modelData;
+
+  std::cout << modelex << std::endl;
 
   return 0;
 }

--- a/compiler/tfldump/include/tfldump/Dump.h
+++ b/compiler/tfldump/include/tfldump/Dump.h
@@ -24,9 +24,16 @@
 namespace tfldump
 {
 
-void dump_model(std::ostream &os, const tflite::Model *model);
-}
+struct ModelEx
+{
+  const tflite::Model *model;
+  const std::vector<char> *rawdata;
+};
 
-std::ostream &operator<<(std::ostream &os, const tflite::Model *model);
+void dump_model(std::ostream &os, const ModelEx &model);
+
+} // namespace tfldump
+
+std::ostream &operator<<(std::ostream &os, const tfldump::ModelEx &model);
 
 #endif // __TFLDUMP_DUMP_H__

--- a/compiler/tfldump/src/Dump.cpp
+++ b/compiler/tfldump/src/Dump.cpp
@@ -340,9 +340,9 @@ void dump_sub_graph(std::ostream &os, tflread::Reader &reader)
   os << std::endl;
 }
 
-void dump_model(std::ostream &os, const tflite::Model *model)
+void dump_model(std::ostream &os, const tflite::Model *model, const std::vector<char> *rawdata)
 {
-  tflread::Reader reader(model);
+  tflread::Reader reader(model, rawdata);
 
   uint32_t num_subgraph = reader.num_subgraph();
 
@@ -376,13 +376,17 @@ void dump_model(std::ostream &os, const tflite::Model *model)
   os << std::endl;
 
   // dump buffer
-  os << "Buffers: B(index) (length) values, if any" << std::endl;
+  os << "Buffers: B(index) (length) values, if any; (length *) for ext_offset" << std::endl;
   for (uint32_t i = 0; i < buffers->size(); ++i)
   {
+    bool ext_offset = false;
     const uint8_t *buff_data;
-    size_t size = reader.buffer_info(i, &buff_data);
+    size_t size = reader.buffer_info(i, &buff_data, ext_offset);
 
-    os << "B(" << i << ") (" << size << ") ";
+    os << "B(" << i << ") (" << size;
+    if (ext_offset)
+      os << " *";
+    os << ") ";
     if (buff_data != nullptr)
     {
       dump_buffer(os, buff_data, size, 16);
@@ -450,8 +454,8 @@ void dump_model(std::ostream &os, const tflite::Model *model)
 
 } // namespace tfldump
 
-std::ostream &operator<<(std::ostream &os, const tflite::Model *model)
+std::ostream &operator<<(std::ostream &os, const tfldump::ModelEx &modelex)
 {
-  tfldump::dump_model(os, model);
+  tfldump::dump_model(os, modelex.model, modelex.rawdata);
   return os;
 }


### PR DESCRIPTION
This will revise to support Buffer offset;
- pass raw file data to retrieve data outside of flatbuffers area
- get flag if Buffer is from outside of flatbuffers area
- show with '*' for Buffers that are outside of flatbuffers area