### PR TITLE
[one-cmds] Add an option for RemoveUnnecessaryCastPass

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -200,6 +200,7 @@ Current transformation options are
 - remove_redundant_reshape : This fuses or removes redundant reshape operators.
 - remove_redundant_transpose : This fuses or removes redundant transpose operators.
 - remove_unnecessary_add : This removes unnecessary add operators.
+- remove_unnecessary_cast : This will remove unnecessary cast with the same input and output type.
 - remove_unnecessary_reshape : This removes unnecessary reshape operators.
 - remove_unnecessary_slice : This removes unnecessary slice operators.
 - remove_unnecessary_strided_slice : This removes unnecessary strided slice operators.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -63,6 +63,7 @@ class CONSTANT:
         'remove_redundant_reshape',
         'remove_redundant_transpose',
         'remove_unnecessary_add',
+        'remove_unnecessary_cast'
         'remove_unnecessary_reshape',
         'remove_unnecessary_slice',
         'remove_unnecessary_strided_slice',
@@ -157,6 +158,7 @@ class CONSTANT:
         ('remove_redundant_reshape', 'fuse or remove subsequent Reshape ops'),
         ('remove_redundant_transpose', 'fuse or remove subsequent Transpose ops'),
         ('remove_unnecessary_add', 'remove unnecessary add ops'),
+        ('remove_unnecessary_cast', 'remove unnecessary cast ops'),
         ('remove_unnecessary_reshape', 'remove unnecessary reshape ops'),
         ('remove_unnecessary_slice', 'remove unnecessary slice ops'),
         ('remove_unnecessary_strided_slice', 'remove unnecessary strided slice ops'),


### PR DESCRIPTION
This commit adds one-cmd option for RemoveUnnecessaryCastPass.

ONE-DCO-1.0-Signed-off-by: Jan Iwaszkiewicz <j.iwaszkiewi@samsung.com>