### PR TITLE
[luci/service] Migrate Quantize shape inference rule to sinf::Algorithm

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -111,7 +111,7 @@ public:
   // loco::TensorShape visit(const luci::CirclePadV2 *node) final;
   // loco::TensorShape visit(const luci::CirclePow *node) final;
   // loco::TensorShape visit(const luci::CirclePRelu *node) final;
-  // loco::TensorShape visit(const luci::CircleQuantize *node) final;
+  loco::TensorShape visit(const luci::CircleQuantize *node) final;
   // loco::TensorShape visit(const luci::CircleRange *node) final;
   // loco::TensorShape visit(const luci::CircleRank *node) final;
   // loco::TensorShape visit(const luci::CircleReduceAny *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2235,12 +2235,6 @@ public:
 
   loco::NodeShape visit(const luci::CirclePRelu *node) final { return infer_p_relu(node); }
 
-  loco::NodeShape visit(const luci::CircleQuantize *node) final
-  {
-    const auto input_shape = luci::shape_get(node->input()).as<loco::TensorShape>();
-    return loco::NodeShape{input_shape};
-  }
-
   loco::NodeShape visit(const luci::CircleRange *node) final { return infer_range(node); }
 
   loco::NodeShape visit(const luci::CircleRank *) final

--- a/compiler/luci/service/src/Nodes/CircleQuantize.cpp
+++ b/compiler/luci/service/src/Nodes/CircleQuantize.cpp
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+#include "luci/Service/CircleShapeInference.h"
+
 #include "CircleCloneNode.h"
+#include "CircleShapeInferenceHelper.h"
 
 namespace luci
 {
@@ -22,6 +25,12 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleQuantize *)
 {
   return _graph->nodes()->create<luci::CircleQuantize>();
+}
+
+loco::TensorShape sinf::Algorithm::visit(const luci::CircleQuantize *node)
+{
+  const auto input_shape = sinf::circle_shape(loco::must_cast<CircleNode *>(node->input()));
+  return input_shape;
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleQuantize.cpp
+++ b/compiler/luci/service/src/Nodes/CircleQuantize.cpp
@@ -27,11 +27,16 @@ luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleQuantize *)
   return _graph->nodes()->create<luci::CircleQuantize>();
 }
 
-loco::TensorShape sinf::Algorithm::visit(const luci::CircleQuantize *node)
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleQuantize *node)
 {
   const auto input = loco::must_cast<CircleNode *>(node->input());
-  const auto input_shape = sinf::circle_shape(input);
+  const auto input_shape = circle_shape(input);
   return input_shape;
 }
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleQuantize.cpp
+++ b/compiler/luci/service/src/Nodes/CircleQuantize.cpp
@@ -29,7 +29,8 @@ luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleQuantize *)
 
 loco::TensorShape sinf::Algorithm::visit(const luci::CircleQuantize *node)
 {
-  const auto input_shape = sinf::circle_shape(loco::must_cast<CircleNode *>(node->input()));
+  const auto input = loco::must_cast<CircleNode *>(node->input());
+  const auto input_shape = sinf::circle_shape(input);
   return input_shape;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleQuantize.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleQuantize.test.cpp
@@ -35,8 +35,8 @@ TEST(CloneNodeTest, clone_Quantize)
 
 TEST(ShapeRuleTest, quantize_dynamic_shape)
 {
-  luci::CircleQuantize quantize;
   luci::CircleInput input;
+  luci::CircleQuantize quantize;
 
   input.shape({1, 2, 3, 4});
   input.shape_status(luci::ShapeStatus::VALID);
@@ -58,14 +58,12 @@ TEST(ShapeRuleTest, quantize_dynamic_shape)
   ASSERT_EQ(2, shape.dim(1).value());
   ASSERT_EQ(0, shape.dim(2).value());
   ASSERT_EQ(4, shape.dim(3).value());
-
-  quantize.drop();
 }
 
-TEST(ShapeRuleTest, quantize_dynamic_shape_NEG)
+TEST(ShapeRuleTest, quantize_shape_not_ready_NEG)
 {
-  luci::CircleQuantize quantize;
   luci::CircleInput input;
+  luci::CircleQuantize quantize;
 
   input.shape_status(luci::ShapeStatus::UNDEFINED);
   quantize.input(&input);
@@ -74,6 +72,4 @@ TEST(ShapeRuleTest, quantize_dynamic_shape_NEG)
   luci::sinf::Rule shape_inf_rule;
 
   ASSERT_FALSE(shape_inf_rule.infer(&quantize, shape));
-
-  quantize.drop();
 }

--- a/compiler/luci/service/src/Nodes/CircleQuantize.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleQuantize.test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "luci/Service/CircleNodeClone.h"
+#include "luci/Service/CircleShapeInference.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,49 @@ TEST(CloneNodeTest, clone_Quantize)
 
   auto cloned_q = dynamic_cast<luci::CircleQuantize *>(cloned);
   ASSERT_NE(nullptr, cloned_q);
+}
+
+TEST(ShapeRuleTest, quantize_dynamic_shape)
+{
+  luci::CircleQuantize quantize;
+  luci::CircleInput input;
+
+  input.shape({1, 2, 3, 4});
+  input.shape_status(luci::ShapeStatus::VALID);
+  input.dim(2).unset();
+
+  quantize.input(&input);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&quantize, shape));
+
+  ASSERT_EQ(4, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_FALSE(shape.dim(2).known());
+  ASSERT_TRUE(shape.dim(3).known());
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(2, shape.dim(1).value());
+  ASSERT_EQ(0, shape.dim(2).value());
+  ASSERT_EQ(4, shape.dim(3).value());
+
+  quantize.drop();
+}
+
+TEST(ShapeRuleTest, quantize_dynamic_shape_NEG)
+{
+  luci::CircleQuantize quantize;
+  luci::CircleInput input;
+
+  input.shape_status(luci::ShapeStatus::UNDEFINED);
+  quantize.input(&input);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_FALSE(shape_inf_rule.infer(&quantize, shape));
+
+  quantize.drop();
 }


### PR DESCRIPTION
When testing dynamic shape inference, the original quantize operation successfully handles it.
I have migrated the inference code and modified shape_get function to circle_shape

Related to: https://github.com/Samsung/ONE/issues/13697
draft: https://github.com/Samsung/ONE/pull/13779
first-pr: https://github.com/Samsung/ONE/pull/13794 (I fail to modify first commit message.. so I create new pull-request)