### PR TITLE
[luci] Fix overflow warning

### DIFF
--- a/compiler/luci/export/src/CircleExporterUtils.h
+++ b/compiler/luci/export/src/CircleExporterUtils.h
@@ -27,7 +27,7 @@
 #include <mio/circle/schema_generated.h>
 
 // limitation of current flatbuffers file size
-inline constexpr unsigned uint64_t FLATBUFFERS_SIZE_MAX = 2147483648UL; // 2GB
+inline constexpr uint64_t FLATBUFFERS_SIZE_MAX = 2147483648UL; // 2GB
 
 namespace luci
 {

--- a/compiler/luci/export/src/CircleExporterUtils.h
+++ b/compiler/luci/export/src/CircleExporterUtils.h
@@ -27,7 +27,7 @@
 #include <mio/circle/schema_generated.h>
 
 // limitation of current flatbuffers file size
-inline constexpr unsigned int FLATBUFFERS_SIZE_MAX = 2147483648;
+inline constexpr unsigned uint64_t FLATBUFFERS_SIZE_MAX = 2147483648UL; // 2GB
 
 namespace luci
 {


### PR DESCRIPTION
This commit resolves analyzer's overflow warning.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>