### PR TITLE
[common-artifacts] Add Add_STR to exclude.lst

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -5,6 +5,8 @@
 
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
+optimize(Add_STR_000) # STRING is not supported
+optimize(Add_STR_001) # STRING is not supported
 
 ## CircleRecipes
 


### PR DESCRIPTION
This adds Add_STR tests to exclude.lst.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/13697
Draft PR: https://github.com/Samsung/ONE/pull/13750