### PR TITLE
[onert] Simplify IPermuteFunction unittest

### DIFF
--- a/runtime/onert/core/src/exec/IPermuteFunction.test.cc
+++ b/runtime/onert/core/src/exec/IPermuteFunction.test.cc
@@ -97,15 +97,19 @@ private:
 class MockUpLayer : public IPermuteFunction
 {
 public:
-  MockUpLayer(const std::vector<ITensor *> &inputs, const std::vector<ITensor *> &outputs)
+  MockUpLayer(const std::vector<std::unique_ptr<MockUpTensor>> &inputs,
+              const std::vector<std::unique_ptr<MockUpTensor>> &outputs)
   {
-    assert(inputs.size() == outputs.size());
-    _src_tensors = inputs;
-    _dst_tensors = outputs;
-    _permute_types.resize(inputs.size());
+    const uint32_t input_size = inputs.size();
+    assert(outputs.size() == input_size);
+    _src_tensors.resize(input_size);
+    _dst_tensors.resize(input_size);
+    _permute_types.resize(input_size);
 
-    for (uint32_t i = 0; i < inputs.size(); i++)
+    for (uint32_t i = 0; i < input_size; i++)
     {
+      _src_tensors[i] = inputs[i].get();
+      _dst_tensors[i] = outputs[i].get();
       if (inputs[i]->layout() == outputs[i]->layout())
         _permute_types[i] = ir::PermuteType::COPY;
       else if (inputs[i]->layout() == ir::Layout::NHWC)
@@ -143,10 +147,7 @@ TEST(IPermuteFunction, float_to_float)
       outputs[i]->setBuffer(output_buffers[i].get());
     }
 
-    auto mockup_layer = std::make_unique<MockUpLayer>(
-      std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-      std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+    auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -185,10 +186,7 @@ TEST(IPermuteFunction, float_to_float)
       outputs[i]->setBuffer(output_buffers[i].get());
     }
 
-    auto mockup_layer = std::make_unique<MockUpLayer>(
-      std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-      std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+    auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -230,10 +228,7 @@ TEST(IPermuteFunction, float_to_float)
       outputs[i]->setBuffer(output_buffers[i].get());
     }
 
-    auto mockup_layer = std::make_unique<MockUpLayer>(
-      std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-      std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+    auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -278,10 +273,7 @@ TEST(IPermuteFunction, float_to_float)
       outputs[i]->setBuffer(output_buffers[i].get());
     }
 
-    auto mockup_layer = std::make_unique<MockUpLayer>(
-      std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-      std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+    auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -346,10 +338,7 @@ TEST(IPermuteFunction, float_to_float)
       outputs[i]->setBuffer(output_buffers[i].get());
     }
 
-    auto mockup_layer = std::make_unique<MockUpLayer>(
-      std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-      std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+    auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -417,9 +406,7 @@ TEST(IPermuteFunction, float_to_qasymm8)
     outputs[i]->setBuffer(output_buffers[i].get());
   }
 
-  auto mockup_layer = std::make_unique<MockUpLayer>(
-    std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+  auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -470,9 +457,7 @@ TEST(IPermuteFunction, float_to_qsymm8)
     outputs[i]->setBuffer(output_buffers[i].get());
   }
 
-  auto mockup_layer = std::make_unique<MockUpLayer>(
-    std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+  auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -523,9 +508,7 @@ TEST(IPermuteFunction, float_to_qsymm16)
     outputs[i]->setBuffer(output_buffers[i].get());
   }
 
-  auto mockup_layer = std::make_unique<MockUpLayer>(
-    std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+  auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -585,9 +568,7 @@ TEST(IPermuteFunction, qasymm8_to_float)
     outputs[i]->setBuffer(output_buffers[i].get());
   }
 
-  auto mockup_layer = std::make_unique<MockUpLayer>(
-    std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+  auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -647,9 +628,7 @@ TEST(IPermuteFunction, qsymm8_to_float)
     outputs[i]->setBuffer(output_buffers[i].get());
   }
 
-  auto mockup_layer = std::make_unique<MockUpLayer>(
-    std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+  auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -709,9 +688,7 @@ TEST(IPermuteFunction, qsymm16_to_float)
     outputs[i]->setBuffer(output_buffers[i].get());
   }
 
-  auto mockup_layer = std::make_unique<MockUpLayer>(
-    std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-    std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(), outputs[3].get()});
+  auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
   mockup_layer->run();
 
   for (size_t i = 0; i < 4; ++i)
@@ -782,10 +759,7 @@ TEST(IPermuteFunction, float_qasymm8_layout)
       outputs[i]->setBuffer(output_buffers[i].get());
     }
 
-    auto mockup_layer = std::make_unique<MockUpLayer>(
-      std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-      std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+    auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)
@@ -880,10 +854,7 @@ TEST(IPermuteFunction, float_qasymm8_layout)
       outputs[i]->setBuffer(output_buffers[i].get());
     }
 
-    auto mockup_layer = std::make_unique<MockUpLayer>(
-      std::vector<ITensor *>{inputs[0].get(), inputs[1].get(), inputs[2].get(), inputs[3].get()},
-      std::vector<ITensor *>{outputs[0].get(), outputs[1].get(), outputs[2].get(),
-                             outputs[3].get()});
+    auto mockup_layer = std::make_unique<MockUpLayer>(inputs, outputs);
     mockup_layer->run();
 
     for (size_t i = 0; i < 4; ++i)


### PR DESCRIPTION
This commit simplifies IPermuteFunction unittest's MockUpLayer usage.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13797