### PR TITLE
[onert] Introduce CheckpointExporter to store checkpoint file

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -26,6 +26,7 @@
 #include "loader/TFLiteLoader.h"
 #include "loader/TrainInfoLoader.h"
 #include "exporter/CircleExporter.h"
+#include "exporter/train/CheckpointExporter.h"
 #include "json/json.h"
 #include "ir/NNPkg.h"
 #include "ir/OpCode.h"
@@ -1745,7 +1746,7 @@ NNFW_STATUS nnfw_session::train_export_checkpoint(const char *path)
 
   try
   {
-    // TODO Implement exporting checkpoint
+    onert::exporter::train::exportCheckpoint(path, _train_info, _execution);
   }
   catch (const std::exception &e)
   {

--- a/runtime/onert/core/include/exporter/train/CheckpointExporter.h
+++ b/runtime/onert/core/include/exporter/train/CheckpointExporter.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXPORTER_TRAIN_CHECKPOINT_EXPORTER_H__
+#define __ONERT_EXPORTER_TRAIN_CHECKPOINT_EXPORTER_H__
+
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace onert
+{
+namespace exec
+{
+class Execution;
+} // namespace exec
+namespace ir
+{
+namespace train
+{
+class TrainingInfo;
+} // namespace train
+} // namespace ir
+} // namespace onert
+
+namespace onert
+{
+namespace exporter
+{
+namespace train
+{
+
+void exportCheckpoint(const std::string &filename,
+                      const std::unique_ptr<ir::train::TrainingInfo> &train_info,
+                      const std::unique_ptr<exec::Execution> &exec);
+
+} // namespace train
+} // namespace exporter
+} // namespace onert
+
+#endif // __ONERT_EXPORTER_TRAIN_CHECKPOINT_EXPORTER_H__

--- a/runtime/onert/core/src/exporter/train/CheckpointExporter.cc
+++ b/runtime/onert/core/src/exporter/train/CheckpointExporter.cc
@@ -36,8 +36,8 @@ using namespace exec;
 class CheckpointExporter
 {
 public:
-  CheckpointExporter(const std::unique_ptr<ir::train::TrainingInfo> &train_info,
-                     const std::unique_ptr<exec::Execution> &exec)
+  CheckpointExporter(const ir::train::TrainingInfo *const train_info,
+                     const exec::Execution *const exec)
   {
     std::memset(&_header, 0, sizeof(_header));
     _header.magic = checkpoint::MAGIC_NUMBER;
@@ -82,7 +82,7 @@ void exportCheckpoint(const std::string &filename,
                       const std::unique_ptr<ir::train::TrainingInfo> &train_info,
                       const std::unique_ptr<exec::Execution> &exec)
 {
-  CheckpointExporter exporter(train_info, exec);
+  CheckpointExporter exporter(train_info.get(), exec.get());
   exporter.save(filename);
 }
 

--- a/runtime/onert/core/src/exporter/train/CheckpointExporter.cc
+++ b/runtime/onert/core/src/exporter/train/CheckpointExporter.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exporter/train/CheckpointExporter.h"
+
+#include "exec/Execution.h"
+#include "ir/train/TrainingInfo.h"
+#include "ir/train/Checkpoint.h"
+
+#include <fstream>
+#include <iostream>
+#include <numeric>
+
+namespace
+{
+
+using namespace onert;
+using namespace ir;
+using namespace train;
+using namespace checkpoint;
+using namespace exec;
+
+class CheckpointExporter
+{
+public:
+  CheckpointExporter(const std::unique_ptr<ir::train::TrainingInfo> &train_info,
+                     const std::unique_ptr<exec::Execution> &exec)
+  {
+    std::memset(&_header, 0, sizeof(_header));
+    _header.magic = checkpoint::MAGIC_NUMBER;
+    _header.schema = checkpoint::SCHEMA_VERSION;
+
+    uint32_t offset = sizeof(_header);
+    // TODO Store tensor and optimizer data
+    UNUSED_RELEASE(exec);
+    _header.other_offset = offset;
+
+    std::memset(&_footer, 0, sizeof(_footer));
+    _footer.cur_step = train_info->trainingStep();
+  }
+
+  void save(const std::string &path)
+  {
+    std::ofstream dst(path.c_str(), std::ios::binary | std::ios::trunc);
+    if (!dst.is_open())
+      throw std::runtime_error{"Failed to save checkpoint: " + path};
+
+    dst.write(reinterpret_cast<const char *>(&_header), sizeof(_header));
+    // TODO Write tensor and optimizer data
+    dst.write(reinterpret_cast<const char *>(&_footer), sizeof(_footer));
+    dst.close();
+  }
+
+private:
+  checkpoint::Header _header;
+  checkpoint::Footer _footer;
+};
+
+} // namespace
+
+namespace onert
+{
+namespace exporter
+{
+namespace train
+{
+
+void exportCheckpoint(const std::string &filename,
+                      const std::unique_ptr<ir::train::TrainingInfo> &train_info,
+                      const std::unique_ptr<exec::Execution> &exec)
+{
+  CheckpointExporter exporter(train_info, exec);
+  exporter.save(filename);
+}
+
+} // namespace train
+} // namespace exporter
+} // namespace onert


### PR DESCRIPTION
This commit introduces CheckpointExporter class to store checkpoint file. Currently, only the header and footer data are saved.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #13670
Draft: #13561