### PR TITLE
[luci/service] Support ADD dynamic shape inference

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -47,7 +47,7 @@ public:
   }
 
   // loco::TensorShape visit(const luci::CircleAbs *node) final;
-  // loco::TensorShape visit(const luci::CircleAdd *node) final;
+  loco::TensorShape visit(const luci::CircleAdd *node) final;
   // loco::TensorShape visit(const luci::CircleAddN *node) final;
   // loco::TensorShape visit(const luci::CircleArgMax *node) final;
   // loco::TensorShape visit(const luci::CircleArgMin *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2019,8 +2019,6 @@ class ShapeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::NodeS
 public:
   loco::NodeShape visit(const luci::CircleAbs *node) final { return use_x(node); }
 
-  loco::NodeShape visit(const luci::CircleAdd *node) final { return broadcast_xy(node); }
-
   loco::NodeShape visit(const luci::CircleAddN *node) final { return infer_add_n(node); }
 
   loco::NodeShape visit(const luci::CircleArgMax *node) final { return infer_arg_maxmin(node); }

--- a/compiler/luci/service/src/Nodes/CircleAdd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAdd.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#include <luci/Service/CircleShapeInference.h>
+
+#include "CircleShapeInferenceHelper.h"
+
 #include "CircleCloneNode.h"
 
 namespace luci
@@ -28,6 +32,17 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleAdd *node)
   if (cloned != nullptr)
     cloned->fusedActivationFunction(node->fusedActivationFunction());
   return cloned;
+}
+
+loco::TensorShape sinf::Algorithm::visit(const luci::CircleAdd *node)
+{
+  const auto x = loco::must_cast<luci::CircleNode *>(node->x());
+  const auto y = loco::must_cast<luci::CircleNode *>(node->y());
+
+  const auto x_shape = sinf::circle_shape(x);
+  const auto y_shape = sinf::circle_shape(y);
+
+  return broadcast_shape(x_shape, y_shape);
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleAdd.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAdd.test.cpp
@@ -56,6 +56,235 @@ TEST(ShapeRuleTest, different_input_shapes_add)
   ASSERT_EQ(5, shape.dim(2).value());
 }
 
+TEST(ShapeRuleTest, add_dynamic_shape_non_1)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+
+  input_2.shape({1, 1, 1});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+  input_2.dim(0).unset();
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&add, shape));
+  ASSERT_EQ(4, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_TRUE(shape.dim(2).known());
+  ASSERT_TRUE(shape.dim(3).known());
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(4, shape.dim(1).value());
+  ASSERT_EQ(3, shape.dim(2).value());
+  ASSERT_EQ(1, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, add_dynamic_shape_1)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+
+  input_2.shape({1, 1, 1});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+  input_2.dim(2).unset();
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&add, shape));
+  ASSERT_EQ(4, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_TRUE(shape.dim(2).known());
+  ASSERT_FALSE(shape.dim(3).known());
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(4, shape.dim(1).value());
+  ASSERT_EQ(3, shape.dim(2).value());
+  ASSERT_EQ(0, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, add_dynamic_shape_both)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+  input_1.dim(3).unset();
+
+  input_2.shape({1, 1, 1});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+  input_2.dim(2).unset();
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&add, shape));
+  ASSERT_EQ(4, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_TRUE(shape.dim(2).known());
+  ASSERT_FALSE(shape.dim(3).known());
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(4, shape.dim(1).value());
+  ASSERT_EQ(3, shape.dim(2).value());
+  ASSERT_EQ(0, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, add_scalar)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+
+  input_2.shape({});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&add, shape));
+  ASSERT_EQ(4, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_TRUE(shape.dim(2).known());
+  ASSERT_TRUE(shape.dim(3).known());
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(4, shape.dim(1).value());
+  ASSERT_EQ(3, shape.dim(2).value());
+  ASSERT_EQ(1, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, add_not_broadcastable_NEG)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+
+  input_2.shape({1, 2, 1});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&add, shape));
+}
+
+TEST(ShapeRuleTest, add_not_broadcastable_2_NEG)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+
+  input_2.shape({2, 1, 1});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&add, shape));
+}
+
+TEST(ShapeRuleTest, add_not_broadcastable_3_NEG)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+
+  input_2.shape({2, 3, 1});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&add, shape));
+}
+
+TEST(ShapeRuleTest, add_not_broadcastable_4_NEG)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+
+  input_2.shape({2, 3, 2});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&add, shape));
+}
+
+TEST(ShapeRuleTest, add_not_broadcastable_5_NEG)
+{
+  luci::CircleInput input_1;
+  luci::CircleInput input_2;
+  luci::CircleAdd add;
+
+  input_1.shape({1, 4, 3, 1});
+  input_1.shape_status(luci::ShapeStatus::VALID);
+
+  input_2.shape({3, 2, 3, 2});
+  input_2.shape_status(luci::ShapeStatus::VALID);
+
+  add.x(&input_1);
+  add.y(&input_2);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&add, shape));
+}
+
 TEST(CloneNodeTest, clone_Add)
 {
   auto g = loco::make_graph();


### PR DESCRIPTION
This supports dynamic shape inference for ADD Op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/13697
Draft PR: https://github.com/Samsung/ONE/pull/13750