### PR TITLE
[onert] Use constructor paramter to set permute type

### DIFF
--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -103,9 +103,14 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   // Add PermuteLayer
   std::vector<ITensor *> output_tensors{getTensor(output_index)};
   std::vector<ITensor *> input_tensors{getTensor(input_index)};
+  std::vector<ir::PermuteType> permute_types;
 
-  auto fn =
-    std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, _external_context);
+  // Laouy in graph is always NHWC, so layout is not changed
+  for (uint32_t i = 0; i < input_tensors.size(); i++)
+    permute_types.emplace_back(ir::PermuteType::COPY);
+
+  auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, permute_types,
+                                                   _external_context);
   _return_fn = std::move(fn);
 }
 

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -105,7 +105,7 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   std::vector<ITensor *> input_tensors{getTensor(input_index)};
   std::vector<ir::PermuteType> permute_types;
 
-  // Laouy in graph is always NHWC, so layout is not changed
+  // Layout in graph is always NHWC, so layout is not changed
   for (uint32_t i = 0; i < input_tensors.size(); i++)
     permute_types.emplace_back(ir::PermuteType::COPY);
 

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
@@ -31,26 +31,18 @@ namespace kernel
 
 PermuteLayer::PermuteLayer(const std::vector<ITensor *> &src_tensors,
                            const std::vector<ITensor *> &dst_tensors,
+                           const std::vector<ir::PermuteType> &types,
                            const std::shared_ptr<ExternalContext> &external_context)
   : _external_context{external_context}, _tasks_map{}
 {
   assert(src_tensors.size() == dst_tensors.size());
+  assert(src_tensors.size() == types.size());
   _src_tensors = src_tensors;
   _dst_tensors = dst_tensors;
+  _permute_types = types;
   _src_tensors_offsets.resize(src_tensors.size());
   _dst_tensors_offsets.resize(dst_tensors.size());
   _permute_types.resize(src_tensors.size());
-
-  // TODO Get from constructor parameter
-  for (uint32_t i = 0; i < src_tensors.size(); i++)
-  {
-    if (src_tensors[i]->layout() == dst_tensors[i]->layout())
-      _permute_types[i] = ir::PermuteType::COPY;
-    else if (src_tensors[i]->layout() == ir::Layout::NHWC)
-      _permute_types[i] = ir::PermuteType::NHWC_TO_NCHW;
-    else
-      _permute_types[i] = ir::PermuteType::NCHW_TO_NHWC;
-  }
 }
 
 void PermuteLayer::optimize()

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
@@ -35,6 +35,7 @@ class PermuteLayer : public onert::exec::IPermuteFunction
 {
 public:
   PermuteLayer(const std::vector<ITensor *> &src_tensors, const std::vector<ITensor *> &dst_tensors,
+               const std::vector<ir::PermuteType> &types,
                const std::shared_ptr<ExternalContext> &external_context);
 
   void optimize() override;

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -85,7 +85,7 @@ void WhileLayer::run()
   std::vector<ITensor *> op_inputs(_input_tensors.begin(), _input_tensors.end());
   std::vector<ITensor *> op_outputs(_output_tensors.begin(), _output_tensors.end());
   std::vector<ir::PermuteType> permute_types;
-  // Laouy in graph is always NHWC, so layout is not changed
+  // Layout in graph is always NHWC, so layout is not changed
   for (uint32_t i = 0; i < op_outputs.size(); i++)
     permute_types.emplace_back(ir::PermuteType::COPY);
   // Copying body inputs to outputs when the loop body is never executed

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -68,7 +68,7 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
   output_back_prop_tensors.emplace_back(output_back_prop_tensor);
   input_back_prop_tensors.emplace_back(input_back_prop_tensor);
 
-  // Laouy in graph is always NHWC, so layout is not changed
+  // Layout in graph is always NHWC, so layout is not changed
   for (uint32_t i = 0; i < input_tensors.size(); i++)
     permute_types.emplace_back(ir::PermuteType::COPY);
 

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -61,11 +61,16 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
 
   std::vector<ITensor *> output_back_prop_tensors;
   std::vector<ITensor *> input_back_prop_tensors;
+  std::vector<ir::PermuteType> permute_types;
 
   auto input_back_prop_tensor = getBackPropTensor(input_index);
   auto output_back_prop_tensor = getBackPropTensor(output_index);
   output_back_prop_tensors.emplace_back(output_back_prop_tensor);
   input_back_prop_tensors.emplace_back(input_back_prop_tensor);
+
+  // Laouy in graph is always NHWC, so layout is not changed
+  for (uint32_t i = 0; i < input_tensors.size(); i++)
+    permute_types.emplace_back(ir::PermuteType::COPY);
 
   // NOTE The output buffers of IOTensors are not essential for training. If there
   //      is no output buffer provided by the user, permute is not performed.
@@ -77,7 +82,7 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
   }
 
   auto fn = std::make_unique<kernel::PermuteLayer>(
-    input_tensors, output_tensors, input_back_prop_tensors, output_back_prop_tensors,
+    input_tensors, output_tensors, input_back_prop_tensors, output_back_prop_tensors, permute_types,
     ignore_forward_in_training, _external_context);
 
   _return_fn = std::move(fn);

--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
@@ -33,9 +33,10 @@ PermuteLayer::PermuteLayer(const std::vector<ITensor *> &src_tensors,
                            const std::vector<ITensor *> &dst_tensors,
                            const std::vector<ITensor *> &input_back_prop_tensors,
                            const std::vector<ITensor *> &output_back_prop_tensors,
+                           const std::vector<ir::PermuteType> &types,
                            bool ignore_forward_in_training,
                            const std::shared_ptr<ExternalContext> &external_context)
-  : builtin::kernel::PermuteLayer{src_tensors, dst_tensors, external_context},
+  : builtin::kernel::PermuteLayer{src_tensors, dst_tensors, types, external_context},
     _input_back_prop_tensors{input_back_prop_tensors},
     _output_back_prop_tensors{output_back_prop_tensors},
     _ignore_forward_in_training{ignore_forward_in_training}

--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.h
@@ -38,7 +38,7 @@ public:
   PermuteLayer(const std::vector<ITensor *> &src_tensors, const std::vector<ITensor *> &dst_tensors,
                const std::vector<ITensor *> &input_back_prop_tensors,
                const std::vector<ITensor *> &output_back_prop_tensors,
-               bool ignore_forward_in_training,
+               const std::vector<ir::PermuteType> &types, bool ignore_forward_in_training,
                const std::shared_ptr<ExternalContext> &external_context);
 
   void optimize() override;

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -252,23 +252,14 @@ class PermuteLayer : public onert::exec::IPermuteFunction
 {
 public:
   PermuteLayer(const std::vector<onert::backend::ITensor *> &inputs,
-               const std::vector<onert::backend::ITensor *> &outputs)
+               const std::vector<onert::backend::ITensor *> &outputs,
+               const std::vector<ir::PermuteType> &types)
   {
     assert(inputs.size() == outputs.size());
+    assert(inputs.size() == types.size());
     _src_tensors = inputs;
     _dst_tensors = outputs;
-    _permute_types.resize(inputs.size());
-
-    // TODO Get from constructor parameter
-    for (uint32_t i = 0; i < inputs.size(); i++)
-    {
-      if (inputs[i]->layout() == outputs[i]->layout())
-        _permute_types[i] = ir::PermuteType::COPY;
-      else if (inputs[i]->layout() == ir::Layout::NHWC)
-        _permute_types[i] = ir::PermuteType::NHWC_TO_NCHW;
-      else
-        _permute_types[i] = ir::PermuteType::NCHW_TO_NHWC;
-    }
+    _permute_types = types;
   }
   virtual ~PermuteLayer() {}
   void optimize() override {}

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -66,10 +66,12 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   // Vector for input quantization I/O
   std::vector<backend::ITensor *> input_tensors;
   std::vector<backend::ITensor *> input_qtensors;
+  std::vector<ir::PermuteType> input_permute_types;
 
   // Vector for output dequantization I/O
   std::vector<backend::ITensor *> output_qtensors;
   std::vector<backend::ITensor *> output_tensors;
+  std::vector<ir::PermuteType> output_permute_types;
 
   // Prepare UserTensor and EdgeTensor for input quantization
   for (uint32_t i = 0; i < inputs.size(); i++)
@@ -87,7 +89,8 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
     auto user_type = desc->info.typeInfo().type();
     auto &model_info = entryExecutor()->inputInfo(i).typeInfo();
     auto model_type = model_info.type();
-    if (user_type != model_type && user_type == ir::DataType::FLOAT32)
+    if ((user_type != model_type && user_type == ir::DataType::FLOAT32) ||
+        (desc->layout == ir::Layout::NCHW))
     {
       auto quantized_info = desc->info;
       quantized_info.typeInfo(model_info);
@@ -98,6 +101,10 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       input_tensors.push_back(tensorpool.back().get());
       input_qtensors.push_back(qtensorpool.back().get());
       inputs[i] = qtensorpool.back().get();
+      if (desc->layout == ir::Layout::NCHW)
+        input_permute_types.push_back(ir::PermuteType::NCHW_TO_NHWC);
+      else
+        input_permute_types.push_back(ir::PermuteType::COPY);
     }
     else
       inputs[i] = tensorpool.back().get();
@@ -118,7 +125,8 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
     auto user_type = desc->info.typeInfo().type();
     auto &model_info = entryExecutor()->outputInfo(i).typeInfo();
     auto model_type = model_info.type();
-    if (user_type != model_type && user_type == ir::DataType::FLOAT32)
+    if ((user_type != model_type && user_type == ir::DataType::FLOAT32) ||
+        (desc->layout == ir::Layout::NCHW))
     {
       auto quantized_info = desc->info;
       quantized_info.typeInfo(model_info);
@@ -129,6 +137,10 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       output_qtensors.push_back(qtensorpool.back().get());
       output_tensors.push_back(tensorpool.back().get());
       outputs[i] = qtensorpool.back().get();
+      if (desc->layout == ir::Layout::NCHW)
+        output_permute_types.push_back(ir::PermuteType::NHWC_TO_NCHW);
+      else
+        output_permute_types.push_back(ir::PermuteType::COPY);
     }
     else
       outputs[i] = tensorpool.back().get();
@@ -137,7 +149,7 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   // Run quantization
   if (input_tensors.size() > 0)
   {
-    auto input_quantize_layer = PermuteLayer(input_tensors, input_qtensors);
+    auto input_quantize_layer = PermuteLayer(input_tensors, input_qtensors, input_permute_types);
     input_quantize_layer.prepare();
     input_quantize_layer.run();
   }
@@ -148,7 +160,8 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   // Run dequantization
   if (output_tensors.size() != 0)
   {
-    auto output_dequantize_layer = PermuteLayer(output_qtensors, output_tensors);
+    auto output_dequantize_layer =
+      PermuteLayer(output_qtensors, output_tensors, output_permute_types);
     output_dequantize_layer.prepare();
     output_dequantize_layer.run();
   }


### PR DESCRIPTION
This commit update PermuteLayer constructor to use parameter to set permute type. 
By this commit, permute will not use tensor layout any more.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/13747
Related issue: https://github.com/Samsung/ONE/issues/12130 https://github.com/Samsung/ONE/issues/13494