### PR TITLE
[luci/service] Migrate Neg shape inference rule to sinf::Algorithm

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -101,7 +101,7 @@ public:
   // loco::TensorShape visit(const luci::CircleMinimum *node) final;
   // loco::TensorShape visit(const luci::CircleMirrorPad *node) final;
   loco::TensorShape visit(const luci::CircleMul *node) final;
-  // loco::TensorShape visit(const luci::CircleNeg *node) final;
+  loco::TensorShape visit(const luci::CircleNeg *node) final;
   // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV4 *node) final;
   // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV5 *node) final;
   // loco::TensorShape visit(const luci::CircleNotEqual *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2142,8 +2142,6 @@ public:
 
   loco::NodeShape visit(const luci::CircleMirrorPad *node) final { return infer_mirror_pad(node); }
 
-  loco::NodeShape visit(const luci::CircleNeg *node) final { return use_x(node); }
-
   loco::NodeShape visit(const luci::CircleNonMaxSuppressionV4 *node) final
   {
     const auto boxes_shape = luci::shape_get(node->boxes()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/Nodes/CircleNeg.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNeg.cpp
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "luci/Service/CircleShapeInference.h"
 
 #include "CircleCloneNode.h"
+#include "CircleShapeInferenceHelper.h"
 
 namespace luci
 {
@@ -23,5 +25,17 @@ luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleNeg *)
 {
   return _graph->nodes()->create<luci::CircleNeg>();
 }
+
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleNeg *node)
+{
+  const auto input_x = loco::must_cast<CircleNode *>(node->x());
+  const auto input_shape = circle_shape(input_x);
+  return input_shape;
+}
+
+} // namespace sinf
 
 } // namespace luci


### PR DESCRIPTION
This commit migrate Neg shape inference rule to sinf::Algorithm.

ONE-DCO-1.0-Signed-off-by: HanJin Choi hanjin4647@gmail.com