### PR TITLE
[onert] Remove tensor's layout usage on permute

### DIFF
--- a/runtime/onert/core/include/ir/Layout.h
+++ b/runtime/onert/core/include/ir/Layout.h
@@ -48,6 +48,13 @@ inline std::string to_string(Layout layout)
   }
 }
 
+enum class PermuteType
+{
+  SAME = 0,
+  NCHW_TO_NHWC = 1,
+  NHWC_TO_NCHW = 2
+};
+
 } // namespace ir
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -103,9 +103,12 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   // Add PermuteLayer
   std::vector<ITensor *> output_tensors{getTensor(output_index)};
   std::vector<ITensor *> input_tensors{getTensor(input_index)};
+  std::vector<ir::PermuteType> permute_types;
+  for (uint32_t i = 0; i < input_tensors.size(); i++)
+    permute_types.emplace_back(ir::PermuteType::SAME);
 
-  auto fn =
-    std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, _external_context);
+  auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, permute_types,
+                                                   _external_context);
   _return_fn = std::move(fn);
 }
 

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
@@ -35,6 +35,7 @@ class PermuteLayer : public onert::exec::IPermuteFunction
 {
 public:
   PermuteLayer(const std::vector<ITensor *> &src_tensors, const std::vector<ITensor *> &dst_tensors,
+               const std::vector<ir::PermuteType> &types,
                const std::shared_ptr<ExternalContext> &external_context);
 
   void optimize() override;

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -84,10 +84,15 @@ void WhileLayer::run()
 
   std::vector<ITensor *> op_inputs(_input_tensors.begin(), _input_tensors.end());
   std::vector<ITensor *> op_outputs(_output_tensors.begin(), _output_tensors.end());
+  std::vector<ir::PermuteType> permute_types;
+  for (uint32_t i = 0; i < op_outputs.size(); i++)
+    permute_types.emplace_back(ir::PermuteType::SAME);
+
   // Copying body inputs to outputs when the loop body is never executed
   if (!getResultCond(cond_output_tensor.get()))
   {
-    PermuteLayer copy_body_inputs_to_op_outputs{op_inputs, op_outputs, _external_context};
+    PermuteLayer copy_body_inputs_to_op_outputs{op_inputs, op_outputs, permute_types,
+                                                _external_context};
     copy_body_inputs_to_op_outputs.run();
     return;
   }
@@ -105,7 +110,8 @@ void WhileLayer::run()
   }
 
   std::vector<ITensor *> body_outputs(temp_outputs.begin(), temp_outputs.end());
-  PermuteLayer copy_body_outputs_to_op_outputs{body_outputs, op_outputs, _external_context};
+  PermuteLayer copy_body_outputs_to_op_outputs{body_outputs, op_outputs, permute_types,
+                                               _external_context};
 
   const auto body_execute_with_op_inputs = [&]() {
     VERBOSE(While) << "Call to $" << _body_subg_index << " (body)" << std::endl;

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -76,8 +76,12 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
       ignore_forward_in_training = true;
   }
 
+  std::vector<ir::PermuteType> permute_types;
+  for (uint32_t i = 0; i < input_tensors.size(); i++)
+    permute_types.emplace_back(ir::PermuteType::SAME);
+
   auto fn = std::make_unique<kernel::PermuteLayer>(
-    input_tensors, output_tensors, input_back_prop_tensors, output_back_prop_tensors,
+    input_tensors, output_tensors, input_back_prop_tensors, output_back_prop_tensors, permute_types,
     ignore_forward_in_training, _external_context);
 
   _return_fn = std::move(fn);

--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
@@ -33,9 +33,10 @@ PermuteLayer::PermuteLayer(const std::vector<ITensor *> &src_tensors,
                            const std::vector<ITensor *> &dst_tensors,
                            const std::vector<ITensor *> &input_back_prop_tensors,
                            const std::vector<ITensor *> &output_back_prop_tensors,
+                           const std::vector<ir::PermuteType> &types,
                            bool ignore_forward_in_training,
                            const std::shared_ptr<ExternalContext> &external_context)
-  : builtin::kernel::PermuteLayer{src_tensors, dst_tensors, external_context},
+  : builtin::kernel::PermuteLayer{src_tensors, dst_tensors, types, external_context},
     _input_back_prop_tensors{input_back_prop_tensors},
     _output_back_prop_tensors{output_back_prop_tensors},
     _ignore_forward_in_training{ignore_forward_in_training}
@@ -73,9 +74,10 @@ void PermuteLayer::backward()
       const auto rank = src_back_prop->getShape().rank();
       auto output_offsets = _dst_tensors_offsets.at(i);
       auto input_offsets = _src_tensors_offsets.at(i);
+      auto permute_type = _permute_types.at(i);
 
       exec::IPermuteFunction::permute(src_back_prop, dst_back_prop, rank, output_offsets,
-                                      input_offsets);
+                                      input_offsets, permute_type);
     }
   }
 }

--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.h
@@ -38,7 +38,7 @@ public:
   PermuteLayer(const std::vector<ITensor *> &src_tensors, const std::vector<ITensor *> &dst_tensors,
                const std::vector<ITensor *> &input_back_prop_tensors,
                const std::vector<ITensor *> &output_back_prop_tensors,
-               bool ignore_forward_in_training,
+               const std::vector<ir::PermuteType> &types, bool ignore_forward_in_training,
                const std::shared_ptr<ExternalContext> &external_context);
 
   void optimize() override;

--- a/runtime/onert/core/src/exec/IPermuteFunction.cc
+++ b/runtime/onert/core/src/exec/IPermuteFunction.cc
@@ -233,17 +233,19 @@ void IPermuteFunction::IPermuteFunction::run()
     auto dst_tensor = _dst_tensors.at(i);
     auto &src_offsets = _src_tensors_offsets.at(i);
     auto &dst_offsets = _dst_tensors_offsets.at(i);
+    auto permute_type = _permute_types.at(i);
     if (src_tensor != dst_tensor)
     {
       const auto rank = src_tensor->getShape().rank();
-      permute(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+      permute(src_tensor, dst_tensor, rank, src_offsets, dst_offsets, permute_type);
     }
   }
 }
 
 void IPermuteFunction::permute(backend::ITensor *src_tensor, backend::ITensor *dst_tensor,
                                size_t rank, std::vector<size_t> &src_offsets,
-                               std::vector<size_t> &dst_offsets)
+                               std::vector<size_t> &dst_offsets,
+                               const ir::PermuteType &permute_type)
 {
   if (src_tensor->total_size() == 0)
   {
@@ -261,28 +263,28 @@ void IPermuteFunction::permute(backend::ITensor *src_tensor, backend::ITensor *d
   switch (src_tensor->data_type())
   {
     case ir::DataType::FLOAT32:
-      permute<float>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+      permute<float>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets, permute_type);
       break;
     case ir::DataType::INT32:
-      permute<int32_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+      permute<int32_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets, permute_type);
       break;
     case ir::DataType::UINT32:
-      permute<uint32_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+      permute<uint32_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets, permute_type);
       break;
     case ir::DataType::BOOL8:
     case ir::DataType::QUANT_UINT8_ASYMM:
     case ir::DataType::UINT8:
-      permute<uint8_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+      permute<uint8_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets, permute_type);
       break;
     case ir::DataType::QUANT_INT8_ASYMM:
     case ir::DataType::QUANT_INT8_SYMM:
-      permute<int8_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+      permute<int8_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets, permute_type);
       break;
     case ir::DataType::INT64:
-      permute<int64_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+      permute<int64_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets, permute_type);
       break;
     case ir::DataType::QUANT_INT16_SYMM:
-      permute<int16_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+      permute<int16_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets, permute_type);
       break;
     default:
       throw std::runtime_error("IPermuteFunction: Not supported data type");

--- a/runtime/onert/core/src/exec/IPermuteFunction.test.cc
+++ b/runtime/onert/core/src/exec/IPermuteFunction.test.cc
@@ -97,11 +97,14 @@ private:
 class MockUpLayer : public IPermuteFunction
 {
 public:
-  MockUpLayer(const std::vector<ITensor *> &inputs, const std::vector<ITensor *> &outputs)
+  MockUpLayer(const std::vector<ITensor *> &inputs, const std::vector<ITensor *> &outputs,
+              const std::vector<ir::PermuteType> &types)
   {
     assert(inputs.size() == outputs.size());
+    assert(types.size() == outputs.size());
     _src_tensors = inputs;
     _dst_tensors = outputs;
+    _permute_types = types;
   }
   virtual ~MockUpLayer() {}
   void optimize() override {}
@@ -135,7 +138,9 @@ TEST(IPermuteFunction, float_to_float)
     auto mockup_layer = std::make_unique<MockUpLayer>(
       std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
       std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+                             outputs[3].get()},
+      std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                   ir::PermuteType::SAME, ir::PermuteType::SAME});
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -177,7 +182,9 @@ TEST(IPermuteFunction, float_to_float)
     auto mockup_layer = std::make_unique<MockUpLayer>(
       std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
       std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+                             outputs[3].get()},
+      std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                   ir::PermuteType::SAME, ir::PermuteType::SAME});
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -222,7 +229,9 @@ TEST(IPermuteFunction, float_to_float)
     auto mockup_layer = std::make_unique<MockUpLayer>(
       std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
       std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+                             outputs[3].get()},
+      std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                   ir::PermuteType::SAME, ir::PermuteType::SAME});
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -270,7 +279,9 @@ TEST(IPermuteFunction, float_to_float)
     auto mockup_layer = std::make_unique<MockUpLayer>(
       std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
       std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+                             outputs[3].get()},
+      std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                   ir::PermuteType::SAME, ir::PermuteType::SAME});
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -307,6 +318,7 @@ TEST(IPermuteFunction, float_to_float)
 
     std::vector<std::unique_ptr<MockUpTensor>> inputs(4);
     std::vector<std::unique_ptr<MockUpTensor>> outputs(4);
+    std::vector<ir::PermuteType> types(4);
     std::vector<std::unique_ptr<uint8_t[]>> output_buffers(4);
     for (size_t i = 0; i < 4; ++i)
     {
@@ -324,11 +336,13 @@ TEST(IPermuteFunction, float_to_float)
       {
         layout = Layout::NCHW;
         shape = Shape{shapes[i].dim(0), shapes[i].dim(3), shapes[i].dim(1), shapes[i].dim(2)};
+        types[i] = ir::PermuteType::NHWC_TO_NCHW;
       }
       else
       {
         layout = Layout::NHWC;
         shape = shapes[i];
+        types[i] = ir::PermuteType::NCHW_TO_NHWC;
       }
       outputs[i] = std::make_unique<MockUpTensor>(shape, type_info, layout, output_pads[i]);
       output_buffers[i] = std::make_unique<uint8_t[]>(outputs[i]->total_size());
@@ -338,7 +352,8 @@ TEST(IPermuteFunction, float_to_float)
     auto mockup_layer = std::make_unique<MockUpLayer>(
       std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
       std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+                             outputs[3].get()},
+      types);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -408,7 +423,9 @@ TEST(IPermuteFunction, float_to_qasymm8)
 
   auto mockup_layer = std::make_unique<MockUpLayer>(
     std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()},
+    std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                 ir::PermuteType::SAME, ir::PermuteType::SAME});
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -461,7 +478,9 @@ TEST(IPermuteFunction, float_to_qsymm8)
 
   auto mockup_layer = std::make_unique<MockUpLayer>(
     std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()},
+    std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                 ir::PermuteType::SAME, ir::PermuteType::SAME});
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -514,7 +533,9 @@ TEST(IPermuteFunction, float_to_qsymm16)
 
   auto mockup_layer = std::make_unique<MockUpLayer>(
     std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()},
+    std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                 ir::PermuteType::SAME, ir::PermuteType::SAME});
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -576,7 +597,9 @@ TEST(IPermuteFunction, qasymm8_to_float)
 
   auto mockup_layer = std::make_unique<MockUpLayer>(
     std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()},
+    std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                 ir::PermuteType::SAME, ir::PermuteType::SAME});
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -638,7 +661,9 @@ TEST(IPermuteFunction, qsymm8_to_float)
 
   auto mockup_layer = std::make_unique<MockUpLayer>(
     std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()},
+    std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                 ir::PermuteType::SAME, ir::PermuteType::SAME});
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -700,7 +725,9 @@ TEST(IPermuteFunction, qsymm16_to_float)
 
   auto mockup_layer = std::make_unique<MockUpLayer>(
     std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()},
+    std::vector<ir::PermuteType>{ir::PermuteType::SAME, ir::PermuteType::SAME,
+                                 ir::PermuteType::SAME, ir::PermuteType::SAME});
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -741,6 +768,7 @@ TEST(IPermuteFunction, float_qasymm8_layout)
 
     std::vector<std::unique_ptr<MockUpTensor>> inputs(4);
     std::vector<std::unique_ptr<MockUpTensor>> outputs(4);
+    std::vector<ir::PermuteType> types(4);
     std::vector<std::unique_ptr<uint8_t[]>> output_buffers(4);
     for (size_t i = 0; i < 4; ++i)
     {
@@ -759,11 +787,13 @@ TEST(IPermuteFunction, float_qasymm8_layout)
       {
         layout = Layout::NCHW;
         shape = Shape{shapes[i].dim(0), shapes[i].dim(3), shapes[i].dim(1), shapes[i].dim(2)};
+        types[i] = ir::PermuteType::NHWC_TO_NCHW;
       }
       else
       {
         layout = Layout::NHWC;
         shape = shapes[i];
+        types[i] = ir::PermuteType::NCHW_TO_NHWC;
       }
       TypeInfo type_info{DataType::QUANT_UINT8_ASYMM, scale, zero_point};
       outputs[i] = std::make_unique<MockUpTensor>(shape, type_info, layout, output_pads[i]);
@@ -774,7 +804,8 @@ TEST(IPermuteFunction, float_qasymm8_layout)
     auto mockup_layer = std::make_unique<MockUpLayer>(
       std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
       std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+                             outputs[3].get()},
+      types);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -839,6 +870,7 @@ TEST(IPermuteFunction, float_qasymm8_layout)
 
     std::vector<std::unique_ptr<MockUpTensor>> inputs(4);
     std::vector<std::unique_ptr<MockUpTensor>> outputs(4);
+    std::vector<ir::PermuteType> types(4);
     std::vector<std::unique_ptr<uint8_t[]>> output_buffers(4);
     for (size_t i = 0; i < 4; ++i)
     {
@@ -857,11 +889,13 @@ TEST(IPermuteFunction, float_qasymm8_layout)
       {
         layout = Layout::NCHW;
         shape = Shape{shapes[i].dim(0), shapes[i].dim(3), shapes[i].dim(1), shapes[i].dim(2)};
+        types[i] = ir::PermuteType::NHWC_TO_NCHW;
       }
       else
       {
         layout = Layout::NHWC;
         shape = shapes[i];
+        types[i] = ir::PermuteType::NCHW_TO_NHWC;
       }
       outputs[i] =
         std::make_unique<MockUpTensor>(shape, TypeInfo(DataType::FLOAT32), layout, output_pads[i]);
@@ -872,7 +906,8 @@ TEST(IPermuteFunction, float_qasymm8_layout)
     auto mockup_layer = std::make_unique<MockUpLayer>(
       std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
       std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+                             outputs[3].get()},
+      types);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -186,6 +186,7 @@ void MultiModelExecutors::createEdgeQuantLayers()
 
     std::vector<backend::ITensor *> inputs;
     std::vector<backend::ITensor *> outputs;
+    std::vector<ir::PermuteType> permute_types;
     for (const auto &[from_iodesc, to_list] : _edge_map)
     {
       if (std::get<ir::ModelIndex>(from_iodesc) == model_index &&
@@ -212,13 +213,16 @@ void MultiModelExecutors::createEdgeQuantLayers()
             auto type_aware_quant_tensor = std::make_unique<EdgeTensor>(to_info, to_layout);
             outputs.emplace_back(type_aware_quant_tensor.get());
 
+            // No layout change on edge
+            permute_types.emplace_back(ir::PermuteType::SAME);
+
             _edge_quant_tensors[to_iodesc] = std::move(type_aware_quant_tensor);
           }
         }
       }
     }
 
-    auto layer = std::make_unique<PermuteLayer>(inputs, outputs);
+    auto layer = std::make_unique<PermuteLayer>(inputs, outputs, permute_types);
     layer->prepare();
     _edge_quant_layers[{model_index, subg_index}] = std::move(layer);
   }
@@ -282,6 +286,7 @@ void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
     }
     std::vector<backend::ITensor *> src_tensors;
     std::vector<backend::ITensor *> dst_tensors;
+    std::vector<ir::PermuteType> permute_types;
     for (const auto &pkg_input : pkg_inputs)
     {
       const auto &io_index = std::get<ir::IOIndex>(pkg_input);
@@ -294,7 +299,8 @@ void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
       // Create EdgeTensor for nnpkg input if type is different
       const auto &orig_info = executor->inputInfo(io_index.value());
       const auto orig_layout = executor->inputLayout(io_index.value());
-      if (input_desc->info.typeInfo().type() != orig_info.typeInfo().type())
+      if ((input_desc->info.typeInfo().type() != orig_info.typeInfo().type()) ||
+          (input_desc->layout == ir::Layout::NCHW))
       {
         auto pkg_input_edge_tensor = std::make_unique<EdgeTensor>(orig_info, orig_layout);
         _pkg_input_quant_tensors[pkg_input] = std::move(pkg_input_edge_tensor);
@@ -302,11 +308,16 @@ void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
         // Append type-aware quantization layer's inputs/outputs
         src_tensors.emplace_back(_pkg_input_tensors[pkg_input].get());
         dst_tensors.emplace_back(_pkg_input_quant_tensors[pkg_input].get());
+
+        if (input_desc->layout == ir::Layout::NCHW)
+          permute_types.emplace_back(ir::PermuteType::NCHW_TO_NHWC);
+        else
+          permute_types.emplace_back(ir::PermuteType::SAME);
       }
     }
 
     // Create type-aware quantization layer for nnpkg inputs
-    auto pkg_input_layer = std::make_unique<PermuteLayer>(src_tensors, dst_tensors);
+    auto pkg_input_layer = std::make_unique<PermuteLayer>(src_tensors, dst_tensors, permute_types);
     pkg_input_layer->prepare();
     _pkg_input_quant_layers[{model_index, subg_index}] = std::move(pkg_input_layer);
 
@@ -322,6 +333,7 @@ void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
     }
     src_tensors.clear();
     dst_tensors.clear();
+    permute_types.clear();
     // Create Tensors of nnpkg outputs for type-aware quantization
     for (const auto &pkg_output : pkg_outputs)
     {
@@ -335,7 +347,8 @@ void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
       // Create EdgeTensor for nnpkg output if type is different
       const auto &orig_info = executor->outputInfo(io_index.value());
       const auto orig_layout = executor->outputLayout(io_index.value());
-      if (output_desc->info.typeInfo().type() != orig_info.typeInfo().type())
+      if ((output_desc->info.typeInfo().type() != orig_info.typeInfo().type()) ||
+          (output_desc->layout == ir::Layout::NCHW))
       {
         auto pkg_output_edge_tensor = std::make_unique<EdgeTensor>(orig_info, orig_layout);
         _pkg_output_quant_tensors[pkg_output] = std::move(pkg_output_edge_tensor);
@@ -343,11 +356,16 @@ void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
         // Append type-aware quantization layer's inputs/outputs
         src_tensors.emplace_back(_pkg_output_quant_tensors[pkg_output].get());
         dst_tensors.emplace_back(_pkg_output_tensors[pkg_output].get());
+
+        if (output_desc->layout == ir::Layout::NCHW)
+          permute_types.emplace_back(ir::PermuteType::NHWC_TO_NCHW);
+        else
+          permute_types.emplace_back(ir::PermuteType::SAME);
       }
     }
 
     // Create type-aware quantization layer for nnpkg outputs
-    auto pkg_output_layer = std::make_unique<PermuteLayer>(src_tensors, dst_tensors);
+    auto pkg_output_layer = std::make_unique<PermuteLayer>(src_tensors, dst_tensors, permute_types);
     pkg_output_layer->prepare();
     _pkg_output_quant_layers[{model_index, subg_index}] = std::move(pkg_output_layer);
   }

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -66,10 +66,12 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   // Vector for input quantization I/O
   std::vector<backend::ITensor *> input_tensors;
   std::vector<backend::ITensor *> input_qtensors;
+  std::vector<ir::PermuteType> input_permute_types;
 
   // Vector for output dequantization I/O
   std::vector<backend::ITensor *> output_qtensors;
   std::vector<backend::ITensor *> output_tensors;
+  std::vector<ir::PermuteType> output_permute_types;
 
   // Prepare UserTensor and EdgeTensor for input quantization
   for (uint32_t i = 0; i < inputs.size(); i++)
@@ -87,7 +89,8 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
     auto user_type = desc->info.typeInfo().type();
     auto &model_info = entryExecutor()->inputInfo(i).typeInfo();
     auto model_type = model_info.type();
-    if (user_type != model_type && user_type == ir::DataType::FLOAT32)
+    if ((user_type != model_type && user_type == ir::DataType::FLOAT32) ||
+        (desc->layout == ir::Layout::NCHW))
     {
       auto quantized_info = desc->info;
       quantized_info.typeInfo(model_info);
@@ -98,6 +101,10 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       input_tensors.push_back(tensorpool.back().get());
       input_qtensors.push_back(qtensorpool.back().get());
       inputs[i] = qtensorpool.back().get();
+      if (desc->layout == ir::Layout::NCHW)
+        input_permute_types.push_back(ir::PermuteType::NCHW_TO_NHWC);
+      else
+        input_permute_types.push_back(ir::PermuteType::SAME);
     }
     else
       inputs[i] = tensorpool.back().get();
@@ -118,7 +125,8 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
     auto user_type = desc->info.typeInfo().type();
     auto &model_info = entryExecutor()->outputInfo(i).typeInfo();
     auto model_type = model_info.type();
-    if (user_type != model_type && user_type == ir::DataType::FLOAT32)
+    if ((user_type != model_type && user_type == ir::DataType::FLOAT32) ||
+        (desc->layout == ir::Layout::NCHW))
     {
       auto quantized_info = desc->info;
       quantized_info.typeInfo(model_info);
@@ -129,6 +137,11 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       output_qtensors.push_back(qtensorpool.back().get());
       output_tensors.push_back(tensorpool.back().get());
       outputs[i] = qtensorpool.back().get();
+
+      if (desc->layout == ir::Layout::NCHW)
+        output_permute_types.push_back(ir::PermuteType::NHWC_TO_NCHW);
+      else
+        output_permute_types.push_back(ir::PermuteType::SAME);
     }
     else
       outputs[i] = tensorpool.back().get();
@@ -137,7 +150,7 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   // Run quantization
   if (input_tensors.size() > 0)
   {
-    auto input_quantize_layer = PermuteLayer(input_tensors, input_qtensors);
+    auto input_quantize_layer = PermuteLayer(input_tensors, input_qtensors, input_permute_types);
     input_quantize_layer.prepare();
     input_quantize_layer.run();
   }
@@ -148,7 +161,8 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   // Run dequantization
   if (output_tensors.size() != 0)
   {
-    auto output_dequantize_layer = PermuteLayer(output_qtensors, output_tensors);
+    auto output_dequantize_layer =
+      PermuteLayer(output_qtensors, output_tensors, output_permute_types);
     output_dequantize_layer.prepare();
     output_dequantize_layer.run();
   }


### PR DESCRIPTION
This commit changes permute operation to not use tensor's layout information. 
Instead, constructor get permutation type.
This commit is preparation to remove layout information from tensor.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #12130 #13494