### PR TITLE
[luci/service] Migrate rsqrt shape inference rule

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -128,7 +128,7 @@ public:
   // loco::TensorShape visit(const luci::CircleReverseSequence *node) final;
   // loco::TensorShape visit(const luci::CircleReverseV2 *node) final;
   // loco::TensorShape visit(const luci::CircleRound *node) final;
-  // loco::TensorShape visit(const luci::CircleRsqrt *node) final;
+  loco::TensorShape visit(const luci::CircleRsqrt *node) final;
   // loco::TensorShape visit(const luci::CircleScatterNd *node) final;
   // loco::TensorShape visit(const luci::CircleSegmentSum *node) final;
   // loco::TensorShape visit(const luci::CircleSelect *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2339,8 +2339,6 @@ public:
     return loco::NodeShape{input_shape};
   }
 
-  loco::NodeShape visit(const luci::CircleRsqrt *node) final { return use_x(node); }
-
   loco::NodeShape visit(const luci::CircleScatterNd *node) final { return infer_scatter_nd(node); }
 
   loco::NodeShape visit(const luci::CircleSegmentSum *node) final

--- a/compiler/luci/service/src/Nodes/CircleRsqrt.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRsqrt.cpp
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+#include "luci/Service/CircleShapeInference.h"
+
 #include "CircleCloneNode.h"
+#include "CircleShapeInferenceHelper.h"
 
 namespace luci
 {
@@ -23,5 +26,16 @@ luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleRsqrt *)
 {
   return _graph->nodes()->create<luci::CircleRsqrt>();
 }
+
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleRsqrt *node)
+{
+  const auto input_shape = circle_shape(loco::must_cast<CircleNode *>(node->x()));
+  return input_shape;
+}
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleRsqrt.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRsqrt.test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "luci/Service/CircleNodeClone.h"
+#include "luci/Service/CircleShapeInference.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,69 @@ TEST(CloneNodeTest, clone_Rsqrt)
 
   auto cloned_rsqrt = dynamic_cast<luci::CircleRsqrt *>(cloned);
   ASSERT_NE(nullptr, cloned_rsqrt);
+}
+
+TEST(ShapeRuleTest, rsqrt_dynamic_shape)
+{
+  luci::CircleInput input;
+  luci::CircleRsqrt rsqrt;
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  input.shape({1, 1, 3, 4});
+  input.shape_status(luci::ShapeStatus::VALID);
+  input.dim(0).unset();
+  input.dim(1).unset();
+
+  rsqrt.x(&input);
+
+  ASSERT_TRUE(shape_inf_rule.infer(&rsqrt, shape));
+  ASSERT_EQ(shape.rank(), 4);
+  ASSERT_FALSE(shape.dim(0).known());
+  ASSERT_FALSE(shape.dim(1).known());
+  ASSERT_TRUE(shape.dim(2).known());
+  ASSERT_TRUE(shape.dim(3).known());
+
+  ASSERT_EQ(0, shape.dim(0).value());
+  ASSERT_EQ(0, shape.dim(1).value());
+  ASSERT_EQ(3, shape.dim(2).value());
+  ASSERT_EQ(4, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, rsqrt_static_shape)
+{
+  luci::CircleInput input;
+  luci::CircleRsqrt rsqrt;
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  input.shape({3, 2, 3, 4});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  rsqrt.x(&input);
+
+  ASSERT_TRUE(shape_inf_rule.infer(&rsqrt, shape));
+  ASSERT_EQ(shape.rank(), 4);
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_TRUE(shape.dim(2).known());
+  ASSERT_TRUE(shape.dim(3).known());
+
+  ASSERT_EQ(3, shape.dim(0).value());
+  ASSERT_EQ(2, shape.dim(1).value());
+  ASSERT_EQ(3, shape.dim(2).value());
+  ASSERT_EQ(4, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, rsqrt_shape_forward_NEG)
+{
+  luci::CircleRsqrt rsqrt;
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  rsqrt.x(nullptr);
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&rsqrt, shape));
 }

--- a/compiler/luci/service/src/Nodes/CircleRsqrt.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRsqrt.test.cpp
@@ -87,7 +87,7 @@ TEST(ShapeRuleTest, rsqrt_static_shape)
   ASSERT_EQ(4, shape.dim(3).value());
 }
 
-TEST(ShapeRuleTest, rsqrt_shape_forward_NEG)
+TEST(ShapeRuleTest, rsqrt_nullptr_input_NEG)
 {
   luci::CircleRsqrt rsqrt;
 
@@ -96,4 +96,18 @@ TEST(ShapeRuleTest, rsqrt_shape_forward_NEG)
 
   rsqrt.x(nullptr);
   ASSERT_ANY_THROW(shape_inf_rule.infer(&rsqrt, shape));
+}
+
+TEST(ShapeRuleTest, rsqrt_shape_not_ready_NEG)
+{
+  luci::CircleInput input;
+  luci::CircleRsqrt rsqrt;
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  input.shape_status(luci::ShapeStatus::UNDEFINED);
+
+  rsqrt.x(&input);
+  ASSERT_FALSE(shape_inf_rule.infer(&rsqrt, shape));
 }


### PR DESCRIPTION
The rsqrt operation did not have any issues with dynamic shape inference.
Therefore, This migrates the existing code from CircleShapeInferenceRule to sinf::Algorithm for consistency and adds tests for shape inference.

Related to : https://github.com/Samsung/ONE/issues/13697
Draft: https://github.com/Samsung/ONE/pull/13838

ONE-DCO-1.0-Signed-off-by: Chansu Park [1265pcs@gmail.com](mailto:1265pcs@gmail.com)