### PR TITLE
[luci/export] Split exportModule method

### DIFF
--- a/compiler/luci/export/src/CircleExporterImpl.cpp
+++ b/compiler/luci/export/src/CircleExporterImpl.cpp
@@ -159,6 +159,11 @@ void CircleExporterImpl::exportModule(Module *module)
   // prepare model data
   prepareModelData(_builder, md);
 
+  exportModuleData(module, md);
+}
+
+void CircleExporterImpl::exportModuleData(Module *module, SerializedModelData &md)
+{
   std::vector<flatbuffers::Offset<circle::SubGraph>> subgraph_vec;
 
   for (size_t g = 0; g < module->size(); ++g)

--- a/compiler/luci/export/src/CircleExporterImpl.h
+++ b/compiler/luci/export/src/CircleExporterImpl.h
@@ -64,6 +64,11 @@ private:
    */
   void exportModule(Module *module);
 
+  /**
+   * @brief implementation that writes Module into internal buffer
+   */
+  void exportModuleData(Module *module, SerializedModelData &md);
+
 private:
   flatbuffers::FlatBufferBuilder _builder;
 };


### PR DESCRIPTION
This will split exportModule method to prepare two pass execution.
