### PR TITLE
[onert] Apply updated quant name to schema header

### DIFF
--- a/runtime/onert/core/src/loader/CircleLoader.cc
+++ b/runtime/onert/core/src/loader/CircleLoader.cc
@@ -90,9 +90,9 @@ public:
 protected:
   ir::DataType tensorTypeToDataType(const TensorType type) override
   {
-    if (type == TensorType::TensorType_Q4_0)
+    if (type == TensorType::TensorType_GGML_Q4_0)
       return ir::DataType::QUANT_GGML_Q4_0;
-    if (type == TensorType::TensorType_Q8_0)
+    if (type == TensorType::TensorType_GGML_Q8_0)
       return ir::DataType::QUANT_GGML_Q8_0;
 
     return BaseLoader::tensorTypeToDataType(type);


### PR DESCRIPTION
This commit updates circle schema generated header to apply updated block quantization naming.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>