### PR TITLE
[infra/onert] Make flatbuffers library static explicitly

### DIFF
--- a/infra/nnfw/cmake/packages/FlatBuffers-23.5.26/FlatBuffersConfig.cmake
+++ b/infra/nnfw/cmake/packages/FlatBuffers-23.5.26/FlatBuffersConfig.cmake
@@ -27,7 +27,7 @@ function(_FlatBuffers_import)
     list(APPEND FlatBuffers_Library_SRCS "${FlatBuffersSource_DIR}/src/util.cpp")
 
     if(NOT TARGET flatbuffers::flatbuffers-23.5.26)
-      add_library(flatbuffers-23.5.26 ${FlatBuffers_Library_SRCS})
+      add_library(flatbuffers-23.5.26 STATIC ${FlatBuffers_Library_SRCS})
       target_include_directories(flatbuffers-23.5.26 PUBLIC "${FlatBuffersSource_DIR}/include")
       set_property(TARGET flatbuffers-23.5.26 PROPERTY POSITION_INDEPENDENT_CODE ON)
       target_compile_options(flatbuffers-23.5.26 PUBLIC $<$<CONFIG:Debug>:-Wno-sign-compare>)


### PR DESCRIPTION
This commit updates cmake script for flatbuffer library to make static library explicitly. 
It prevents build regression from sometimes building shared library.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>