### PR TITLE
[onert] Change NNAPI library type

### DIFF
--- a/runtime/onert/api/nnapi/CMakeLists.txt
+++ b/runtime/onert/api/nnapi/CMakeLists.txt
@@ -2,18 +2,13 @@ file(GLOB_RECURSE SOURCES_FRONTEND "*.cc")
 file(GLOB_RECURSE TESTS_FRONTEND "*.test.cc")
 list(REMOVE_ITEM SOURCES_FRONTEND ${TESTS_FRONTEND})
 
-set(LIB_ONERT onert)
+set(LIB_NNAPI onert_nnapi)
 
-add_library(${LIB_ONERT} SHARED ${SOURCES_FRONTEND})
-target_include_directories(${LIB_ONERT} PUBLIC include)
-target_link_libraries(${LIB_ONERT} PUBLIC onert_core) # TODO Link PRIVATE onert_core
-target_link_libraries(${LIB_ONERT} PRIVATE nnfw_common)
-target_link_libraries(${LIB_ONERT} PRIVATE nnfw_coverage)
-
-set_target_properties(${LIB_ONERT} PROPERTIES OUTPUT_NAME neuralnetworks)
-set_target_properties(${LIB_ONERT} PROPERTIES INSTALL_RPATH "$ORIGIN:$ORIGIN/nnfw")
-
-install(TARGETS ${LIB_ONERT} DESTINATION lib)
+add_library(${LIB_NNAPI} STATIC ${SOURCES_FRONTEND})
+target_include_directories(${LIB_NNAPI} PUBLIC include)
+target_link_libraries(${LIB_NNAPI} PUBLIC onert_core) # TODO Link PRIVATE onert_core
+target_link_libraries(${LIB_NNAPI} PRIVATE nnfw_common)
+target_link_libraries(${LIB_NNAPI} PRIVATE nnfw_coverage)
 
 if(NOT ENABLE_TEST)
   return()
@@ -21,11 +16,10 @@ endif(NOT ENABLE_TEST)
 
 add_executable(test_onert_frontend_nnapi ${TESTS_FRONTEND})
 
-target_link_libraries(test_onert_frontend_nnapi PRIVATE ${LIB_ONERT} dl)
-target_link_libraries(test_onert_frontend_nnapi PRIVATE gtest)
-target_link_libraries(test_onert_frontend_nnapi PRIVATE gtest_main)
-# INSTALL_RPATH is for onert_core public link
-# TODO Remove INSTALL_RPATH
-set_target_properties(test_onert_frontend_nnapi PROPERTIES INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../lib/nnfw")
+target_link_libraries(test_onert_frontend_nnapi ${LIB_NNAPI} dl)
+target_link_libraries(test_onert_frontend_nnapi gtest)
+target_link_libraries(test_onert_frontend_nnapi gtest_main)
+# Set INSTALL_RPATH to find onert_core
+set_target_properties(test_onert_frontend_nnapi PROPERTIES INSTALL_RPATH "$ORIGIN/../lib/nnfw")
 
 install(TARGETS test_onert_frontend_nnapi DESTINATION unittest)

--- a/runtime/onert/api/nnapi/compilation.cc
+++ b/runtime/onert/api/nnapi/compilation.cc
@@ -104,3 +104,10 @@ int ANeuralNetworksCompilation_setPreference(ANeuralNetworksCompilation *compila
   // NYI: nothing to set
   return ANEURALNETWORKS_NO_ERROR;
 }
+
+int ANeuralNetworksCompilation_setCaching(ANeuralNetworksCompilation *, const char *,
+                                          const uint8_t *)
+{
+  VERBOSE(NNAPI::Compilation) << "setCaching: NYI" << std::endl;
+  return ANEURALNETWORKS_BAD_STATE;
+}

--- a/runtime/onert/api/nnapi/execution.cc
+++ b/runtime/onert/api/nnapi/execution.cc
@@ -502,3 +502,21 @@ int ANeuralNetworksExecution_getOutputOperandDimensions(ANeuralNetworksExecution
 
   return ANEURALNETWORKS_NO_ERROR;
 }
+
+int ANeuralNetworksBurst_create(ANeuralNetworksCompilation *, ANeuralNetworksBurst **)
+{
+  VERBOSE(NNAPI::Execution) << "BurstCreate: NYI" << std::endl;
+  return ANEURALNETWORKS_BAD_STATE;
+}
+
+void ANeuralNetworksBurst_free(ANeuralNetworksBurst *)
+{
+  // TODO delete burst
+  // delete burst;
+}
+
+int ANeuralNetworksExecution_burstCompute(ANeuralNetworksExecution *, ANeuralNetworksBurst *)
+{
+  VERBOSE(NNAPI::Execution) << "burstCompute: NYI" << std::endl;
+  return ANEURALNETWORKS_BAD_STATE;
+}

--- a/runtime/onert/api/nnapi/model.cc
+++ b/runtime/onert/api/nnapi/model.cc
@@ -174,6 +174,13 @@ int ANeuralNetworksModel_setOperandValue(ANeuralNetworksModel *model, int32_t in
   return ANEURALNETWORKS_NO_ERROR;
 }
 
+int ANeuralNetworksModel_setOperandSymmPerChannelQuantParams(
+  ANeuralNetworksModel *, int32_t, const ANeuralNetworksSymmPerChannelQuantParams *)
+{
+  VERBOSE(NNAPI::Model) << "setOperandSymmPerChannelQuantParams: NYI" << std::endl;
+  return ANEURALNETWORKS_BAD_STATE;
+}
+
 int ANeuralNetworksModel_setOperandValueFromMemory(ANeuralNetworksModel *model, int32_t index,
                                                    const ANeuralNetworksMemory *memory,
                                                    size_t offset, size_t length)

--- a/tests/nnapi/CMakeLists.txt
+++ b/tests/nnapi/CMakeLists.txt
@@ -49,9 +49,11 @@ target_include_directories(${RUNTIME_NNAPI_TEST} PRIVATE ${RUNTIME_NNAPI_TEST_SR
 # Define NNTEST_ONLY_PUBLIC_API to avoid android dependency
 target_compile_definitions(${RUNTIME_NNAPI_TEST} PRIVATE NNTEST_ONLY_PUBLIC_API)
 
-target_link_libraries(${RUNTIME_NNAPI_TEST} onert)
+target_link_libraries(${RUNTIME_NNAPI_TEST} onert_nnapi)
 target_link_libraries(${RUNTIME_NNAPI_TEST} gtest gmock)
 target_link_libraries(${RUNTIME_NNAPI_TEST} ${LIB_PTHREAD} dl)
+# Set INSTALL_RPATH to find onert_core
+set_target_properties(${RUNTIME_NNAPI_TEST} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib/nnfw")
 
 install(TARGETS ${RUNTIME_NNAPI_TEST} DESTINATION nnapi-gtest)
 

--- a/tests/nnapi/include/NeuralNetworksWrapper.h
+++ b/tests/nnapi/include/NeuralNetworksWrapper.h
@@ -21,10 +21,9 @@
 #define __NNFW_RT_NEURAL_NETWORKS_WRAPPER_H__
 
 // Fix for onert:
-//  NeuralNetworks.h => NeuralNetworksShim.h
-//  Additional include NeuralNetworksExShim.h
-#include "NeuralNetworksShim.h"
-#include "NeuralNetworksExShim.h"
+//  Additional include NeuralNetworksEx.h
+#include "NeuralNetworks.h"
+#include "NeuralNetworksEx.h"
 
 #include <math.h>
 #include <optional>


### PR DESCRIPTION
This commit changes NNAPI library to static and rename to 'onert-nnapi'.
It includes empty NNAPI function to resolve link error.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13816 