### PR TITLE
Draft: [luci/service] Infer dynamic shape for fullyconnected

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -74,7 +74,7 @@ public:
   // loco::TensorShape visit(const luci::CircleFloor *node) final;
   // loco::TensorShape visit(const luci::CircleFloorDiv *node) final;
   // loco::TensorShape visit(const luci::CircleFloorMod *node) final;
-  // loco::TensorShape visit(const luci::CircleFullyConnected *node) final;
+  loco::TensorShape visit(const luci::CircleFullyConnected *node) final;
   // loco::TensorShape visit(const luci::CircleGather *node) final;
   // loco::TensorShape visit(const luci::CircleGatherNd *node) final;
   // loco::TensorShape visit(const luci::CircleGreater *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -683,47 +683,6 @@ loco::NodeShape infer_fill(const luci::CircleFill *node)
   return loco::NodeShape{shape};
 }
 
-loco::NodeShape infer_fully_connected(const luci::CircleFullyConnected *node)
-{
-  auto input_shape = luci::shape_get(node->input()).as<loco::TensorShape>();
-  auto weights_shape = luci::shape_get(node->weights()).as<loco::TensorShape>();
-
-  loco::TensorShape out_shape;
-
-  // NOTE Some recipes in some repositories are using rank 4 input for FullyConnected.
-  //      Until they are all fixed, disable following assert.
-  // TODO Enable following assert after related fixes are applied
-  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L194
-  // LUCI_ASSERT(input_shape.rank() == 2 || input_shape.rank() == 3,
-  //             "Input rank of FullyConnected should be 2 or 3");
-
-  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L225
-  LUCI_ASSERT(weights_shape.rank() == 2, "Weights of FullyConnected should be 2");
-
-  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L353-L367
-  if (node->keep_num_dims())
-  {
-    out_shape.rank(input_shape.rank());
-    for (uint32_t i = 0; i < input_shape.rank(); ++i)
-      out_shape.dim(i) = input_shape.dim(i);
-    out_shape.dim(out_shape.rank() - 1) = weights_shape.dim(0);
-  }
-  else
-  {
-    uint32_t input_size = 1;
-    for (uint32_t i = 0; i < input_shape.rank(); i++)
-    {
-      input_size = input_size * input_shape.dim(i).value();
-    }
-    const uint32_t batch_size = input_size / weights_shape.dim(1).value();
-    out_shape.rank(2);
-    out_shape.dim(0) = batch_size;
-    out_shape.dim(1) = weights_shape.dim(0);
-  }
-
-  return loco::NodeShape{out_shape};
-}
-
 loco::NodeShape infer_gather(const luci::CircleGather *node)
 {
   loco::TensorShape output_shape;
@@ -2109,11 +2068,6 @@ public:
   loco::NodeShape visit(const luci::CircleFloorDiv *node) final { return broadcast_xy(node); }
 
   loco::NodeShape visit(const luci::CircleFloorMod *node) final { return broadcast_xy(node); }
-
-  loco::NodeShape visit(const luci::CircleFullyConnected *node) final
-  {
-    return infer_fully_connected(node);
-  }
 
   loco::NodeShape visit(const luci::CircleGather *node) final { return infer_gather(node); }
 

--- a/compiler/luci/service/src/Nodes/CircleFullyConnected.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFullyConnected.cpp
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "luci/Service/CircleShapeInference.h"
 
 #include "CircleCloneNode.h"
+#include "CircleShapeInferenceHelper.h"
+
+#include "Check.h"
 
 namespace luci
 {
@@ -35,5 +39,71 @@ luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFullyConnected 
   }
   return cloned;
 }
+
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleFullyConnected *node)
+{
+  auto input_shape = circle_shape(loco::must_cast<CircleNode *>(node->input()));
+  auto weights_shape = circle_shape(loco::must_cast<CircleNode *>(node->weights()));
+
+  loco::TensorShape out_shape;
+
+  // NOTE Some recipes in some repositories are using rank 4 input for FullyConnected.
+  //      Until they are all fixed, disable following assert.
+  // TODO Enable following assert after related fixes are applied
+  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L194
+  // LUCI_ASSERT(input_shape.rank() == 2 || input_shape.rank() == 3,
+  //             "Input rank of FullyConnected should be 2 or 3");
+
+  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L225
+  LUCI_ASSERT(weights_shape.rank() == 2, "Weights of FullyConnected should be 2");
+
+  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L353-L367
+  if (node->keep_num_dims())
+  {
+    out_shape.rank(input_shape.rank());
+    for (uint32_t i = 0; i < input_shape.rank(); ++i)
+      out_shape.dim(i) = input_shape.dim(i);
+    out_shape.dim(out_shape.rank() - 1) = weights_shape.dim(0);
+  }
+  else
+  {
+    uint32_t input_size = 1;
+    bool is_dynamic_shape = false;
+    for (uint32_t i = 0; i < input_shape.rank(); i++)
+    {
+      if (not input_shape.dim(i).known() && i != input_shape.rank() - 1)
+      {
+        is_dynamic_shape = true;
+        break;
+      }
+      input_size = input_size * (input_shape.dim(i).known() ? input_shape.dim(i).value()
+                                                            : weights_shape.dim(1).value());
+    }
+
+    // Originally, input_size is calculated by multiplying dimensions from 0 to rank()-1
+    // The output BatchSize is determined by the input_size, which is calculated by multiplying
+    // dimensions up to rank()-2. Since weights_shape.dim(1).value() ==
+    // input_shape.dim(input_shape.rank()-1).value(). However, If dim(rank()-1) is
+    // unknown(=dynamic), dim(rank()-1).value will be set 0. As a result, BatchSize may also become
+    // 0 due to value of last input dimension.
+
+    out_shape.rank(2);
+    if (is_dynamic_shape)
+      out_shape.dim(0).unset();
+    else
+    {
+      const uint32_t batch_size = input_size / weights_shape.dim(1).value();
+      out_shape.dim(0) = batch_size;
+    }
+    out_shape.dim(1) = weights_shape.dim(0);
+  }
+
+  return out_shape;
+}
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleFullyConnected.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFullyConnected.test.cpp
@@ -16,6 +16,8 @@
 
 #include "luci/Service/CircleNodeClone.h"
 
+#include "luci/Service/CircleShapeInference.h"
+
 #include <gtest/gtest.h>
 
 TEST(CloneNodeTest, clone_FullyConnected)
@@ -58,4 +60,112 @@ TEST(CloneNodeTest, clone_FullyConnected_wf_NEG)
   auto gc = loco::make_graph();
   auto cloned = luci::clone_node(node_fc, gc.get());
   ASSERT_EQ(nullptr, cloned);
+}
+
+TEST(ShapeRuleTest, fully_connected_dynamic_shape_keep_dims)
+{
+  luci::CircleInput input;
+  luci::CircleConst weights;
+  luci::CircleConst bias;
+  luci::CircleFullyConnected fully_connected;
+
+  input.shape({1, 10, 20});
+  input.shape_status(luci::ShapeStatus::VALID);
+  input.dim(1).unset();
+
+  weights.shape({15, 20});
+  weights.shape_status(luci::ShapeStatus::VALID);
+
+  bias.shape_status(luci::ShapeStatus::VALID);
+
+  fully_connected.input(&input);
+  fully_connected.weights(&weights);
+  fully_connected.bias(&bias);
+  fully_connected.keep_num_dims(true);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&fully_connected, shape));
+  ASSERT_EQ(3, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_FALSE(shape.dim(1).known());
+  ASSERT_TRUE(shape.dim(2).known());
+
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(15, shape.dim(2).value());
+}
+
+TEST(ShapeRuleTest, fully_connected_dynamic_shape_no_keep_dims)
+{
+  luci::CircleInput input;
+  luci::CircleConst weights;
+  luci::CircleConst bias;
+  luci::CircleFullyConnected fully_connected;
+
+  input.shape({1, 10, 20});
+  input.shape_status(luci::ShapeStatus::VALID);
+  input.dim(2).unset();
+
+  weights.shape({15, 20});
+  weights.shape_status(luci::ShapeStatus::VALID);
+
+  bias.shape_status(luci::ShapeStatus::VALID);
+
+  fully_connected.input(&input);
+  fully_connected.weights(&weights);
+  fully_connected.bias(&bias);
+  fully_connected.keep_num_dims(false);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&fully_connected, shape));
+  ASSERT_EQ(2, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+
+  ASSERT_EQ(10, shape.dim(0).value());
+  ASSERT_EQ(15, shape.dim(1).value());
+}
+
+TEST(ShapeRuleTest, fully_connected_nullptr_weights_NEG)
+{
+  luci::CircleInput input;
+  luci::CircleConst bias;
+  luci::CircleFullyConnected fully_connected;
+
+  input.shape({1, 10, 20});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  bias.shape_status(luci::ShapeStatus::VALID);
+
+  fully_connected.input(&input);
+  fully_connected.weights(nullptr);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&fully_connected, shape));
+}
+
+TEST(ShapeRuleTest, fully_connected_nullptr_input_NEG)
+{
+  luci::CircleConst weights;
+  luci::CircleConst bias;
+  luci::CircleFullyConnected fully_connected;
+
+  weights.shape({15, 20});
+  weights.shape_status(luci::ShapeStatus::VALID);
+
+  bias.shape_status(luci::ShapeStatus::VALID);
+
+  fully_connected.input(nullptr);
+  fully_connected.weights(&weights);
+  fully_connected.bias(&bias);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&fully_connected, shape));
 }


### PR DESCRIPTION
This infers dynamic shapes for fully connected layers.
If the output shape retains its dimensions, the operation works correctly. 
However, if the output shape does not retain its dimensions, the behavior has been modified accordingly.

ONE-DCO-1.0-Signed-off-by: HanJin Choi hanjin4647@gmail.com

Related to : https://github.com/Samsung/ONE/issues/13697
