### PR TITLE
[DRAFT][luci/service] Infer pad shape for non-const paddings.

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -161,7 +161,7 @@ loco::TensorShape broadcast_shape(const loco::TensorShape &x, const loco::Tensor
   return output_shape;
 }
 
-loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::CircleConst *paddings)
+loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::CircleNode *paddings)
 {
   const loco::DataType S32 = loco::DataType::S32;
   const loco::DataType S64 = loco::DataType::S64;
@@ -180,6 +180,13 @@ loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::Ci
   loco::TensorShape output_shape;
 
   output_shape.rank(input_shape.rank());
+
+  auto const_padding = dynamic_cast<const luci::CircleConst *>(paddings);
+
+  // If padding is not constant, return unkown shape.
+  if (const_padding == nullptr)
+    return output_shape;
+
   for (int32_t ni = 0; ni < n; ++ni)
   {
     if (not input_shape.dim(ni).known())
@@ -189,15 +196,15 @@ loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::Ci
     }
     int32_t idx = ni * 2;
     int value = input_shape.dim(ni).value();
-    if (paddings->dtype() == S32)
+    if (const_padding->dtype() == S32)
     {
-      value += paddings->at<S32>(idx + 0); // left
-      value += paddings->at<S32>(idx + 1); // right
+      value += const_padding->at<S32>(idx + 0); // left
+      value += const_padding->at<S32>(idx + 1); // right
     }
     else
     {
-      auto pl = paddings->at<S64>(idx + 0);
-      auto pr = paddings->at<S64>(idx + 1);
+      auto pl = const_padding->at<S64>(idx + 0);
+      auto pr = const_padding->at<S64>(idx + 1);
       auto max = static_cast<int64_t>(std::numeric_limits<int32_t>::max());
       auto low = static_cast<int64_t>(std::numeric_limits<int32_t>::lowest());
       LUCI_ASSERT(pl <= max, "paddings is over 32 bit limit");
@@ -210,14 +217,6 @@ loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::Ci
     output_shape.dim(ni) = value;
   }
 
-  return output_shape;
-}
-
-loco::TensorShape unknown_shape(const loco::TensorShape &input_shape)
-{
-  loco::TensorShape output_shape;
-  int32_t n = input_shape.rank();
-  output_shape.rank(n);
   return output_shape;
 }
 

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -213,5 +213,17 @@ loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::Ci
   return output_shape;
 }
 
+loco::TensorShape unknown_shape(const loco::TensorShape &input_shape)
+{
+  loco::TensorShape output_shape;
+  int32_t n = input_shape.rank();
+  output_shape.rank(n);
+  for (int32_t ni = 0; ni < n; ++ni)
+  {
+    output_shape.dim(ni).unset();
+  }
+  return output_shape;
+}
+
 } // namespace sinf
 } // namespace luci

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -218,10 +218,6 @@ loco::TensorShape unknown_shape(const loco::TensorShape &input_shape)
   loco::TensorShape output_shape;
   int32_t n = input_shape.rank();
   output_shape.rank(n);
-  for (int32_t ni = 0; ni < n; ++ni)
-  {
-    output_shape.dim(ni).unset();
-  }
   return output_shape;
 }
 

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.h
@@ -48,9 +48,12 @@ loco::TensorShape circle_shape(const luci::CircleNode *node);
 // Throw an exception if x and y are not broadcastable.
 loco::TensorShape broadcast_shape(const loco::TensorShape &x, const loco::TensorShape &y);
 
-// Return shape of pad ops using paddings.
+// Return shape of pad ops using const paddings.
 loco::TensorShape pad_shape(const loco::TensorShape &input_shape,
                             const luci::CircleConst *paddings);
+
+// Return shape that only rank is known. All deminsions of shape is unknown.
+loco::TensorShape unknown_shape(const loco::TensorShape &input_shape);
 
 /**
  * @brief Create a higher-rank TensorShape following NumPy broadcasting semantics

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.h
@@ -49,11 +49,7 @@ loco::TensorShape circle_shape(const luci::CircleNode *node);
 loco::TensorShape broadcast_shape(const loco::TensorShape &x, const loco::TensorShape &y);
 
 // Return shape of pad ops using const paddings.
-loco::TensorShape pad_shape(const loco::TensorShape &input_shape,
-                            const luci::CircleConst *paddings);
-
-// Return shape that only rank is known. All deminsions of shape is unknown.
-loco::TensorShape unknown_shape(const loco::TensorShape &input_shape);
+loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::CircleNode *paddings);
 
 /**
  * @brief Create a higher-rank TensorShape following NumPy broadcasting semantics

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.h
@@ -48,7 +48,8 @@ loco::TensorShape circle_shape(const luci::CircleNode *node);
 // Throw an exception if x and y are not broadcastable.
 loco::TensorShape broadcast_shape(const loco::TensorShape &x, const loco::TensorShape &y);
 
-// Return shape of pad ops using const paddings.
+// Return shape of pad ops using paddings.
+// If paddings is static, return the shape filled with unknown dimensions.
 loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::CircleNode *paddings);
 
 /**

--- a/compiler/luci/service/src/Nodes/CirclePad.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.cpp
@@ -41,14 +41,7 @@ loco::TensorShape Algorithm::visit(const luci::CirclePad *node)
   }
   else
   {
-    loco::TensorShape output_shape;
-    int32_t n = input_shape.rank();
-    output_shape.rank(n);
-    for (int32_t ni = 0; ni < n; ++ni)
-    {
-      output_shape.dim(ni).unset();
-    }
-    return output_shape;
+    return unknown_shape(input_shape);
   }
 }
 

--- a/compiler/luci/service/src/Nodes/CirclePad.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.cpp
@@ -32,11 +32,24 @@ namespace sinf
 
 loco::TensorShape Algorithm::visit(const luci::CirclePad *node)
 {
-  // TODO support non-const case
-  auto paddings = loco::must_cast<luci::CircleConst *>(node->paddings());
+  auto paddings = dynamic_cast<luci::CircleConst *>(node->paddings());
   auto circle_input = loco::must_cast<const luci::CircleNode *>(node->input());
   auto input_shape = circle_shape(circle_input);
-  return pad_shape(input_shape, paddings);
+  if (paddings != nullptr)
+  {
+    return pad_shape(input_shape, paddings);
+  }
+  else
+  {
+    loco::TensorShape output_shape;
+    int32_t n = input_shape.rank();
+    output_shape.rank(n);
+    for (int32_t ni = 0; ni < n; ++ni)
+    {
+      output_shape.dim(ni).unset();
+    }
+    return output_shape;
+  }
 }
 
 } // namespace sinf

--- a/compiler/luci/service/src/Nodes/CirclePad.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.cpp
@@ -32,6 +32,7 @@ namespace sinf
 
 loco::TensorShape Algorithm::visit(const luci::CirclePad *node)
 {
+
   auto paddings = loco::must_cast<const luci::CircleNode *>(node->paddings());
 
   auto circle_input = loco::must_cast<const luci::CircleNode *>(node->input());

--- a/compiler/luci/service/src/Nodes/CirclePad.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.cpp
@@ -32,17 +32,12 @@ namespace sinf
 
 loco::TensorShape Algorithm::visit(const luci::CirclePad *node)
 {
-  auto paddings = dynamic_cast<luci::CircleConst *>(node->paddings());
+  auto paddings = loco::must_cast<const luci::CircleNode *>(node->paddings());
+
   auto circle_input = loco::must_cast<const luci::CircleNode *>(node->input());
   auto input_shape = circle_shape(circle_input);
-  if (paddings != nullptr)
-  {
-    return pad_shape(input_shape, paddings);
-  }
-  else
-  {
-    return unknown_shape(input_shape);
-  }
+
+  return pad_shape(input_shape, paddings);
 }
 
 } // namespace sinf

--- a/compiler/luci/service/src/Nodes/CirclePad.test.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.test.cpp
@@ -90,3 +90,61 @@ TEST(ShapeRuleTest, pad_without_padding_NEG)
 
   ASSERT_ANY_THROW(shape_inf_rule.infer(node_pad, shape));
 }
+
+TEST(ShapeRuleTest, pad_non_const_paddings)
+{
+  auto g = loco::make_graph();
+  auto node_pad = g->nodes()->create<luci::CirclePad>();
+
+  auto node_paddings = g->nodes()->create<luci::CircleInput>();
+  auto node_input = g->nodes()->create<luci::CircleInput>();
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  node_input->shape({1, 2, 3, 4});
+  node_input->shape_status(luci::ShapeStatus::VALID);
+  node_input->dim(2).unset();
+
+  node_paddings->dtype(loco::DataType::S64);
+  node_paddings->shape({4, 2});
+  node_paddings->shape_status(luci::ShapeStatus::VALID);
+
+  node_pad->input(node_input);
+  node_pad->paddings(node_paddings);
+
+  ASSERT_TRUE(shape_inf_rule.infer(node_pad, shape));
+  ASSERT_EQ(shape.rank(), 4);
+  ASSERT_FALSE(shape.dim(0).known());
+  ASSERT_FALSE(shape.dim(1).known());
+  ASSERT_FALSE(shape.dim(2).known());
+  ASSERT_FALSE(shape.dim(3).known());
+
+  ASSERT_EQ(0, shape.dim(0).value());
+  ASSERT_EQ(0, shape.dim(1).value());
+  ASSERT_EQ(0, shape.dim(2).value());
+  ASSERT_EQ(0, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, pad_without_input_NEG)
+{
+  auto g = loco::make_graph();
+  auto node_pad = g->nodes()->create<luci::CirclePad>();
+
+  auto node_paddings = g->nodes()->create<luci::CircleConst>();
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  node_paddings->dtype(loco::DataType::S64);
+  node_paddings->shape({4, 2});
+  node_paddings->shape_status(luci::ShapeStatus::VALID);
+
+  const loco::DataType S64 = loco::DataType::S64;
+  uint32_t t = 64 * 8;
+  node_paddings->size<S64>(t);
+
+  node_pad->paddings(node_paddings);
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(node_pad, shape));
+}

--- a/compiler/luci/service/src/Nodes/CirclePad.test.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.test.cpp
@@ -104,7 +104,6 @@ TEST(ShapeRuleTest, pad_non_const_paddings)
 
   node_input->shape({1, 2, 3, 4});
   node_input->shape_status(luci::ShapeStatus::VALID);
-  node_input->dim(2).unset();
 
   node_paddings->dtype(loco::DataType::S64);
   node_paddings->shape({4, 2});


### PR DESCRIPTION
This supports shape inference of pad when paddings is not constant.

ONE-DCO-1.0-Signed-off-by: JuYoung Lee rsb98759@gmail.com