### PR TITLE
[onert-micro] do not exit when arm compiler not found

### DIFF
--- a/onert-micro/CMakeLists.txt
+++ b/onert-micro/CMakeLists.txt
@@ -7,7 +7,6 @@ find_program(ARM_C_COMPILER_PATH ${ARM_C_COMPILER})
 
 if (NOT ARM_C_COMPILER_PATH)
     message(STATUS "Build onert-micro failed: ARM compiler is NOT FOUND")
-    return()
 endif ()
 
 set(OM_CIRCLE_SCHEMA onert_micro_circle_schema)


### PR DESCRIPTION
- do not exit if arm compiler not found since it causes lots of CI infra failure.

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>