### PR TITLE
[compute/cker] Add big integer mul test

### DIFF
--- a/compute/cker/src/Mul.test.cc
+++ b/compute/cker/src/Mul.test.cc
@@ -208,6 +208,28 @@ TEST(CKer_Operation, Mul)
       EXPECT_EQ(output[i], expected_output[i]);
   }
 
+  // Int64 big value
+  {
+    // Shape: {1, 2, 2, 1}
+    std::vector<int64_t> input1 = {INT32_MIN, INT32_MIN, INT32_MAX, 3};
+    // Shape: {1, 2, 2, 1}
+    std::vector<int64_t> input2 = {INT32_MAX, INT32_MIN, INT32_MAX, 4};
+    std::vector<int64_t> expected_output = {INT64_MIN / 2 + INT32_MAX + 1, INT64_MAX / 2 + 1,
+                                            INT64_MAX / 2 + INT32_MIN + INT32_MIN + 2, 12};
+    std::vector<int64_t> output(4);
+
+    nnfw::cker::BinaryArithmeticOpParam param;
+    param.int64_activation_min = std::numeric_limits<int64_t>::lowest();
+    param.int64_activation_max = std::numeric_limits<int64_t>::max();
+    nnfw::cker::Shape shape{1, 2, 2, 1};
+
+    nnfw::cker::BinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::MUL>(
+      param, shape, input1.data(), shape, input2.data(), shape, output.data());
+
+    for (size_t i = 0; i < expected_output.size(); ++i)
+      EXPECT_EQ(output[i], expected_output[i]);
+  }
+
   // Int64 Relu
   {
     // Shape: {1, 2, 2, 1}


### PR DESCRIPTION
This commit add big integer mul cker unittest.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/pull/13711/files#r1726028222