### PR TITLE
[onert/contrib] Disable logging runtime build as default

### DIFF
--- a/infra/debian/runtime/rules
+++ b/infra/debian/runtime/rules
@@ -17,7 +17,7 @@ override_dh_auto_build:
 	find packaging/ -type f -name "*.tar.gz" | xargs -i tar xf {} -C externals
 	mkdir -p $(NNFW_WORKSPACE)
 	./nnfw configure -DCMAKE_BUILD_TYPE=Release -DEXTERNALS_BUILD_THREADS=$(NPROC) \
-	  -DBUILD_LOGGING=OFF -DDOWNLOAD_GTEST=OFF -DENABLE_TEST=OFF \
+	  -DDOWNLOAD_GTEST=OFF -DENABLE_TEST=OFF \
 		-DBUILD_PYTHON_BINDING=OFF
 	./nnfw build -j$(NPROC)
 override_dh_auto_install:

--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -14,7 +14,6 @@ option(ENABLE_STRICT_BUILD "Treat warning as error" ON)
 option(ENABLE_COVERAGE "Build for coverage test" OFF)
 option(BUILD_EXT_MULTITHREAD "Build external build using multi thread" ON)
 option(BUILD_ONERT "Build onert" ON)
-option(BUILD_LOGGING "Build logging runtime" ON)
 option(BUILD_RUNTIME_NNAPI_TEST "Build Runtime NN API Generated Test" ON)
 option(BUILD_RUNTIME_NNFW_API_TEST "Build Runtime NNFW API Tests" ON)
 option(BUILD_TFLITE_RUN "Build tflite-run" ON)
@@ -45,6 +44,7 @@ option(BUILD_GPU_CL "Build gpu_cl backend" OFF)
 option(BUILD_TENSORFLOW_LITE_GPU "Build TensorFlow Lite GPU delegate from the downloaded source" OFF)
 option(BUILD_NPUD "Build NPU daemon" OFF)
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
+option(BUILD_LOGGING "Build logging runtime" OFF)
 #
 # Default build configuration for tools
 #

--- a/infra/nnfw/cmake/options/options_aarch64-android.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-android.cmake
@@ -2,4 +2,3 @@
 #
 option(BUILD_ANDROID_BENCHMARK_APP "Enable Android Benchmark App" ON)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
-option(BUILD_LOGGING "Build logging runtime" OFF)

--- a/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
@@ -7,6 +7,5 @@ option(DOWNLOAD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(BUILD_LOGGING "Build logging runtime" OFF)
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)

--- a/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
@@ -7,6 +7,5 @@ option(DOWNLOAD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(BUILD_LOGGING "Build logging runtime" OFF)
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)

--- a/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
@@ -7,6 +7,5 @@ option(DOWNLOAD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(BUILD_LOGGING "Build logging runtime" OFF)
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)

--- a/infra/nnfw/cmake/options/options_i686-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_i686-tizen.cmake
@@ -6,7 +6,6 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(BUILD_LOGGING "Build logging runtime" OFF)
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 

--- a/infra/nnfw/cmake/options/options_riscv64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_riscv64-tizen.cmake
@@ -6,7 +6,6 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(BUILD_LOGGING "Build logging runtime" OFF)
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 

--- a/infra/nnfw/cmake/options/options_x86_64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_x86_64-tizen.cmake
@@ -6,7 +6,6 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(BUILD_LOGGING "Build logging runtime" OFF)
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 


### PR DESCRIPTION
This commit disables logging runtime build in contrib directory as default.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>