### PR TITLE
[luci/service] Support DIV dynamic shape inference

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -64,7 +64,7 @@ public:
   // loco::TensorShape visit(const luci::CircleDepthToSpace *node) final;
   // loco::TensorShape visit(const luci::CircleDepthwiseConv2D *node) final;
   // loco::TensorShape visit(const luci::CircleDequantize *node) final;
-  // loco::TensorShape visit(const luci::CircleDiv *node) final;
+  loco::TensorShape visit(const luci::CircleDiv *node) final;
   // loco::TensorShape visit(const luci::CircleElu *node) final;
   // loco::TensorShape visit(const luci::CircleEqual *node) final;
   // loco::TensorShape visit(const luci::CircleExp *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -16,6 +16,104 @@
 
 #include "CircleShapeInferenceHelper.h"
 
+#include <oops/InternalExn.h>
+
+using namespace luci::sinf;
+
+namespace
+{
+
+/**
+ * @brief  Expand shape x and y to same rank by align right and filling with 1
+ */
+void expand_rank(loco::TensorShape &x, loco::TensorShape &y)
+{
+  auto x_rank = x.rank();
+  auto y_rank = y.rank();
+
+  if (x_rank == y_rank)
+    return;
+
+  TensorShapeExpander x_exp(x);
+  TensorShapeExpander y_exp(y);
+
+  auto xy_rank = std::max(x_rank, y_rank);
+
+  x = x_rank > y_rank ? x : x_exp.to(xy_rank);
+  y = y_rank > x_rank ? y : y_exp.to(xy_rank);
+}
+
+/**
+ * @brief  Return shape of expanded dimension of input x and y having same rank
+ */
+loco::TensorShape expand_dimension(const loco::TensorShape &x, const loco::TensorShape &y)
+{
+  assert(x.rank() == y.rank()); // FIX_CALLER_UNLESS
+
+  auto rank = x.rank();
+
+  loco::TensorShape output_shape;
+
+  output_shape.rank(rank);
+
+  // Shape inference rule (commutative)
+  // Values of x, y, and Result are categorized as 1, X, ? where
+  // X is a positive integer greater than 1 and ? is unknown.
+  //     x | y | Result
+  // c1. 1 | X | X
+  // c2. 1 | ? | ?
+  // c3. X | X | X
+  // c4. X | ? | X
+  // c5. ? | ? | ?
+  // Throw exception if none of the below conditions are met
+  // e1. x == y
+  // e2. x != y and x == 1
+  // e3. x != y and y == 1
+  // e4. x is unknown
+  // e5. y is unknown
+  for (uint32_t axis = 0; axis < rank; ++axis)
+  {
+    const bool x_is_known = x.dim(axis).known();
+    const bool y_is_known = y.dim(axis).known();
+
+    if (x_is_known and y_is_known)
+    {
+      const auto x_dim = x.dim(axis).value();
+      const auto y_dim = y.dim(axis).value();
+
+      // each dimension of x and y should be same or one must be 1 if different
+      if (!((x_dim == y_dim) || (x_dim == 1 || y_dim == 1)))
+        INTERNAL_EXN("Cannot produce expand_dimension of two shapes");
+
+      // c1, c3
+      output_shape.dim(axis).set(std::max(x_dim, y_dim));
+    }
+    else if (not x_is_known and not y_is_known)
+    {
+      // c5
+      output_shape.dim(axis).unset();
+    }
+    else
+    {
+      const uint32_t known_dim = x_is_known ? x.dim(axis).value() : y.dim(axis).value();
+      if (known_dim == 1)
+      {
+        // c2
+        output_shape.dim(axis).unset();
+      }
+      else
+      {
+        // c4
+        output_shape.dim(axis).set(known_dim);
+      }
+    }
+  }
+
+  return output_shape;
+}
+
+} // namespace
+
 namespace luci
 {
 
@@ -45,6 +143,18 @@ loco::TensorShape circle_shape(const luci::CircleNode *node)
   for (uint32_t r = 0; r < node->rank(); ++r)
     shape.dim(r) = node->dim(r);
   return shape;
+}
+
+loco::TensorShape broadcast_shape(const loco::TensorShape &x, const loco::TensorShape &y)
+{
+  auto x_match = x;
+  auto y_match = y;
+
+  expand_rank(x_match, y_match);
+
+  auto output_shape = expand_dimension(x_match, y_match);
+
+  return output_shape;
 }
 
 } // namespace sinf

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -57,13 +57,13 @@ loco::TensorShape expand_dimension(const loco::TensorShape &x, const loco::Tenso
   output_shape.rank(rank);
 
   // Shape inference rule (commutative)
-  // Values of x, y, and Result are categorized as 1, X, ? where
-  // X is a positive integer greater than 1 and ? is unknown.
+  // Dimension values of x, y, and Result are categorized as 1, N, ?
+  // where N is a positive integer greater than 1 and ? is unknown.
   //     x | y | Result
-  // c1. 1 | X | X
+  // c1. 1 | N | N
   // c2. 1 | ? | ?
-  // c3. X | X | X
-  // c4. X | ? | X
+  // c3. N | N | N
+  // c4. N | ? | N
   // c5. ? | ? | ?
   // Throw exception if none of the below conditions are met
   // e1. x == y

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.h
@@ -44,6 +44,49 @@ namespace sinf // Namespace for Shape Inference
 // Return shape of circle node as loco::TensorShape
 loco::TensorShape circle_shape(const luci::CircleNode *node);
 
+// Return broadcasted shape of output from two input shapes
+// Throw an exception if x and y are not broadcastable.
+loco::TensorShape broadcast_shape(const loco::TensorShape &x, const loco::TensorShape &y);
+
+/**
+ * @brief Create a higher-rank TensorShape following NumPy broadcasting semantics
+ *
+ * HOW TO USE:
+ *
+ *   auto expanded_tensor_shape = expand(tensor_shape).to(N);
+ */
+class TensorShapeExpander final
+{
+public:
+  TensorShapeExpander(const loco::TensorShape &shape) : _shape{shape}
+  {
+    // DO NOTHING
+  }
+
+public:
+  loco::TensorShape to(uint32_t output_rank)
+  {
+    auto const &input_shape = _shape;
+    uint32_t const input_rank = input_shape.rank();
+
+    assert(input_rank <= output_rank && "Cannot shrink rank");
+    uint32_t const axis_shift = output_rank - input_rank;
+
+    loco::TensorShape output_shape;
+
+    output_shape.rank(output_rank);
+    for (uint32_t axis = 0; axis < output_rank; ++axis)
+    {
+      output_shape.dim(axis) = (axis < axis_shift) ? 1 : input_shape.dim(axis - axis_shift);
+    }
+
+    return output_shape;
+  }
+
+private:
+  const loco::TensorShape _shape;
+};
+
 } // namespace sinf
 } // namespace luci
 

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2082,8 +2082,6 @@ public:
     return loco::NodeShape{input_shape};
   }
 
-  loco::NodeShape visit(const luci::CircleDiv *node) final { return broadcast_xy(node); }
-
   loco::NodeShape visit(const luci::CircleElu *node) final
   {
     auto input_shape = luci::shape_get(node->features()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/Nodes/CircleDiv.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDiv.cpp
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#include <luci/Service/CircleShapeInference.h>
+
 #include "CircleCloneNode.h"
+
+#include "CircleShapeInferenceHelper.h"
 
 namespace luci
 {
@@ -28,6 +32,19 @@ luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDiv *node)
   if (cloned != nullptr)
     cloned->fusedActivationFunction(node->fusedActivationFunction());
   return cloned;
+}
+
+loco::TensorShape sinf::Algorithm::visit(const luci::CircleDiv *node)
+{
+  const auto x = loco::must_cast<luci::CircleNode *>(node->x());
+  const auto y = loco::must_cast<luci::CircleNode *>(node->y());
+
+  const auto x_shape = sinf::circle_shape(x);
+  const auto y_shape = sinf::circle_shape(y);
+
+  auto output_shape = broadcast_shape(x_shape, y_shape);
+
+  return output_shape;
 }
 
 } // namespace luci


### PR DESCRIPTION
This supports dynamic shape inference for DIV Op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/13697