### PR TITLE
Release note 1.29.0

### DIFF
--- a/docs/release/1.29/index.rst
+++ b/docs/release/1.29/index.rst
@@ -1,0 +1,13 @@
+.. ONE documentation master file, created by
+   sphinx-quickstart on Thu Aug 29 12:18:12 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+1.29
+====
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+  ./release-note-1.29.0.md

--- a/docs/release/1.29/release-note_1.29.0.md
+++ b/docs/release/1.29/release-note_1.29.0.md
@@ -1,0 +1,11 @@
+# Release Note 1.29.0
+
+## ONE Compiler
+
+- Support more optimization option(s): `--transform_sqrt_div_to_rsqrt_mul`, `--fold_mul`,
+    `--fuse_add_to_fullyconnected_bias`, `--fuse_mul_to_fullyconnected_weights`,
+    `--fuse_mul_with_fullyconnected`.
+- Add more optimization: `CanonicalizePass`.
+- _tflite2circle_ supports more data types: FLOAT64, UINT64, UINT32, UINT16.
+- _luci-interpreter_ supports more data types on some ops.
+- Support multiple option names in command schema.


### PR DESCRIPTION
This commit is a release note for 1.29.0.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>