### PR TITLE
 [onert] Move PermuteType

### DIFF
--- a/runtime/onert/core/include/ir/Layout.h
+++ b/runtime/onert/core/include/ir/Layout.h
@@ -33,6 +33,13 @@ enum class Layout
   NCHW
 };
 
+enum class PermuteType
+{
+  NHWC_TO_NCHW,
+  NCHW_TO_NHWC,
+  COPY
+};
+
 inline std::string to_string(Layout layout)
 {
   switch (layout)

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
@@ -65,20 +65,20 @@ void PermuteLayer::optimize()
       dst_offsets_it->resize(0);
       if (underlying_type(src->data_type()) != underlying_type(dst->data_type()))
         continue;
-      const auto permute_type = [&]() -> PermuteType {
+      const auto permute_type = [&]() -> ir::PermuteType {
         if (src->getShape().rank() == 4 && src->layout() == ir::Layout::NHWC &&
             dst->layout() == ir::Layout::NCHW)
         {
-          return PermuteType::NHWC_TO_NCHW;
+          return ir::PermuteType::NHWC_TO_NCHW;
         }
         else if (src->getShape().rank() == 4 && src->layout() == ir::Layout::NCHW &&
                  dst->layout() == ir::Layout::NHWC)
         {
-          return PermuteType::NCHW_TO_NHWC;
+          return ir::PermuteType::NCHW_TO_NHWC;
         }
         else
         {
-          return PermuteType::COPY;
+          return ir::PermuteType::COPY;
         }
       }();
 
@@ -88,7 +88,7 @@ void PermuteLayer::optimize()
           // NOTE The buffer of both tensor can be nullptr in this step
           const auto data_size = ir::sizeOfDataType(src_tensor.data_type());
 
-          if (permute_type == PermuteType::COPY)
+          if (permute_type == ir::PermuteType::COPY)
           {
             if ((!src_tensor.has_padding() && !dst_tensor.has_padding()))
             {
@@ -125,8 +125,8 @@ void PermuteLayer::optimize()
           else
           {
             assert(src_tensor.getShape().rank() == 4 &&
-                   (permute_type == PermuteType::NHWC_TO_NCHW ||
-                    permute_type == PermuteType::NCHW_TO_NHWC));
+                   (permute_type == ir::PermuteType::NHWC_TO_NCHW ||
+                    permute_type == ir::PermuteType::NCHW_TO_NHWC));
             const auto loop_shape = src_tensor.getShape();
             const auto copy_len = data_size;
 

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -66,14 +66,6 @@ inline void CopyDynamic(const ::onert::backend::ITensor *src, const ::onert::bac
 
 class IPermuteFunction : public IFunction
 {
-protected:
-  enum class PermuteType
-  {
-    NHWC_TO_NCHW,
-    NCHW_TO_NHWC,
-    COPY
-  };
-
 public:
   virtual void run() override;
 
@@ -138,25 +130,25 @@ private:
     assert(dst_buffer != nullptr);
     assert(dst_size == dst->total_size());
 
-    const auto permute_type = [&]() -> PermuteType {
+    const auto permute_type = [&]() -> ir::PermuteType {
       if (src->layout() == ir::Layout::NHWC && dst->layout() == ir::Layout::NCHW)
       {
-        return PermuteType::NHWC_TO_NCHW;
+        return ir::PermuteType::NHWC_TO_NCHW;
       }
       else if (src->layout() == ir::Layout::NCHW && dst->layout() == ir::Layout::NHWC)
       {
-        return PermuteType::NCHW_TO_NHWC;
+        return ir::PermuteType::NCHW_TO_NHWC;
       }
       else
       {
-        return PermuteType::COPY;
+        return ir::PermuteType::COPY;
       }
     }();
-    if (rank == 4 && permute_type != PermuteType::COPY)
+    if (rank == 4 && permute_type != ir::PermuteType::COPY)
     {
       switch (permute_type)
       {
-        case PermuteType::NHWC_TO_NCHW:
+        case ir::PermuteType::NHWC_TO_NCHW:
         {
           ir::FeatureShape shape;
           auto dst_shape = dst->getShape();
@@ -181,7 +173,7 @@ private:
           };
           break;
         }
-        case PermuteType::NCHW_TO_NHWC:
+        case ir::PermuteType::NCHW_TO_NHWC:
         {
           ir::FeatureShape shape;
           auto dst_shape = dst->getShape();


### PR DESCRIPTION
 This commit changes PermuteType from IPermuteFunction's protected enum class to public enum class and move into Layout.h.
 It will be used on outside of IPermuteFunction's derived classes.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

Draft: #13747 