### PR TITLE
[luci/service] Add sinf namespace for sinf::Algorithm::visit()

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleAdd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAdd.cpp
@@ -34,15 +34,20 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleAdd *node)
   return cloned;
 }
 
-loco::TensorShape sinf::Algorithm::visit(const luci::CircleAdd *node)
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleAdd *node)
 {
   const auto x = loco::must_cast<luci::CircleNode *>(node->x());
   const auto y = loco::must_cast<luci::CircleNode *>(node->y());
 
-  const auto x_shape = sinf::circle_shape(x);
-  const auto y_shape = sinf::circle_shape(y);
+  const auto x_shape = circle_shape(x);
+  const auto y_shape = circle_shape(y);
 
   return broadcast_shape(x_shape, y_shape);
 }
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleBatchMatMul.cpp
+++ b/compiler/luci/service/src/Nodes/CircleBatchMatMul.cpp
@@ -76,15 +76,18 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleBatchMatMul *no
   return cloned;
 }
 
+namespace sinf
+{
+
 // BatchMatMulV2 supports broadcasting in the batch dimensions(BatchMatMul doesn't)
 // TODO Distinguish BatchMatMul and BatchMatMulV2
-loco::TensorShape sinf::Algorithm::visit(const luci::CircleBatchMatMul *node)
+loco::TensorShape Algorithm::visit(const luci::CircleBatchMatMul *node)
 {
   const auto x = loco::must_cast<CircleNode *>(node->x());
   const auto y = loco::must_cast<CircleNode *>(node->y());
 
-  const auto x_shape = sinf::circle_shape(x);
-  const auto y_shape = sinf::circle_shape(y);
+  const auto x_shape = circle_shape(x);
+  const auto y_shape = circle_shape(y);
 
   uint32_t x_rank = x_shape.rank();
   uint32_t y_rank = y_shape.rank();
@@ -143,5 +146,7 @@ loco::TensorShape sinf::Algorithm::visit(const luci::CircleBatchMatMul *node)
 
   return output_shape;
 }
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleConcatenation.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConcatenation.cpp
@@ -37,7 +37,10 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleConcatenation *
   return cloned;
 }
 
-loco::TensorShape sinf::Algorithm::visit(const luci::CircleConcatenation *node)
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleConcatenation *node)
 {
   // TODO Support when CircleConcatenation has 0 input
   assert(node->numValues() > 0);
@@ -100,5 +103,7 @@ loco::TensorShape sinf::Algorithm::visit(const luci::CircleConcatenation *node)
 
   return output_shape;
 }
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleDiv.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDiv.cpp
@@ -34,17 +34,22 @@ luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDiv *node)
   return cloned;
 }
 
-loco::TensorShape sinf::Algorithm::visit(const luci::CircleDiv *node)
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleDiv *node)
 {
   const auto x = loco::must_cast<luci::CircleNode *>(node->x());
   const auto y = loco::must_cast<luci::CircleNode *>(node->y());
 
-  const auto x_shape = sinf::circle_shape(x);
-  const auto y_shape = sinf::circle_shape(y);
+  const auto x_shape = circle_shape(x);
+  const auto y_shape = circle_shape(y);
 
   auto output_shape = broadcast_shape(x_shape, y_shape);
 
   return output_shape;
 }
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleIfOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleIfOut.cpp
@@ -73,13 +73,17 @@ CircleIfOutGraphs get_out_graphs(const luci::CircleIfOut *node)
 
 namespace luci
 {
+namespace sinf
+{
 
-loco::TensorShape sinf::Algorithm::visit(const luci::CircleIfOut *node)
+loco::TensorShape Algorithm::visit(const luci::CircleIfOut *node)
 {
   auto graphs = get_out_graphs(node);
   assert(*graphs.then_graph_output->shape() == *graphs.else_graph_output->shape());
   return *graphs.then_graph_output->shape();
 }
+
+} // namespace sinf
 
 loco::DataType tinf::Algorithm::visit(const luci::CircleIfOut *node)
 {

--- a/compiler/luci/service/src/Nodes/CircleSoftmax.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSoftmax.cpp
@@ -30,11 +30,16 @@ luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSoftmax *node)
   return cloned;
 }
 
-loco::TensorShape sinf::Algorithm::visit(const luci::CircleSoftmax *node)
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleSoftmax *node)
 {
   const auto logits = loco::must_cast<luci::CircleNode *>(node->logits());
 
   return sinf::circle_shape(logits);
 }
+
+} // namespace sinf
 
 } // namespace luci


### PR DESCRIPTION
This PR explicitly marks 'sinf namespace' for each node's sinf::Algorithm::visit() function.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>

* background : https://github.com/Samsung/ONE/pull/13780#discussion_r1734047594 