### PR TITLE
Draft: [luci/service] Support Conv2D ops dynamic shape inference

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -58,11 +58,11 @@ public:
   // loco::TensorShape visit(const luci::CircleCeil *node) final;
   loco::TensorShape visit(const luci::CircleConcatenation *node) final;
   // loco::TensorShape visit(const luci::CircleConst *node) final;
-  // loco::TensorShape visit(const luci::CircleConv2D *node) final;
+  loco::TensorShape visit(const luci::CircleConv2D *node) final;
   // loco::TensorShape visit(const luci::CircleCos *node) final;
   // loco::TensorShape visit(const luci::CircleCustom *node) final;
   // loco::TensorShape visit(const luci::CircleDepthToSpace *node) final;
-  // loco::TensorShape visit(const luci::CircleDepthwiseConv2D *node) final;
+  loco::TensorShape visit(const luci::CircleDepthwiseConv2D *node) final;
   // loco::TensorShape visit(const luci::CircleDequantize *node) final;
   loco::TensorShape visit(const luci::CircleDiv *node) final;
   // loco::TensorShape visit(const luci::CircleElu *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -442,7 +442,6 @@ loco::NodeShape infer_broadcast_to(const luci::CircleBroadcastTo *node)
   return loco::NodeShape{shape_by_input};
 }
 
-
 loco::NodeShape infer_depth_to_space(const luci::CircleDepthToSpace *node)
 {
   auto input_shape = luci::shape_get(node->input()).as<loco::TensorShape>();
@@ -474,7 +473,6 @@ loco::NodeShape infer_depth_to_space(const luci::CircleDepthToSpace *node)
 
   return loco::NodeShape{output_shape};
 }
-
 
 loco::NodeShape infer_expand_dims(const luci::CircleExpandDims *node)
 {
@@ -1906,7 +1904,6 @@ public:
   {
     return infer_depth_to_space(node);
   }
-
 
   loco::NodeShape visit(const luci::CircleDequantize *node) final
   {

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -412,57 +412,6 @@ loco::NodeShape infer_batch_to_space_nd(const luci::CircleBatchToSpaceND *node)
   return loco::NodeShape{shape_output};
 }
 
-struct OutputSize
-{
-  uint32_t height = 0;
-  uint32_t width = 0;
-};
-
-template <class Conv2DType> OutputSize infer_conv2d_type(const Conv2DType *node)
-{
-  auto ifm_shape = luci::shape_get(node->input()).template as<loco::TensorShape>();
-  auto ker_shape = luci::shape_get(node->filter()).template as<loco::TensorShape>();
-  assert(ifm_shape.rank() == 4);
-  assert(ker_shape.rank() == 4);
-  assert(ifm_shape.dim(1).known());
-  assert(ifm_shape.dim(2).known());
-  assert(ker_shape.dim(1).known());
-  assert(ker_shape.dim(2).known());
-
-  uint32_t input_height = ifm_shape.dim(1).value();
-  uint32_t input_width = ifm_shape.dim(2).value();
-  uint32_t stride_height = node->stride()->h();
-  uint32_t stride_width = node->stride()->w();
-  uint32_t ker_height = ker_shape.dim(1).value();
-  uint32_t ker_width = ker_shape.dim(2).value();
-  uint32_t dilation_height = node->dilation()->h();
-  uint32_t dilation_width = node->dilation()->w();
-  uint32_t effective_ker_height = dilation_height * (ker_height - 1) + 1;
-  uint32_t effective_ker_width = dilation_width * (ker_width - 1) + 1;
-
-  uint32_t output_height = 0;
-  uint32_t output_width = 0;
-
-  if (node->padding() == luci::Padding::VALID)
-  {
-    LUCI_ASSERT(input_height + stride_height > effective_ker_height, "Invalid shape");
-    LUCI_ASSERT(input_width + stride_width > effective_ker_width, "Invalid shape");
-    output_height = (input_height + stride_height - effective_ker_height) / stride_height;
-    output_width = (input_width + stride_width - effective_ker_width) / stride_width;
-  }
-  else if (node->padding() == luci::Padding::SAME)
-  {
-    output_height = (input_height + stride_height - 1) / stride_height;
-    output_width = (input_width + stride_width - 1) / stride_width;
-  }
-  else
-    LUCI_ASSERT(false, "Wrong padding type");
-
-  OutputSize os{output_height, output_width};
-
-  return os;
-}
-
 loco::NodeShape infer_broadcast_to(const luci::CircleBroadcastTo *node)
 {
   const loco::DataType S32 = loco::DataType::S32;
@@ -493,33 +442,6 @@ loco::NodeShape infer_broadcast_to(const luci::CircleBroadcastTo *node)
   return loco::NodeShape{shape_by_input};
 }
 
-loco::NodeShape infer_conv2d(const luci::CircleConv2D *node)
-{
-  LOGGER(l);
-
-  auto ifm_shape = luci::shape_get(node->input()).as<loco::TensorShape>();  // in NHWC
-  auto ker_shape = luci::shape_get(node->filter()).as<loco::TensorShape>(); // in OHWI
-
-  assert(ifm_shape.rank() == 4);
-  assert(ker_shape.rank() == 4);
-  assert(ifm_shape.dim(3) == ker_shape.dim(3));
-
-  auto os = infer_conv2d_type(node);
-
-  loco::TensorShape ofm_shape;
-  ofm_shape.rank(4);
-  ofm_shape.dim(0) = ifm_shape.dim(0);
-  ofm_shape.dim(1) = os.height;
-  ofm_shape.dim(2) = os.width;
-  ofm_shape.dim(3) = ker_shape.dim(0);
-
-  INFO(l) << "[luci] CircleConv2D ShapeInf ifm(" << ifm_shape.rank() << ") ker(" << ker_shape.rank()
-          << ") output(" << ofm_shape.dim(0).value() << "," << ofm_shape.dim(1).value() << ","
-          << ofm_shape.dim(2).value() << "," << ofm_shape.dim(3).value() << ") " << node->name()
-          << std::endl;
-
-  return loco::NodeShape{ofm_shape};
-}
 
 loco::NodeShape infer_depth_to_space(const luci::CircleDepthToSpace *node)
 {
@@ -553,27 +475,6 @@ loco::NodeShape infer_depth_to_space(const luci::CircleDepthToSpace *node)
   return loco::NodeShape{output_shape};
 }
 
-loco::NodeShape infer_depthwise_conv2d(const luci::CircleDepthwiseConv2D *node)
-{
-  auto ifm_shape = luci::shape_get(node->input()).as<loco::TensorShape>();  // in NHWC
-  auto ker_shape = luci::shape_get(node->filter()).as<loco::TensorShape>(); // in 1 H W CM
-
-  assert(ifm_shape.rank() == 4);
-  assert(ker_shape.rank() == 4);
-  assert(ker_shape.dim(0).value() == 1);
-  assert(ifm_shape.dim(3).value() * node->depthMultiplier() == ker_shape.dim(3).value());
-
-  auto os = infer_conv2d_type(node);
-
-  loco::TensorShape ofm_shape;
-  ofm_shape.rank(4);
-  ofm_shape.dim(0) = ifm_shape.dim(0);
-  ofm_shape.dim(1) = os.height;
-  ofm_shape.dim(2) = os.width;
-  ofm_shape.dim(3) = ker_shape.dim(3);
-
-  return loco::NodeShape{ofm_shape};
-}
 
 loco::NodeShape infer_expand_dims(const luci::CircleExpandDims *node)
 {
@@ -1993,8 +1894,6 @@ public:
 
   loco::NodeShape visit(const luci::CircleConst *node) final { return use_own(node); }
 
-  loco::NodeShape visit(const luci::CircleConv2D *node) final { return infer_conv2d(node); }
-
   loco::NodeShape visit(const luci::CircleCos *node) final { return use_x(node); }
 
   loco::NodeShape visit(const luci::CircleCumSum *node) final { return use_input(node); }
@@ -2008,10 +1907,6 @@ public:
     return infer_depth_to_space(node);
   }
 
-  loco::NodeShape visit(const luci::CircleDepthwiseConv2D *node) final
-  {
-    return infer_depthwise_conv2d(node);
-  }
 
   loco::NodeShape visit(const luci::CircleDequantize *node) final
   {

--- a/compiler/luci/service/src/HelperConv2Ds.h
+++ b/compiler/luci/service/src/HelperConv2Ds.h
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #include "Check.h"
 #include "CircleShapeInferenceHelper.h"
 
@@ -24,8 +23,7 @@ namespace luci
 namespace sinf
 {
 
-template <class Conv2DType>
-loco::TensorShape conv2d_output_shape(const Conv2DType *node)
+template <class Conv2DType> loco::TensorShape conv2d_output_shape(const Conv2DType *node)
 {
   auto ifm_shape = circle_shape(loco::must_cast<const luci::CircleNode *>(node->input()));
   auto ker_shape = circle_shape(loco::must_cast<const luci::CircleNode *>(node->filter()));
@@ -62,7 +60,8 @@ loco::TensorShape conv2d_output_shape(const Conv2DType *node)
     if (node->padding() == luci::Padding::VALID)
     {
       LUCI_ASSERT(input_height + stride_height > effective_ker_height, "Invalid shape");
-      output_shape.dim(1).set((input_height + stride_height - effective_ker_height) / stride_height);
+      output_shape.dim(1).set((input_height + stride_height - effective_ker_height) /
+                              stride_height);
     }
     else if (node->padding() == luci::Padding::SAME)
     {

--- a/compiler/luci/service/src/HelperConv2Ds.h
+++ b/compiler/luci/service/src/HelperConv2Ds.h
@@ -32,17 +32,6 @@ template <class Conv2DType> loco::TensorShape conv2d_output_shape(const Conv2DTy
   assert(ker_shape.dim(1).known());
   assert(ker_shape.dim(2).known());
 
-  uint32_t input_height = ifm_shape.dim(1).value();
-  uint32_t input_width = ifm_shape.dim(2).value();
-  uint32_t ker_height = ker_shape.dim(1).value();
-  uint32_t ker_width = ker_shape.dim(2).value();
-  uint32_t stride_height = node->stride()->h();
-  uint32_t stride_width = node->stride()->w();
-  uint32_t dilation_height = node->dilation()->h();
-  uint32_t dilation_width = node->dilation()->w();
-  uint32_t effective_ker_height = dilation_height * (ker_height - 1) + 1;
-  uint32_t effective_ker_width = dilation_width * (ker_width - 1) + 1;
-
   // Output shape is 4D in NHWC order.
   // This will only specify output shape for height and width.
   // The other two dimensions (batch and channel) will be set by caller.

--- a/compiler/luci/service/src/HelperConv2Ds.h
+++ b/compiler/luci/service/src/HelperConv2Ds.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "Check.h"
+#include "CircleShapeInferenceHelper.h"
+
+namespace luci
+{
+
+namespace sinf
+{
+
+template <class Conv2DType>
+loco::TensorShape conv2d_output_shape(const Conv2DType *node)
+{
+  auto ifm_shape = circle_shape(loco::must_cast<const luci::CircleNode *>(node->input()));
+  auto ker_shape = circle_shape(loco::must_cast<const luci::CircleNode *>(node->filter()));
+  assert(ifm_shape.rank() == 4);
+  assert(ker_shape.rank() == 4);
+  assert(ker_shape.dim(1).known());
+  assert(ker_shape.dim(2).known());
+
+  uint32_t input_height = ifm_shape.dim(1).value();
+  uint32_t input_width = ifm_shape.dim(2).value();
+  uint32_t ker_height = ker_shape.dim(1).value();
+  uint32_t ker_width = ker_shape.dim(2).value();
+  uint32_t stride_height = node->stride()->h();
+  uint32_t stride_width = node->stride()->w();
+  uint32_t dilation_height = node->dilation()->h();
+  uint32_t dilation_width = node->dilation()->w();
+  uint32_t effective_ker_height = dilation_height * (ker_height - 1) + 1;
+  uint32_t effective_ker_width = dilation_width * (ker_width - 1) + 1;
+
+  // Output shape is 4D in NHWC order.
+  // This will only specify output shape for height and width.
+  // The other two dimensions (batch and channel) will be set by caller.
+  loco::TensorShape output_shape;
+  output_shape.rank(4);
+
+  if (ifm_shape.dim(1).known())
+  {
+    uint32_t input_height = ifm_shape.dim(1).value();
+    uint32_t ker_height = ker_shape.dim(1).value();
+    uint32_t stride_height = node->stride()->h();
+    uint32_t dilation_height = node->dilation()->h();
+    uint32_t effective_ker_height = dilation_height * (ker_height - 1) + 1;
+
+    if (node->padding() == luci::Padding::VALID)
+    {
+      LUCI_ASSERT(input_height + stride_height > effective_ker_height, "Invalid shape");
+      output_shape.dim(1).set((input_height + stride_height - effective_ker_height) / stride_height);
+    }
+    else if (node->padding() == luci::Padding::SAME)
+    {
+      output_shape.dim(1).set((input_height + stride_height - 1) / stride_height);
+    }
+    else
+    {
+      LUCI_ASSERT(false, "Wrong padding type");
+    }
+  }
+
+  if (ifm_shape.dim(2).known())
+  {
+    uint32_t input_width = ifm_shape.dim(2).value();
+    uint32_t ker_width = ker_shape.dim(2).value();
+    uint32_t stride_width = node->stride()->w();
+    uint32_t dilation_width = node->dilation()->w();
+    uint32_t effective_ker_width = dilation_width * (ker_width - 1) + 1;
+
+    if (node->padding() == luci::Padding::VALID)
+    {
+      LUCI_ASSERT(input_width + stride_width > effective_ker_width, "Invalid shape");
+      output_shape.dim(2).set((input_width + stride_width - effective_ker_width) / stride_width);
+    }
+    else if (node->padding() == luci::Padding::SAME)
+    {
+      output_shape.dim(2).set((input_width + stride_width - 1) / stride_width);
+    }
+    else
+    {
+      LUCI_ASSERT(false, "Wrong padding type");
+    }
+  }
+
+  return output_shape;
+}
+
+} // namespace sinf
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConv2D.cpp
@@ -51,8 +51,6 @@ namespace sinf
 loco::TensorShape Algorithm::visit(const luci::CircleConv2D *node)
 {
   LOGGER(l);
-
-  std::cout << "CircleConv2D ShapeInf" << std::endl;
   
   auto ifm_shape = luci::shape_get(node->input()).as<loco::TensorShape>();  // in NHWC
   auto ker_shape = luci::shape_get(node->filter()).as<loco::TensorShape>(); // in OHWI
@@ -70,8 +68,6 @@ loco::TensorShape Algorithm::visit(const luci::CircleConv2D *node)
           << ") output(" << ofm_shape.dim(0).value() << "," << ofm_shape.dim(1).value() << ","
           << ofm_shape.dim(2).value() << "," << ofm_shape.dim(3).value() << ") " << node->name()
           << std::endl;
-
-  std::cout << "CircleConv2D ShapeInf end" << std::endl;
 
   return ofm_shape;
 }

--- a/compiler/luci/service/src/Nodes/CircleConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConv2D.cpp
@@ -52,8 +52,10 @@ loco::TensorShape Algorithm::visit(const luci::CircleConv2D *node)
 {
   LOGGER(l);
   
-  auto ifm_shape = luci::shape_get(node->input()).as<loco::TensorShape>();  // in NHWC
-  auto ker_shape = luci::shape_get(node->filter()).as<loco::TensorShape>(); // in OHWI
+  auto ifm = loco::must_cast<luci::CircleNode *>(node->input());
+  auto ifm_shape = circle_shape(ifm); // in NHWC
+  auto ker = loco::must_cast<luci::CircleNode *>(node->filter());
+  auto ker_shape = circle_shape(ker); // in OHWI
 
   assert(ifm_shape.rank() == 4);
   assert(ker_shape.rank() == 4);

--- a/compiler/luci/service/src/Nodes/CircleConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConv2D.cpp
@@ -51,7 +51,7 @@ namespace sinf
 loco::TensorShape Algorithm::visit(const luci::CircleConv2D *node)
 {
   LOGGER(l);
-  
+
   auto ifm = loco::must_cast<luci::CircleNode *>(node->input());
   auto ifm_shape = circle_shape(ifm); // in NHWC
   auto ker = loco::must_cast<luci::CircleNode *>(node->filter());

--- a/compiler/luci/service/src/Nodes/CircleConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConv2D.cpp
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
+#include "HelperConv2Ds.h"
+#include "luci/Service/CircleShapeInference.h"
+
 #include "CircleCloneNode.h"
+#include "CircleShapeInferenceHelper.h"
+
+#include <luci/Log.h>
 
 namespace luci
 {
@@ -38,5 +44,38 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleConv2D *node)
   }
   return cloned;
 }
+
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleConv2D *node)
+{
+  LOGGER(l);
+
+  std::cout << "CircleConv2D ShapeInf" << std::endl;
+  
+  auto ifm_shape = luci::shape_get(node->input()).as<loco::TensorShape>();  // in NHWC
+  auto ker_shape = luci::shape_get(node->filter()).as<loco::TensorShape>(); // in OHWI
+
+  assert(ifm_shape.rank() == 4);
+  assert(ker_shape.rank() == 4);
+  assert(ifm_shape.dim(3) == ker_shape.dim(3));
+
+  loco::TensorShape ofm_shape = conv2d_output_shape(node);
+  // Height and width have already been determined by conv2d_output_shape
+  ofm_shape.dim(0) = ifm_shape.dim(0);
+  ofm_shape.dim(3) = ker_shape.dim(0);
+
+  INFO(l) << "[luci] CircleConv2D ShapeInf ifm(" << ifm_shape.rank() << ") ker(" << ker_shape.rank()
+          << ") output(" << ofm_shape.dim(0).value() << "," << ofm_shape.dim(1).value() << ","
+          << ofm_shape.dim(2).value() << "," << ofm_shape.dim(3).value() << ") " << node->name()
+          << std::endl;
+
+  std::cout << "CircleConv2D ShapeInf end" << std::endl;
+
+  return ofm_shape;
+}
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleConv2D.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConv2D.test.cpp
@@ -61,7 +61,6 @@ TEST(CloneNodeTest, clone_Conv2D_padding_NEG)
   ASSERT_EQ(nullptr, cloned);
 }
 
-
 TEST(ShapeRuleTest, Conv2D_sinf_dynamic)
 {
   luci::CircleInput ifm;
@@ -85,8 +84,7 @@ TEST(ShapeRuleTest, Conv2D_sinf_dynamic)
   loco::TensorShape shape;
   luci::sinf::Rule shape_inf_rule;
   shape_inf_rule.infer(&node_conv2d, shape);
-  
-  
+
   ASSERT_EQ(false, shape.dim(0).known());
   ASSERT_EQ(false, shape.dim(1).known());
   ASSERT_EQ(true, shape.dim(2).known());

--- a/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.cpp
@@ -54,7 +54,6 @@ loco::TensorShape Algorithm::visit(const luci::CircleDepthwiseConv2D *node)
   auto ker = loco::must_cast<luci::CircleNode *>(node->filter());
   auto ker_shape = circle_shape(ker); // in 1 H W CM
 
-
   assert(ifm_shape.rank() == 4);
   assert(ker_shape.rank() == 4);
   assert(ker_shape.dim(0).value() == 1);
@@ -64,7 +63,7 @@ loco::TensorShape Algorithm::visit(const luci::CircleDepthwiseConv2D *node)
   // Height and width have already been determined by conv2d_output_shape
   ofm_shape.dim(0) = ifm_shape.dim(0);
   ofm_shape.dim(3) = ker_shape.dim(3);
-  
+
   return ofm_shape;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.cpp
@@ -49,8 +49,11 @@ namespace sinf
 
 loco::TensorShape Algorithm::visit(const luci::CircleDepthwiseConv2D *node)
 {
-  auto ifm_shape = luci::shape_get(node->input()).as<loco::TensorShape>();  // in NHWC
-  auto ker_shape = luci::shape_get(node->filter()).as<loco::TensorShape>(); // in 1 H W CM
+  auto ifm = loco::must_cast<luci::CircleNode *>(node->input());
+  auto ifm_shape = circle_shape(ifm); // in NHWC
+  auto ker = loco::must_cast<luci::CircleNode *>(node->filter());
+  auto ker_shape = circle_shape(ker); // in 1 H W CM
+
 
   assert(ifm_shape.rank() == 4);
   assert(ker_shape.rank() == 4);

--- a/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.test.cpp
@@ -61,7 +61,6 @@ TEST(CloneNodeTest, clone_DepthwiseConv2D_padding_NEG)
   ASSERT_EQ(nullptr, cloned);
 }
 
-
 TEST(ShapeRuleTest, DepthwiseConv2D_sinf_dynamic)
 {
   luci::CircleInput ifm;
@@ -85,8 +84,7 @@ TEST(ShapeRuleTest, DepthwiseConv2D_sinf_dynamic)
   loco::TensorShape shape;
   luci::sinf::Rule shape_inf_rule;
   shape_inf_rule.infer(&node_dwconv2d, shape);
-  
-  
+
   ASSERT_EQ(false, shape.dim(0).known());
   ASSERT_EQ(true, shape.dim(1).known());
   ASSERT_EQ(true, shape.dim(2).known());


### PR DESCRIPTION
This supports dynamic shape inference for Conv2D and DepthwiseConv2D.

If the input feature map (ifm) has unknown dimensions, it forwards those unknown dimensions directly to the output shape.

related to : https://github.com/Samsung/ONE/issues/13697

I am planning to make some PRs for this changes. (Splitting into smaller changes..)

1. Migrate existing sinf rules (Conv2D, DepthwiseConv2D) to sinf::Algorithm
   - Separate the `infer_conv2d_type` function used in Conv2D and DepthwiseConv2D into the `HelperConv2Ds.h` header file.
2. Implement dynamic shape inference support for Conv2D
   - Add known states for height and width to the OutputSize struct.
   - Make `infer_conv2d_type` function can aware unknown dimensions.
4. Implement dynamic shape inference support for DepthwiseConv2D
   - Use known states that added in right before PR step.
5. (Optional) Refactor to make the `infer_conv2d_type` function returns a `loco::TensorShape` object
   - Return the object with only the inferred height and width set (in NHWC format).
   - Other dimensions will be returned as unknown.
   - This can remove redundant casting to get shape
6. (Optional too) Refactor to remove template from `infer_conv2d_type` function.
   - But this makes the `infer_conv2d_type` function has **5(!!)** arguments.
8. Add some tests related to Conv2D and DepthwiseConv2D
   - I am thinking hard about how to add NEG test to dynamic shape inference.

ONE-DCO-1.0-Signed-off-by: Chansu Park [1265pcs@gmail.com](mailto:1265pcs@gmail.com)