### PR TITLE
[Draft][luci] infer dynamic shape for pad

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -107,7 +107,7 @@ public:
   // loco::TensorShape visit(const luci::CircleNotEqual *node) final;
   // loco::TensorShape visit(const luci::CircleOneHot *node) final;
   // loco::TensorShape visit(const luci::CirclePack *node) final;
-  // loco::TensorShape visit(const luci::CirclePad *node) final;
+  loco::TensorShape visit(const luci::CirclePad *node) final;
   // loco::TensorShape visit(const luci::CirclePadV2 *node) final;
   // loco::TensorShape visit(const luci::CirclePow *node) final;
   // loco::TensorShape visit(const luci::CirclePRelu *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.h
@@ -19,7 +19,7 @@
 
 #include <loco/IR/NodeShape.h>
 #include <loco/IR/TensorShape.h>
-
+#include "Check.h"
 #include <luci/IR/CircleNodes.h>
 
 namespace luci
@@ -43,6 +43,61 @@ namespace sinf // Namespace for Shape Inference
 
 // Return shape of circle node as loco::TensorShape
 loco::TensorShape circle_shape(const luci::CircleNode *node);
+
+template <class CIRCLENODE>
+loco::TensorShape use_paddings(const CIRCLENODE *node, const luci::CircleConst *paddings)
+{
+  const loco::DataType S32 = loco::DataType::S32;
+  const loco::DataType S64 = loco::DataType::S64;
+
+  auto input_shape = luci::shape_get(node->input()).template as<loco::TensorShape>();
+
+  // TODO support other data type
+  LUCI_ASSERT(paddings->dtype() == S32 || paddings->dtype() == S64, "Support int 32/64 for now");
+  LUCI_ASSERT(paddings->rank() == 2, "paddings should be rank 2");
+
+  int32_t n = paddings->dim(0).value();
+  int32_t v = paddings->dim(1).value();
+
+  LUCI_ASSERT(v == 2, "paddings should be [n, 2]");
+  LUCI_ASSERT(n == int32_t(input_shape.rank()),
+              "paddings [n, 2] should have same value of input rank");
+
+  loco::TensorShape output_shape;
+
+  output_shape.rank(input_shape.rank());
+  for (int32_t ni = 0; ni < n; ++ni)
+  {
+    if (not input_shape.dim(ni).known())
+    {
+      output_shape.dim(ni).unset();
+      continue;
+    }
+    int32_t idx = ni * 2;
+    int value = input_shape.dim(ni).value();
+    if (paddings->dtype() == S32)
+    {
+      value += paddings->at<S32>(idx + 0); // left
+      value += paddings->at<S32>(idx + 1); // right
+    }
+    else
+    {
+      auto pl = paddings->at<S64>(idx + 0);
+      auto pr = paddings->at<S64>(idx + 1);
+      auto max = static_cast<int64_t>(std::numeric_limits<int32_t>::max());
+      auto low = static_cast<int64_t>(std::numeric_limits<int32_t>::lowest());
+      LUCI_ASSERT(pl <= max, "paddings is over 32 bit limit");
+      LUCI_ASSERT(pl >= low, "paddings is over 32 bit limit");
+      LUCI_ASSERT(pr <= max, "paddings is over 32 bit limit");
+      LUCI_ASSERT(pr >= low, "paddings is over 32 bit limit");
+      value += static_cast<int32_t>(pl); // left
+      value += static_cast<int32_t>(pr); // right
+    }
+    output_shape.dim(ni) = value;
+  }
+
+  return output_shape;
+}
 
 } // namespace sinf
 } // namespace luci

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1046,13 +1046,6 @@ loco::NodeShape infer_pack(const luci::CirclePack *node)
   return loco::NodeShape{output_shape};
 }
 
-loco::NodeShape infer_pad(const luci::CirclePad *node)
-{
-  // TODO support non-const case
-  auto paddings = loco::must_cast<luci::CircleConst *>(node->paddings());
-  return use_paddings(node, paddings);
-}
-
 loco::NodeShape infer_pad_v2(const luci::CirclePadV2 *node)
 {
   // TODO support non-const case
@@ -2302,8 +2295,6 @@ public:
   loco::NodeShape visit(const luci::CircleOneHot *node) final { return infer_one_hot(node); }
 
   loco::NodeShape visit(const luci::CirclePack *node) final { return infer_pack(node); }
-
-  loco::NodeShape visit(const luci::CirclePad *node) final { return infer_pad(node); }
 
   loco::NodeShape visit(const luci::CirclePadV2 *node) final { return infer_pad_v2(node); }
 

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -235,35 +235,32 @@ loco::NodeShape use_paddings(const CIRCLENODE *node, const luci::CircleConst *pa
   output_shape.rank(input_shape.rank());
   for (int32_t ni = 0; ni < n; ++ni)
   {
-    int32_t idx = ni * 2;
-    int value = input_shape.dim(ni).value();
-    if (!input_shape.dim(ni).known())
+    if (not input_shape.dim(ni).known())
     {
       output_shape.dim(ni).unset();
+      continue;
+    }
+    int32_t idx = ni * 2;
+    int value = input_shape.dim(ni).value();
+    if (paddings->dtype() == S32)
+    {
+      value += paddings->at<S32>(idx + 0); // left
+      value += paddings->at<S32>(idx + 1); // right
     }
     else
     {
-
-      if (paddings->dtype() == S32)
-      {
-        value += paddings->at<S32>(idx + 0); // left
-        value += paddings->at<S32>(idx + 1); // right
-      }
-      else
-      {
-        auto pl = paddings->at<S64>(idx + 0);
-        auto pr = paddings->at<S64>(idx + 1);
-        auto max = static_cast<int64_t>(std::numeric_limits<int32_t>::max());
-        auto low = static_cast<int64_t>(std::numeric_limits<int32_t>::lowest());
-        LUCI_ASSERT(pl <= max, "paddings is over 32 bit limit");
-        LUCI_ASSERT(pl >= low, "paddings is over 32 bit limit");
-        LUCI_ASSERT(pr <= max, "paddings is over 32 bit limit");
-        LUCI_ASSERT(pr >= low, "paddings is over 32 bit limit");
-        value += static_cast<int32_t>(pl); // left
-        value += static_cast<int32_t>(pr); // right
-      }
-      output_shape.dim(ni) = value;
+      auto pl = paddings->at<S64>(idx + 0);
+      auto pr = paddings->at<S64>(idx + 1);
+      auto max = static_cast<int64_t>(std::numeric_limits<int32_t>::max());
+      auto low = static_cast<int64_t>(std::numeric_limits<int32_t>::lowest());
+      LUCI_ASSERT(pl <= max, "paddings is over 32 bit limit");
+      LUCI_ASSERT(pl >= low, "paddings is over 32 bit limit");
+      LUCI_ASSERT(pr <= max, "paddings is over 32 bit limit");
+      LUCI_ASSERT(pr >= low, "paddings is over 32 bit limit");
+      value += static_cast<int32_t>(pl); // left
+      value += static_cast<int32_t>(pr); // right
     }
+    output_shape.dim(ni) = value;
   }
 
   return loco::NodeShape{output_shape};

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -237,25 +237,33 @@ loco::NodeShape use_paddings(const CIRCLENODE *node, const luci::CircleConst *pa
   {
     int32_t idx = ni * 2;
     int value = input_shape.dim(ni).value();
-    if (paddings->dtype() == S32)
+    if (!input_shape.dim(ni).known())
     {
-      value += paddings->at<S32>(idx + 0); // left
-      value += paddings->at<S32>(idx + 1); // right
+      output_shape.dim(ni).unset();
     }
     else
     {
-      auto pl = paddings->at<S64>(idx + 0);
-      auto pr = paddings->at<S64>(idx + 1);
-      auto max = static_cast<int64_t>(std::numeric_limits<int32_t>::max());
-      auto low = static_cast<int64_t>(std::numeric_limits<int32_t>::lowest());
-      LUCI_ASSERT(pl <= max, "paddings is over 32 bit limit");
-      LUCI_ASSERT(pl >= low, "paddings is over 32 bit limit");
-      LUCI_ASSERT(pr <= max, "paddings is over 32 bit limit");
-      LUCI_ASSERT(pr >= low, "paddings is over 32 bit limit");
-      value += static_cast<int32_t>(pl); // left
-      value += static_cast<int32_t>(pr); // right
+
+      if (paddings->dtype() == S32)
+      {
+        value += paddings->at<S32>(idx + 0); // left
+        value += paddings->at<S32>(idx + 1); // right
+      }
+      else
+      {
+        auto pl = paddings->at<S64>(idx + 0);
+        auto pr = paddings->at<S64>(idx + 1);
+        auto max = static_cast<int64_t>(std::numeric_limits<int32_t>::max());
+        auto low = static_cast<int64_t>(std::numeric_limits<int32_t>::lowest());
+        LUCI_ASSERT(pl <= max, "paddings is over 32 bit limit");
+        LUCI_ASSERT(pl >= low, "paddings is over 32 bit limit");
+        LUCI_ASSERT(pr <= max, "paddings is over 32 bit limit");
+        LUCI_ASSERT(pr >= low, "paddings is over 32 bit limit");
+        value += static_cast<int32_t>(pl); // left
+        value += static_cast<int32_t>(pr); // right
+      }
+      output_shape.dim(ni) = value;
     }
-    output_shape.dim(ni) = value;
   }
 
   return loco::NodeShape{output_shape};

--- a/compiler/luci/service/src/Nodes/CirclePad.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.cpp
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#include <luci/Service/CircleShapeInference.h>
+
 #include "CircleCloneNode.h"
+
+#include "CircleShapeInferenceHelper.h"
 
 namespace luci
 {
@@ -22,6 +26,11 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CirclePad *)
 {
   return _graph->nodes()->create<luci::CirclePad>();
+}
+loco::TensorShape sinf::Algorithm::visit(const luci::CirclePad *node)
+{
+  auto paddings = loco::must_cast<luci::CircleConst *>(node->paddings());
+  return use_paddings(node, paddings);
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CirclePad.test.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.test.cpp
@@ -38,7 +38,6 @@ TEST(ShapeRuleTest, pad_dynamic_shape)
 {
   luci::CirclePad pad;
   luci::CircleInput input;
-  // Use circle input as paddings
   luci::CircleConst padddings;
 
   loco::TensorShape shape;
@@ -70,5 +69,23 @@ TEST(ShapeRuleTest, pad_dynamic_shape)
   ASSERT_EQ(2, shape.dim(1).value());
   ASSERT_EQ(0, shape.dim(2).value());
   ASSERT_EQ(4, shape.dim(3).value());
+  pad.drop();
+}
+
+TEST(ShapeRuleTest, pad_without_padding_NEG)
+{
+  luci::CirclePad pad;
+  luci::CircleInput input;
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  input.shape({1, 2, 3, 4});
+  input.shape_status(luci::ShapeStatus::VALID);
+  input.dim(2).unset();
+
+  pad.input(&input);
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&pad, shape));
+
   pad.drop();
 }

--- a/compiler/luci/service/src/Nodes/CirclePad.test.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.test.cpp
@@ -16,6 +16,8 @@
 
 #include "luci/Service/CircleNodeClone.h"
 
+#include <luci/Service/CircleShapeInference.h>
+
 #include <gtest/gtest.h>
 
 TEST(CloneNodeTest, clone_Pad)
@@ -30,4 +32,43 @@ TEST(CloneNodeTest, clone_Pad)
 
   auto cloned_pad = dynamic_cast<luci::CirclePad *>(cloned);
   ASSERT_NE(nullptr, cloned_pad);
+}
+
+TEST(ShapeRuleTest, pad_dynamic_shape)
+{
+  luci::CirclePad pad;
+  luci::CircleInput input;
+  // Use circle input as paddings
+  luci::CircleConst padddings;
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  input.shape({1, 2, 3, 4});
+  input.shape_status(luci::ShapeStatus::VALID);
+  input.dim(2).unset();
+
+  padddings.dtype(loco::DataType::S64);
+  padddings.shape({4, 2});
+  padddings.shape_status(luci::ShapeStatus::VALID);
+
+  const loco::DataType S64 = loco::DataType::S64;
+  uint32_t t = 64 * 8;
+  padddings.size<S64>(t);
+
+  pad.input(&input);
+  pad.paddings(&padddings);
+
+  ASSERT_TRUE(shape_inf_rule.infer(&pad, shape));
+  ASSERT_EQ(shape.rank(), 4);
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_FALSE(shape.dim(2).known());
+  ASSERT_TRUE(shape.dim(3).known());
+
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(2, shape.dim(1).value());
+  ASSERT_EQ(0, shape.dim(2).value());
+  ASSERT_EQ(4, shape.dim(3).value());
+  pad.drop();
 }


### PR DESCRIPTION
This infers dynmic shaep for pad.
If input shape is unknown, output shape is also unknown.

for  #13573

ONE-DCO-1.0-Signed-off-by: JuYoung Lee <rsb98759@gmail.com>