### PR TITLE
[cker] Fix computing CCE Gradient

### DIFF
--- a/compute/cker/include/cker/eigen/xent_op.h
+++ b/compute/cker/include/cker/eigen/xent_op.h
@@ -49,7 +49,7 @@ template <typename Device, typename T> struct XentFunctor
                   const Eigen::array<Eigen::DenseIndex, 2> &labels_bcast,
                   typename TTypes<T>::ConstMatrix logits, typename TTypes<T>::ConstMatrix labels,
                   typename TTypes<T>::Matrix scratch, typename TTypes<T>::Vec loss,
-                  typename TTypes<T>::Matrix backprop);
+                  typename TTypes<T>::Matrix backprop, T reduction_size);
 };
 
 } // namespace functor
@@ -80,7 +80,7 @@ template <typename Device, typename T> struct XentFunctorBase
                   const Eigen::array<Eigen::DenseIndex, 2> &labels_bcast,
                   typename TTypes<T>::ConstMatrix logits, typename TTypes<T>::ConstMatrix labels,
                   typename TTypes<T>::Matrix scratch, typename TTypes<T>::Vec loss,
-                  typename TTypes<T>::Matrix backprop)
+                  typename TTypes<T>::Matrix backprop, T reduction_size)
   {
     T *scratch_ptr = scratch.data();
     T *backprop_ptr = backprop.data();
@@ -124,7 +124,7 @@ template <typename Device, typename T> struct XentFunctorBase
           for (int j = 0; j < row_size; j++)
           {
             loss_sum += this_labels[j] * (log_sum - this_backprop[j]);
-            this_backprop[j] = (exp(this_backprop[j]) / sum) - this_labels[j];
+            this_backprop[j] = ((exp(this_backprop[j]) / sum) - this_labels[j]) / reduction_size;
           }
           loss_ptr[i] = loss_sum;
         }

--- a/runtime/onert/backend/train/ops/LossCategoricalCrossentropyLayer.cc
+++ b/runtime/onert/backend/train/ops/LossCategoricalCrossentropyLayer.cc
@@ -59,11 +59,12 @@ void LossCategoricalCrossentropyLayer::backward()
 {
   assert(_back_prop_y_pred != nullptr);
 
+  const auto reduction_type = convertLossReductionType(_reduction_type);
   if (_y_pred->data_type() == OperandType::FLOAT32)
   {
     nnfw::cker::train::CategoricalCrossEntropyGrad(
       getShape(_y_pred), getBuffer<float>(_y_pred), getShape(_y_true), getBuffer<float>(_y_true),
-      getShape(_back_prop_y_pred), getBuffer<float>(_back_prop_y_pred));
+      getShape(_back_prop_y_pred), getBuffer<float>(_back_prop_y_pred), reduction_type);
   }
   else
   {


### PR DESCRIPTION
This commit fixes computing CCE Gradients.
  - SUM_OVER_BATCH_SIZE : computes CCE gradients with sum over batch size
  - SUM : computes CCE gradients with sum for each batch as it is before

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>