### PR TITLE
[onert] Introduce replacing an input

### DIFF
--- a/runtime/onert/core/include/ir/IOperation.h
+++ b/runtime/onert/core/include/ir/IOperation.h
@@ -38,6 +38,7 @@ struct IOperation
   virtual std::string name() const { return std::string{toString(opcode())}; }
   virtual OpCode opcode() const = 0;
 
+  virtual void replaceInput(size_t pos, const OperandIndex &index) = 0;
   virtual void replaceInputs(const OperandIndex &from, const OperandIndex &to) = 0;
   virtual void replaceOutputs(const OperandIndex &from, const OperandIndex &to) = 0;
   virtual const OperandIndexSequence &getInputs() const = 0;

--- a/runtime/onert/core/include/ir/OperandIndexSequence.h
+++ b/runtime/onert/core/include/ir/OperandIndexSequence.h
@@ -50,6 +50,7 @@ public:
   const OperandIndex &at(IOIndex set_index) const { return _vec.at(set_index.value()); }
   const OperandIndex &at(uint32_t index) const { return _vec.at(index); }
   bool contains(const OperandIndex &index) const;
+  void replace(size_t pos, const OperandIndex &index);
   void replace(const OperandIndex &from, const OperandIndex &to);
   OperandIndexSequence operator|(ir::Remove filter) const
   {

--- a/runtime/onert/core/include/ir/Operation.h
+++ b/runtime/onert/core/include/ir/Operation.h
@@ -48,6 +48,7 @@ public:
   virtual ~Operation();
 
 public:
+  void replaceInput(size_t pos, const OperandIndex &index) override;
   void replaceInputs(const OperandIndex &from, const OperandIndex &to) override;
   void replaceOutputs(const OperandIndex &from, const OperandIndex &to) override;
   OperandIndexSequence &getInputs() { return _inputs; }

--- a/runtime/onert/core/src/ir/OperandIndexSequence.cc
+++ b/runtime/onert/core/src/ir/OperandIndexSequence.cc
@@ -17,6 +17,7 @@
 #include "ir/OperandIndexSequence.h"
 
 #include <algorithm>
+#include <cassert>
 #include <sstream>
 
 namespace onert
@@ -48,6 +49,12 @@ OperandIndexSequence::OperandIndexSequence(std::initializer_list<uint32_t> list)
 bool OperandIndexSequence::contains(const OperandIndex &index) const
 {
   return std::find(_vec.begin(), _vec.end(), index) != _vec.end();
+}
+
+void OperandIndexSequence::replace(size_t pos, const OperandIndex &index)
+{
+  assert(pos < _vec.size() && "OperandIndexSequence: Out of range");
+  _vec.at(pos) = index;
 }
 
 void OperandIndexSequence::replace(const OperandIndex &from, const OperandIndex &to)

--- a/runtime/onert/core/src/ir/Operation.cc
+++ b/runtime/onert/core/src/ir/Operation.cc
@@ -52,6 +52,8 @@ void Operation::setOutputs(const OperandIndexSequence &indexes)
   _outputs = indexes;
 }
 
+void Operation::replaceInput(size_t pos, const OperandIndex &index) { _inputs.replace(pos, index); }
+
 void Operation::replaceInputs(const OperandIndex &from, const OperandIndex &to)
 {
   _inputs.replace(from, to);


### PR DESCRIPTION
This commit introduces a function that replaces an input by position of input index sequence.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>