### PR TITLE
[luci] Migrate concat shape inference rule

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -56,7 +56,7 @@ public:
   // loco::TensorShape visit(const luci::CircleBatchToSpaceND *node) final;
   // loco::TensorShape visit(const luci::CircleCast *node) final;
   // loco::TensorShape visit(const luci::CircleCeil *node) final;
-  // loco::TensorShape visit(const luci::CircleConcatenation *node) final;
+  loco::TensorShape visit(const luci::CircleConcatenation *node) final;
   // loco::TensorShape visit(const luci::CircleConst *node) final;
   // loco::TensorShape visit(const luci::CircleConv2D *node) final;
   // loco::TensorShape visit(const luci::CircleCos *node) final;

--- a/compiler/luci/service/src/Nodes/CircleConcatenation.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConcatenation.cpp
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#include <luci/Service/CircleShapeInference.h>
+
 #include "CircleCloneNode.h"
+
+#include "CircleShapeInferenceHelper.h"
 
 namespace luci
 {
@@ -31,6 +35,70 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleConcatenation *
     cloned->axis(node->axis());
   }
   return cloned;
+}
+
+loco::TensorShape sinf::Algorithm::visit(const luci::CircleConcatenation *node)
+{
+  // TODO Support when CircleConcatenation has 0 input
+  assert(node->numValues() > 0);
+
+  auto first_shape = luci::shape_get(node->values(0)).as<loco::TensorShape>();
+  auto axis = node->axis();
+  if (axis < 0)
+    axis += first_shape.rank();
+
+  assert(0 <= axis);
+  assert(first_shape.rank() > static_cast<uint32_t>(axis));
+
+  loco::TensorShape output_shape;
+
+  output_shape.rank(first_shape.rank());
+  for (uint32_t i = 0; i < output_shape.rank(); ++i)
+    output_shape.dim(i) = first_shape.dim(i);
+
+  for (uint32_t i = 1; i < node->numValues(); ++i)
+  {
+    auto input_shape = luci::shape_get(node->values(i)).as<loco::TensorShape>();
+    if (input_shape.rank() != output_shape.rank())
+      INTERNAL_EXN_V("Input has incompatible shape", node->name());
+
+    for (uint32_t j = 0; j < output_shape.rank(); ++j)
+    {
+      if (j == static_cast<uint32_t>(axis))
+      {
+        if (output_shape.dim(j).known() and input_shape.dim(j).known())
+        {
+          output_shape.dim(j) = output_shape.dim(j).value() + input_shape.dim(j).value();
+        }
+        else
+        {
+          // If any of inputs is unknown, just mark it as unknown.
+          output_shape.dim(j).unset();
+        }
+      }
+      else
+      {
+        if (output_shape.dim(j).known() and input_shape.dim(j).known())
+        {
+          if (output_shape.dim(j).value() != input_shape.dim(j).value())
+          {
+            INTERNAL_EXN_V("Input has incompatible shape.", node->name());
+          }
+        }
+        else
+        {
+          if (input_shape.dim(j).known())
+          {
+            assert(not output_shape.dim(j).known()); // FIX_ME_UNLESS
+            output_shape.dim(j) = input_shape.dim(j);
+          }
+          // For unknown input_shape, leave output_shape as-is
+        }
+      }
+    }
+  }
+
+  return output_shape;
 }
 
 } // namespace luci


### PR DESCRIPTION
This migrates concat Op's shape inference rule to sinf::Algorithm.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/13730#issuecomment-2300311180