### PR TITLE
[onert] Add ir namespace to checkpoint header file

### DIFF
--- a/runtime/onert/core/include/ir/train/Checkpoint.h
+++ b/runtime/onert/core/include/ir/train/Checkpoint.h
@@ -19,6 +19,8 @@
 
 namespace onert
 {
+namespace ir
+{
 namespace train
 {
 namespace checkpoint
@@ -46,6 +48,7 @@ constexpr uint8_t SCHEMA_VERSION = 1;
 
 } // namespace checkpoint
 } // namespace train
+} // namespace ir
 } // namespace onert
 
 #endif // __ONERT_IR_TRAIN_CHECKPOINT_H__


### PR DESCRIPTION
This commit adds the missing ir namespace to checkpoint header file.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #13670
Draft: #13561