### PR TITLE
[onert] Fix warnings in checkpoint loader and exporter

### DIFF
--- a/runtime/onert/core/src/exporter/train/CheckpointExporter.cc
+++ b/runtime/onert/core/src/exporter/train/CheckpointExporter.cc
@@ -73,9 +73,9 @@ struct DataBuffer
 private:
   std::vector<uint32_t> _offset;
   std::vector<char> _data;
-  uint32_t _start_offset;
+  uint32_t _start_offset = 0;
   std::vector<uint32_t>::iterator _offset_it;
-  char *_data_ptr;
+  char *_data_ptr = nullptr;
 };
 
 class CheckpointExporter

--- a/runtime/onert/core/src/loader/train/CheckpointLoader.cc
+++ b/runtime/onert/core/src/loader/train/CheckpointLoader.cc
@@ -66,7 +66,7 @@ public:
       throw std::runtime_error{"Invalid checkpoint file footer data"};
 
     memset(reinterpret_cast<char *>(&_footer), 0, sizeof(_footer));
-    _file.seekg(_header.other_offset, std::ios::beg);
+    _file.seekg(static_cast<std::streamoff>(_header.other_offset), std::ios::beg);
     _file.read(reinterpret_cast<char *>(&_footer), sizeof(_footer));
   }
 


### PR DESCRIPTION
This commit fixes some warnings by static analyzer
- Implicit casting signed integer to explicit casting in loader
- Initialize fields in exporter

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>