### PR TITLE
[onert] Use getUses() reference

### DIFF
--- a/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.cc
@@ -40,7 +40,7 @@ void TrainableConstantInsertionPass::callback(const ir::OperationIndex &node_ind
       continue;
 
     // Insert new operands for shared constant except for the current node.
-    const auto uses = object.getUses();
+    const auto &uses = object.getUses();
     for (const auto &use_index : uses)
     {
       if (use_index == node_index)

--- a/runtime/onert/core/src/ir/train/UseDefGenerator.cc
+++ b/runtime/onert/core/src/ir/train/UseDefGenerator.cc
@@ -425,7 +425,7 @@ void UseDefGenerator::initForForwardingNodes()
     }
 
     assert(_training_usedefs.at(forwarding_operand_index).getTrainingUses().size() == 0);
-    const auto uses = operand.getUses();
+    const auto &uses = operand.getUses();
     for (const auto &use : uses)
       insertUse(forwarding_operand_index, TrainingOperationIndex{use, is_forward});
   });


### PR DESCRIPTION
This commit updates to use getUses() return's reference explicitly.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>