### PR TITLE
[luci/service] Support StridedSlice dynamic shape inference

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
+++ b/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
@@ -404,7 +404,7 @@ loco::TensorShape Algorithm::visit(const luci::CircleStridedSlice *node)
   // TODO support non-const strides_node
   if (strides_const == nullptr)
   {
-    INTERNAL_EXN("StridedSlice strides node are not Constant");
+    INTERNAL_EXN("StridedSlice strides node is not Constant");
   }
   if (begin_const == nullptr || end_const == nullptr)
   {

--- a/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
+++ b/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
@@ -386,14 +386,9 @@ loco::TensorShape Algorithm::visit(const luci::CircleStridedSlice *node)
 
   auto input_node = loco::must_cast<luci::CircleNode *>(node->input());
 
-  auto begin_node = dynamic_cast<luci::CircleConst *>(node->begin());
-  auto end_node = dynamic_cast<luci::CircleConst *>(node->end());
-  auto strides_node = dynamic_cast<luci::CircleConst *>(node->strides());
-  // TODO support non-const case
-  if (begin_node == nullptr || end_node == nullptr || strides_node == nullptr)
-  {
-    INTERNAL_EXN("StridedSlice begin/end/strides nodes are not Constant");
-  }
+  auto begin_node = loco::must_cast<luci::CircleNode *>(node->begin());
+  auto end_node = loco::must_cast<luci::CircleNode *>(node->end());
+  auto strides_node = loco::must_cast<luci::CircleNode *>(node->strides());
 
   LUCI_ASSERT(begin_node->dtype() == S32, "Only support S32 for begin_node");
   LUCI_ASSERT(end_node->dtype() == S32, "Only support S32 for end_node");
@@ -403,16 +398,33 @@ loco::TensorShape Algorithm::visit(const luci::CircleStridedSlice *node)
   LUCI_ASSERT(end_node->rank() == 1, "Only support rank 1 for end_node");
   LUCI_ASSERT(strides_node->rank() == 1, "Only support rank 1 for strides_node");
 
+  auto begin_const = dynamic_cast<luci::CircleConst *>(node->begin());
+  auto end_const = dynamic_cast<luci::CircleConst *>(node->end());
+  auto strides_const = dynamic_cast<luci::CircleConst *>(node->strides());
+  // TODO support non-const strides_node
+  if (strides_const == nullptr)
+  {
+    INTERNAL_EXN("StridedSlice strides node are not Constant");
+  }
+  // TODO Support cases where the mask attributes are non-zero.
+  if (begin_const == nullptr || end_const == nullptr)
+  {
+    // The dimensions of the output shape are all set to unknown.
+    output_shape.rank(input_node->rank());
+    return output_shape;
+  }
+
   loco::TensorShape input_shape = circle_shape(input_node);
 
-  assert(begin_node->size<S32>() <= input_shape.rank());
-  assert(end_node->size<S32>() <= input_shape.rank());
-  assert(strides_node->size<S32>() <= input_shape.rank());
+  assert(begin_const->size<S32>() <= input_shape.rank());
+  assert(end_const->size<S32>() <= input_shape.rank());
+  assert(strides_const->size<S32>() <= input_shape.rank());
 
   StridedSliceContext op_context(node);
   auto op_params = BuildStridedSliceParams(&op_context);
   auto &effective_input_shape = op_context.effective_input_shape;
   std::vector<int64_t> output_shape_vector;
+  std::vector<bool> output_known_vector;
 
   for (int32_t idx = effective_input_shape.rank() - 1; idx >= 0; --idx)
   {
@@ -438,6 +450,7 @@ loco::TensorShape Algorithm::visit(const luci::CircleStridedSlice *node)
     if (!shrink_axis)
     {
       output_shape_vector.push_back(dim_shape);
+      output_known_vector.push_back(effective_input_shape.dim(idx).known());
     }
   }
 
@@ -445,6 +458,9 @@ loco::TensorShape Algorithm::visit(const luci::CircleStridedSlice *node)
   output_shape.rank(shape_size);
   for (uint32_t idx = 0; idx < shape_size; ++idx)
   {
+    bool known = output_known_vector[shape_size - 1u - idx];
+    if (not known)
+      continue;
     int64_t dim = output_shape_vector.at(shape_size - 1u - idx);
     LUCI_ASSERT(0 <= dim && dim < 0xfffffffL, "Dimension size exceeds limit");
     // reverse copy

--- a/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
+++ b/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
@@ -406,7 +406,6 @@ loco::TensorShape Algorithm::visit(const luci::CircleStridedSlice *node)
   {
     INTERNAL_EXN("StridedSlice strides node are not Constant");
   }
-  // TODO Support cases where the mask attributes are non-zero.
   if (begin_const == nullptr || end_const == nullptr)
   {
     // The dimensions of the output shape are all set to unknown.

--- a/compiler/luci/service/src/Nodes/CircleStridedSlice.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleStridedSlice.test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "luci/Service/CircleNodeClone.h"
+#include "luci/Service/CircleShapeInference.h"
 
 #include <gtest/gtest.h>
 
@@ -40,4 +41,339 @@ TEST(CloneNodeTest, clone_StridedSlice)
   ASSERT_EQ(node_ss->ellipsis_mask(), cloned_ss->ellipsis_mask());
   ASSERT_EQ(node_ss->new_axis_mask(), cloned_ss->new_axis_mask());
   ASSERT_EQ(node_ss->shrink_axis_mask(), cloned_ss->shrink_axis_mask());
+}
+
+TEST(ShapeRuleTest, strided_slice_static_shape)
+{
+  luci::CircleInput input;
+  luci::CircleConst begin;
+  luci::CircleConst end;
+  luci::CircleConst strides;
+
+  luci::CircleStridedSlice strided_slice;
+
+  input.shape({5, 6, 7, 8});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  begin.dtype(loco::DataType::S32);
+  begin.shape({4});
+  begin.size<loco::DataType::S32>(4);
+  begin.at<loco::DataType::S32>(0) = 0;
+  begin.at<loco::DataType::S32>(1) = 0;
+  begin.at<loco::DataType::S32>(2) = 0;
+  begin.at<loco::DataType::S32>(3) = 0;
+  begin.shape_status(luci::ShapeStatus::VALID);
+
+  end.dtype(loco::DataType::S32);
+  end.shape({4});
+  end.size<loco::DataType::S32>(4);
+  end.at<loco::DataType::S32>(0) = 1;
+  end.at<loco::DataType::S32>(1) = 3;
+  end.at<loco::DataType::S32>(2) = 5;
+  end.at<loco::DataType::S32>(3) = 7;
+  end.shape_status(luci::ShapeStatus::VALID);
+
+  strides.dtype(loco::DataType::S32);
+  strides.shape({4});
+  strides.size<loco::DataType::S32>(4);
+  strides.at<loco::DataType::S32>(0) = 1;
+  strides.at<loco::DataType::S32>(1) = 1;
+  strides.at<loco::DataType::S32>(2) = 1;
+  strides.at<loco::DataType::S32>(3) = 1;
+  strides.shape_status(luci::ShapeStatus::VALID);
+
+  strided_slice.input(&input);
+  strided_slice.begin(&begin);
+  strided_slice.end(&end);
+  strided_slice.strides(&strides);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&strided_slice, shape));
+  ASSERT_EQ(4, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_TRUE(shape.dim(2).known());
+  ASSERT_TRUE(shape.dim(3).known());
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(3, shape.dim(1).value());
+  ASSERT_EQ(5, shape.dim(2).value());
+  ASSERT_EQ(7, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, strided_slice_non_const_begin_end)
+{
+  luci::CircleInput input;
+  luci::CircleInput begin;
+  luci::CircleInput end;
+  luci::CircleConst strides;
+
+  luci::CircleStridedSlice strided_slice;
+
+  input.shape({5, 6, 7, 8});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  begin.dtype(loco::DataType::S32);
+  begin.shape({4});
+  begin.shape_status(luci::ShapeStatus::VALID);
+
+  end.dtype(loco::DataType::S32);
+  end.shape({4});
+  end.shape_status(luci::ShapeStatus::VALID);
+  end.dim(0).unset();
+
+  strides.dtype(loco::DataType::S32);
+  strides.shape({4});
+  strides.size<loco::DataType::S32>(4);
+  strides.at<loco::DataType::S32>(0) = 1;
+  strides.at<loco::DataType::S32>(1) = 1;
+  strides.at<loco::DataType::S32>(2) = 1;
+  strides.at<loco::DataType::S32>(3) = 1;
+  strides.shape_status(luci::ShapeStatus::VALID);
+
+  strided_slice.input(&input);
+  strided_slice.begin(&begin);
+  strided_slice.end(&end);
+  strided_slice.strides(&strides);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&strided_slice, shape));
+  ASSERT_EQ(4, shape.rank());
+  ASSERT_FALSE(shape.dim(0).known());
+  ASSERT_FALSE(shape.dim(1).known());
+  ASSERT_FALSE(shape.dim(2).known());
+  ASSERT_FALSE(shape.dim(3).known());
+  ASSERT_EQ(0, shape.dim(0).value());
+  ASSERT_EQ(0, shape.dim(1).value());
+  ASSERT_EQ(0, shape.dim(2).value());
+  ASSERT_EQ(0, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, strided_slice_dynamic_input)
+{
+  luci::CircleInput input;
+  luci::CircleConst begin;
+  luci::CircleConst end;
+  luci::CircleConst strides;
+
+  luci::CircleStridedSlice strided_slice;
+
+  input.shape({5, 6, 7, 8});
+  input.shape_status(luci::ShapeStatus::VALID);
+  input.dim(2).unset();
+
+  begin.dtype(loco::DataType::S32);
+  begin.shape({4});
+  begin.size<loco::DataType::S32>(4);
+  begin.at<loco::DataType::S32>(0) = 0;
+  begin.at<loco::DataType::S32>(1) = 0;
+  begin.at<loco::DataType::S32>(2) = 0;
+  begin.at<loco::DataType::S32>(3) = 0;
+  begin.shape_status(luci::ShapeStatus::VALID);
+
+  end.dtype(loco::DataType::S32);
+  end.shape({4});
+  end.size<loco::DataType::S32>(4);
+  end.at<loco::DataType::S32>(0) = 1;
+  end.at<loco::DataType::S32>(1) = 3;
+  end.at<loco::DataType::S32>(2) = 5;
+  end.at<loco::DataType::S32>(3) = 7;
+  end.shape_status(luci::ShapeStatus::VALID);
+
+  strides.dtype(loco::DataType::S32);
+  strides.shape({4});
+  strides.size<loco::DataType::S32>(4);
+  strides.at<loco::DataType::S32>(0) = 1;
+  strides.at<loco::DataType::S32>(1) = 1;
+  strides.at<loco::DataType::S32>(2) = 1;
+  strides.at<loco::DataType::S32>(3) = 1;
+  strides.shape_status(luci::ShapeStatus::VALID);
+
+  strided_slice.input(&input);
+  strided_slice.begin(&begin);
+  strided_slice.end(&end);
+  strided_slice.strides(&strides);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&strided_slice, shape));
+  ASSERT_EQ(4, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_TRUE(shape.dim(1).known());
+  ASSERT_FALSE(shape.dim(2).known());
+  ASSERT_TRUE(shape.dim(3).known());
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(3, shape.dim(1).value());
+  ASSERT_EQ(0, shape.dim(2).value());
+  ASSERT_EQ(7, shape.dim(3).value());
+}
+
+TEST(ShapeRuleTest, strided_slice_nullptr_input_NEG)
+{
+  luci::CircleConst begin;
+  luci::CircleConst end;
+  luci::CircleConst strides;
+
+  luci::CircleStridedSlice strided_slice;
+
+  begin.dtype(loco::DataType::S32);
+  begin.shape({4});
+  begin.size<loco::DataType::S32>(4);
+  begin.at<loco::DataType::S32>(0) = 0;
+  begin.at<loco::DataType::S32>(1) = 0;
+  begin.at<loco::DataType::S32>(2) = 0;
+  begin.at<loco::DataType::S32>(3) = 0;
+  begin.shape_status(luci::ShapeStatus::VALID);
+
+  end.dtype(loco::DataType::S32);
+  end.shape({4});
+  end.size<loco::DataType::S32>(4);
+  end.at<loco::DataType::S32>(0) = 1;
+  end.at<loco::DataType::S32>(1) = 3;
+  end.at<loco::DataType::S32>(2) = 5;
+  end.at<loco::DataType::S32>(3) = 0;
+  end.shape_status(luci::ShapeStatus::VALID);
+
+  strides.dtype(loco::DataType::S32);
+  strides.shape({4});
+  strides.size<loco::DataType::S32>(4);
+  strides.at<loco::DataType::S32>(0) = 1;
+  strides.at<loco::DataType::S32>(1) = 1;
+  strides.at<loco::DataType::S32>(2) = 1;
+  strides.at<loco::DataType::S32>(3) = 1;
+  strides.shape_status(luci::ShapeStatus::VALID);
+
+  strided_slice.input(nullptr);
+  strided_slice.begin(&begin);
+  strided_slice.end(&end);
+  strided_slice.strides(&strides);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&strided_slice, shape));
+}
+
+TEST(ShapeRuleTest, strided_slice_nullptr_begin_NEG)
+{
+  luci::CircleInput input;
+  luci::CircleConst end;
+  luci::CircleConst strides;
+
+  luci::CircleStridedSlice strided_slice;
+
+  input.shape({5, 6, 7, 8});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  end.dtype(loco::DataType::S32);
+  end.shape({4});
+  end.size<loco::DataType::S32>(4);
+  end.at<loco::DataType::S32>(0) = 1;
+  end.at<loco::DataType::S32>(1) = 3;
+  end.at<loco::DataType::S32>(2) = 5;
+  end.at<loco::DataType::S32>(3) = 0;
+  end.shape_status(luci::ShapeStatus::VALID);
+
+  strides.dtype(loco::DataType::S32);
+  strides.shape({4});
+  strides.size<loco::DataType::S32>(4);
+  strides.at<loco::DataType::S32>(0) = 1;
+  strides.at<loco::DataType::S32>(1) = 1;
+  strides.at<loco::DataType::S32>(2) = 1;
+  strides.at<loco::DataType::S32>(3) = 1;
+  strides.shape_status(luci::ShapeStatus::VALID);
+
+  strided_slice.input(&input);
+  strided_slice.begin(nullptr);
+  strided_slice.end(&end);
+  strided_slice.strides(&strides);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&strided_slice, shape));
+}
+
+TEST(ShapeRuleTest, strided_slice_nullptr_end_NEG)
+{
+  luci::CircleInput input;
+  luci::CircleConst begin;
+  luci::CircleConst strides;
+
+  luci::CircleStridedSlice strided_slice;
+
+  input.shape({5, 6, 7, 8});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  begin.dtype(loco::DataType::S32);
+  begin.shape({4});
+  begin.size<loco::DataType::S32>(4);
+  begin.at<loco::DataType::S32>(0) = 0;
+  begin.at<loco::DataType::S32>(1) = 0;
+  begin.at<loco::DataType::S32>(2) = 0;
+  begin.at<loco::DataType::S32>(3) = 0;
+  begin.shape_status(luci::ShapeStatus::VALID);
+
+  strides.dtype(loco::DataType::S32);
+  strides.shape({4});
+  strides.size<loco::DataType::S32>(4);
+  strides.at<loco::DataType::S32>(0) = 1;
+  strides.at<loco::DataType::S32>(1) = 1;
+  strides.at<loco::DataType::S32>(2) = 1;
+  strides.at<loco::DataType::S32>(3) = 1;
+  strides.shape_status(luci::ShapeStatus::VALID);
+
+  strided_slice.input(&input);
+  strided_slice.begin(&begin);
+  strided_slice.end(nullptr);
+  strided_slice.strides(&strides);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&strided_slice, shape));
+}
+
+TEST(ShapeRuleTest, strided_slice_nullptr_strides_NEG)
+{
+  luci::CircleInput input;
+  luci::CircleConst begin;
+  luci::CircleConst end;
+
+  luci::CircleStridedSlice strided_slice;
+
+  input.shape({5, 6, 7, 8});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  begin.dtype(loco::DataType::S32);
+  begin.shape({4});
+  begin.size<loco::DataType::S32>(4);
+  begin.at<loco::DataType::S32>(0) = 0;
+  begin.at<loco::DataType::S32>(1) = 0;
+  begin.at<loco::DataType::S32>(2) = 0;
+  begin.at<loco::DataType::S32>(3) = 0;
+  begin.shape_status(luci::ShapeStatus::VALID);
+
+  end.dtype(loco::DataType::S32);
+  end.shape({4});
+  end.size<loco::DataType::S32>(4);
+  end.at<loco::DataType::S32>(0) = 1;
+  end.at<loco::DataType::S32>(1) = 3;
+  end.at<loco::DataType::S32>(2) = 5;
+  end.at<loco::DataType::S32>(3) = 0;
+  end.shape_status(luci::ShapeStatus::VALID);
+
+  strided_slice.input(&input);
+  strided_slice.begin(&begin);
+  strided_slice.end(&end);
+  strided_slice.strides(nullptr);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&strided_slice, shape));
 }


### PR DESCRIPTION
This supports dynamic shape inference for StridedSlice op,
in case where the input node is dynamic or the begin/end nodes are not const.

ONE-DCO-1.0-Signed-off-by: sunki <ajsthfldu@outlook.com>