### PR TITLE
[one-cmds] Add missing comma

### DIFF
--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -63,7 +63,7 @@ class CONSTANT:
         'remove_redundant_reshape',
         'remove_redundant_transpose',
         'remove_unnecessary_add',
-        'remove_unnecessary_cast'
+        'remove_unnecessary_cast',
         'remove_unnecessary_reshape',
         'remove_unnecessary_slice',
         'remove_unnecessary_strided_slice',


### PR DESCRIPTION
This commit adds missing comman in constant.py.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13965
