### PR TITLE
[onert] Add registerLayerScopeTensors to ITrainableFuntion

### DIFF
--- a/runtime/onert/core/include/backend/train/LayerScopeTensor.h
+++ b/runtime/onert/core/include/backend/train/LayerScopeTensor.h
@@ -58,6 +58,8 @@ private:
   LayerScopeTensorLifeTime _lifetime;
 };
 
+using LayerScopeTensors = std::vector<std::shared_ptr<LayerScopeTensor>>;
+
 } // namespace train
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/include/exec/train/ITrainableFunction.h
+++ b/runtime/onert/core/include/exec/train/ITrainableFunction.h
@@ -18,6 +18,9 @@
 #define __ONERT_EXEC_TRAIN_I_TRAINABLE_FUNCTION_H__
 
 #include <cstdint>
+#include <optional>
+
+#include "backend/train/LayerScopeTensor.h"
 
 namespace onert
 {
@@ -32,6 +35,12 @@ public:
   virtual ~ITrainableFunction() = default;
   virtual void forward(bool training) = 0;
   virtual void backward() = 0;
+
+  // Implement this if LayerScopeTensors is necessary
+  virtual std::optional<backend::train::LayerScopeTensors> registerLayerScopeTensors()
+  {
+    return std::nullopt;
+  }
 };
 
 } // namespace train


### PR DESCRIPTION
This PR adds registerLayerScopeTensors to ITrainableFunction. 'registerLayerScopeTensors` is to register LayerScopeTensor into TensorReigstry.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>
draft : https://github.com/Samsung/ONE/pull/13486
for : https://github.com/Samsung/ONE/issues/13282