### PR TITLE
[luci/import] Revise importModule method

### DIFF
--- a/compiler/luci/import/include/luci/Importer.h
+++ b/compiler/luci/import/include/luci/Importer.h
@@ -41,9 +41,10 @@ public:
     // DO NOTHING
   }
 
-public:
-  // TODO move to private
+private:
   std::unique_ptr<Module> importModule(const circle::Model *model) const;
+
+public:
   std::unique_ptr<Module> importModule(const uint8_t *data, size_t size);
 
 private:

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -268,6 +268,10 @@ Importer::Importer()
 
 std::unique_ptr<Module> Importer::importModule(const circle::Model *model) const
 {
+  assert(model);
+  assert(_file_data);
+  assert(_file_size);
+
   auto module = make_module();
 
   const GraphBuilderSource *source_ptr = &GraphBuilderRegistry::get();
@@ -279,17 +283,8 @@ std::unique_ptr<Module> Importer::importModule(const circle::Model *model) const
   }
 
   CircleReader reader;
-  if (_file_data && _file_size)
-  {
-    if (!reader.parse(model, _file_data, _file_size))
-      return nullptr;
-  }
-  else
-  {
-    // TODO remove this
-    if (!reader.parse(model))
-      return nullptr;
-  }
+  if (!reader.parse(model, _file_data, _file_size))
+    return nullptr;
 
   for (uint32_t g = 0; g < reader.num_subgraph(); ++g)
   {


### PR DESCRIPTION
This will revise importModule method with circle::Module as
- make it private to prevent future isses with large model
- add some guards
- only call reader with file data and size