### PR TITLE
[luci/export] Clear model data in prepareModelData

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -673,6 +673,8 @@ namespace luci
 
 void prepareModelData(FlatBufferBuilder &builder, SerializedModelData &md)
 {
+  md.clear();
+
   // add one empty buffer
   //   note: this follows TFLite
   //   note: there's a comment in tflite fbs file


### PR DESCRIPTION
This will clear model data in prepareModelData method.
- this is to clear before second pass
