### PR TITLE
[luci/service] Support shape inference for non-const paddings

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -182,7 +182,6 @@ loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::Ci
   output_shape.rank(input_shape.rank());
 
   auto const_padding = dynamic_cast<const luci::CircleConst *>(paddings);
-
   if (const_padding == nullptr)
     return output_shape;
 

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.h
@@ -49,8 +49,8 @@ loco::TensorShape circle_shape(const luci::CircleNode *node);
 loco::TensorShape broadcast_shape(const loco::TensorShape &x, const loco::TensorShape &y);
 
 // Return shape of pad ops using paddings.
-loco::TensorShape pad_shape(const loco::TensorShape &input_shape,
-                            const luci::CircleConst *paddings);
+// If paddings is static, return the shape filled with unknown dimensions.
+loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::CircleNode *paddings);
 
 /**
  * @brief Create a higher-rank TensorShape following NumPy broadcasting semantics

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.h
@@ -49,7 +49,7 @@ loco::TensorShape circle_shape(const luci::CircleNode *node);
 loco::TensorShape broadcast_shape(const loco::TensorShape &x, const loco::TensorShape &y);
 
 // Return shape of pad ops using paddings.
-// If paddings is static, return the shape filled with unknown dimensions.
+// If paddings is not static, return the shape filled with unknown dimensions.
 loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::CircleNode *paddings);
 
 /**

--- a/compiler/luci/service/src/Nodes/CirclePad.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.cpp
@@ -32,8 +32,9 @@ namespace sinf
 
 loco::TensorShape Algorithm::visit(const luci::CirclePad *node)
 {
-  // TODO support non-const case
-  auto paddings = loco::must_cast<luci::CircleConst *>(node->paddings());
+
+  auto paddings = loco::must_cast<const luci::CircleNode *>(node->paddings());
+
   auto circle_input = loco::must_cast<const luci::CircleNode *>(node->input());
   auto input_shape = circle_shape(circle_input);
   return pad_shape(input_shape, paddings);

--- a/compiler/luci/service/src/Nodes/CirclePad.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.cpp
@@ -32,11 +32,10 @@ namespace sinf
 
 loco::TensorShape Algorithm::visit(const luci::CirclePad *node)
 {
-
   auto paddings = loco::must_cast<const luci::CircleNode *>(node->paddings());
-
   auto circle_input = loco::must_cast<const luci::CircleNode *>(node->input());
   auto input_shape = circle_shape(circle_input);
+
   return pad_shape(input_shape, paddings);
 }
 

--- a/compiler/luci/service/src/Nodes/CirclePad.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.cpp
@@ -35,7 +35,6 @@ loco::TensorShape Algorithm::visit(const luci::CirclePad *node)
   auto paddings = loco::must_cast<const luci::CircleNode *>(node->paddings());
   auto circle_input = loco::must_cast<const luci::CircleNode *>(node->input());
   auto input_shape = circle_shape(circle_input);
-
   return pad_shape(input_shape, paddings);
 }
 

--- a/compiler/luci/service/src/Nodes/CirclePad.test.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.test.cpp
@@ -125,25 +125,21 @@ TEST(ShapeRuleTest, pad_non_const_paddings)
   ASSERT_EQ(0, shape.dim(3).value());
 }
 
-TEST(ShapeRuleTest, pad_without_input_NEG)
+TEST(ShapeRuleTest, pad_empty_padding_NEG)
 {
   auto g = loco::make_graph();
   auto node_pad = g->nodes()->create<luci::CirclePad>();
-
-  auto node_paddings = g->nodes()->create<luci::CircleConst>();
+  auto node_input = g->nodes()->create<luci::CircleInput>();
+  auto node_paddings = g->nodes()->create<luci::CircleAdd>();
 
   loco::TensorShape shape;
   luci::sinf::Rule shape_inf_rule;
 
-  node_paddings->dtype(loco::DataType::S64);
-  node_paddings->shape({4, 2});
-  node_paddings->shape_status(luci::ShapeStatus::VALID);
+  node_input->shape({1, 2, 3, 4});
+  node_input->shape_status(luci::ShapeStatus::VALID);
 
-  const loco::DataType S64 = loco::DataType::S64;
-  uint32_t t = 64 * 8;
-  node_paddings->size<S64>(t);
-
+  node_pad->input(node_input);
   node_pad->paddings(node_paddings);
 
-  ASSERT_ANY_THROW(shape_inf_rule.infer(node_pad, shape));
+  ASSERT_FALSE(shape_inf_rule.infer(node_pad, shape));
 }

--- a/compiler/luci/service/src/Nodes/CirclePad.test.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.test.cpp
@@ -124,22 +124,3 @@ TEST(ShapeRuleTest, pad_non_const_paddings)
   ASSERT_EQ(0, shape.dim(2).value());
   ASSERT_EQ(0, shape.dim(3).value());
 }
-
-TEST(ShapeRuleTest, pad_empty_padding_NEG)
-{
-  auto g = loco::make_graph();
-  auto node_pad = g->nodes()->create<luci::CirclePad>();
-  auto node_input = g->nodes()->create<luci::CircleInput>();
-  auto node_paddings = g->nodes()->create<luci::CircleAdd>();
-
-  loco::TensorShape shape;
-  luci::sinf::Rule shape_inf_rule;
-
-  node_input->shape({1, 2, 3, 4});
-  node_input->shape_status(luci::ShapeStatus::VALID);
-
-  node_pad->input(node_input);
-  node_pad->paddings(node_paddings);
-
-  ASSERT_FALSE(shape_inf_rule.infer(node_pad, shape));
-}

--- a/compiler/luci/service/src/Nodes/CirclePad.test.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.test.cpp
@@ -90,3 +90,60 @@ TEST(ShapeRuleTest, pad_without_padding_NEG)
 
   ASSERT_ANY_THROW(shape_inf_rule.infer(node_pad, shape));
 }
+
+TEST(ShapeRuleTest, pad_non_const_paddings)
+{
+  auto g = loco::make_graph();
+  auto node_pad = g->nodes()->create<luci::CirclePad>();
+
+  auto node_paddings = g->nodes()->create<luci::CircleInput>();
+  auto node_input = g->nodes()->create<luci::CircleInput>();
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  node_input->shape({1, 2, 3, 4});
+  node_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_paddings->dtype(loco::DataType::S64);
+  node_paddings->shape({4, 2});
+  node_paddings->shape_status(luci::ShapeStatus::VALID);
+
+  node_pad->input(node_input);
+  node_pad->paddings(node_paddings);
+
+  ASSERT_TRUE(shape_inf_rule.infer(node_pad, shape));
+  ASSERT_EQ(shape.rank(), 4);
+  ASSERT_FALSE(shape.dim(0).known());
+  ASSERT_FALSE(shape.dim(1).known());
+  ASSERT_FALSE(shape.dim(2).known());
+  ASSERT_FALSE(shape.dim(3).known());
+
+  ASSERT_EQ(0, shape.dim(0).value());
+  ASSERT_EQ(0, shape.dim(1).value());
+  ASSERT_EQ(0, shape.dim(2).value());
+  ASSERT_EQ(0, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, pad_without_input_NEG)
+{
+  auto g = loco::make_graph();
+  auto node_pad = g->nodes()->create<luci::CirclePad>();
+
+  auto node_paddings = g->nodes()->create<luci::CircleConst>();
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  node_paddings->dtype(loco::DataType::S64);
+  node_paddings->shape({4, 2});
+  node_paddings->shape_status(luci::ShapeStatus::VALID);
+
+  const loco::DataType S64 = loco::DataType::S64;
+  uint32_t t = 64 * 8;
+  node_paddings->size<S64>(t);
+
+  node_pad->paddings(node_paddings);
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(node_pad, shape));
+}


### PR DESCRIPTION
This PR supports infer shape of pad operation with dynamic paddings.
ONE-DCO-1.0-Signed-off-by: JuYoung Lee rsb98759@gmail.com