### PR TITLE
[luci/export] Introduce clear methods

### DIFF
--- a/compiler/luci/export/src/SerializedData.cpp
+++ b/compiler/luci/export/src/SerializedData.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SerializedData.h"
+
+namespace luci
+{
+
+void CircleExportMetadata::clear(void)
+{
+  _source_table.clear();
+  _op_table.clear();
+  _execution_plan_table.clear();
+}
+
+void SerializedModelData::clear(void)
+{
+  _operator_codes.clear();
+  _buffers.clear();
+  _metadata.clear();
+  _cached_buffer_id.clear();
+}
+
+} // namespace luci

--- a/compiler/luci/export/src/SerializedData.h
+++ b/compiler/luci/export/src/SerializedData.h
@@ -70,6 +70,8 @@ public:
     _execution_plan_table[node_id] = execution_plan_inform;
   }
 
+  void clear(void);
+
 public:
   const std::vector<uint8_t> encoded_source_table(void);
   const std::vector<uint8_t> encoded_op_table(void);
@@ -133,6 +135,8 @@ struct SerializedModelData final
    */
   uint32_t registerBuiltinOpcode(circle::BuiltinOperator builtin_code,
                                  const std::string &custom_code, const int32_t op_version);
+
+  void clear(void);
 };
 
 // Prerequisites for circle::Model object creation


### PR DESCRIPTION
This will add clear methods to CircleExportMetadata and SerializedModelData.
