### PR TITLE
Draft: [luci/service] support shape inference for non-const param of Range 

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -112,7 +112,7 @@ public:
   // loco::TensorShape visit(const luci::CirclePow *node) final;
   // loco::TensorShape visit(const luci::CirclePRelu *node) final;
   loco::TensorShape visit(const luci::CircleQuantize *node) final;
-  // loco::TensorShape visit(const luci::CircleRange *node) final;
+  loco::TensorShape visit(const luci::CircleRange *node) final;
   // loco::TensorShape visit(const luci::CircleRank *node) final;
   // loco::TensorShape visit(const luci::CircleReduceAny *node) final;
   // loco::TensorShape visit(const luci::CircleReduceMax *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -953,49 +953,6 @@ loco::NodeShape infer_p_relu(const luci::CirclePRelu *node)
   return loco::NodeShape{output_shape};
 }
 
-loco::NodeShape infer_range(const luci::CircleRange *node)
-{
-  loco::TensorShape output_shape;
-  output_shape.rank(1);
-
-  auto start_node = dynamic_cast<luci::CircleConst *>(node->start());
-  auto limit_node = dynamic_cast<luci::CircleConst *>(node->limit());
-  auto delta_node = dynamic_cast<luci::CircleConst *>(node->delta());
-
-  if (start_node == nullptr || limit_node == nullptr || delta_node == nullptr)
-  {
-    return use_own(node);
-  }
-
-  double start = 0, limit = 0, delta = 0;
-
-#define GET_RANGE_PARAM(DT)         \
-  start = start_node->scalar<DT>(); \
-  limit = limit_node->scalar<DT>(); \
-  delta = delta_node->scalar<DT>();
-
-  switch (start_node->dtype())
-  {
-    case loco::DataType::FLOAT32:
-      GET_RANGE_PARAM(loco::DataType::FLOAT32)
-      break;
-    case loco::DataType::S32:
-      GET_RANGE_PARAM(loco::DataType::S32)
-      break;
-    default:
-      INTERNAL_EXN("Range data type not supported");
-  }
-
-#undef GET_RANGE_PARAM
-
-  if (delta == 0)
-    INTERNAL_EXN("Delta can not be zero");
-
-  output_shape.dim(0) = ceil((limit - start) / delta);
-
-  return loco::NodeShape{output_shape};
-}
-
 loco::NodeShape infer_reshape(const luci::CircleReshape *node)
 {
   LOGGER(l);
@@ -2167,8 +2124,6 @@ public:
   loco::NodeShape visit(const luci::CirclePow *node) final { return broadcast_xy(node); }
 
   loco::NodeShape visit(const luci::CirclePRelu *node) final { return infer_p_relu(node); }
-
-  loco::NodeShape visit(const luci::CircleRange *node) final { return infer_range(node); }
 
   loco::NodeShape visit(const luci::CircleRank *) final
   {

--- a/compiler/luci/service/src/Nodes/CircleRange.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRange.cpp
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
+#include "luci/Service/CircleShapeInference.h"
+
 #include "CircleCloneNode.h"
+#include "CircleShapeInferenceHelper.h"
+
+#include <cmath>
 
 namespace luci
 {
@@ -23,5 +28,53 @@ luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleRange *)
 {
   return _graph->nodes()->create<luci::CircleRange>();
 }
+
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleRange *node)
+{
+  loco::TensorShape output_shape;
+  output_shape.rank(1);
+
+  auto start_node = dynamic_cast<luci::CircleConst *>(node->start());
+  auto limit_node = dynamic_cast<luci::CircleConst *>(node->limit());
+  auto delta_node = dynamic_cast<luci::CircleConst *>(node->delta());
+
+  if (start_node == nullptr || limit_node == nullptr || delta_node == nullptr)
+  {
+    return output_shape;
+  }
+
+  double start = 0, limit = 0, delta = 0;
+
+#define GET_RANGE_PARAM(DT)         \
+  start = start_node->scalar<DT>(); \
+  limit = limit_node->scalar<DT>(); \
+  delta = delta_node->scalar<DT>();
+
+  switch (start_node->dtype())
+  {
+    case loco::DataType::FLOAT32:
+      GET_RANGE_PARAM(loco::DataType::FLOAT32)
+      break;
+    case loco::DataType::S32:
+      GET_RANGE_PARAM(loco::DataType::S32)
+      break;
+    default:
+      INTERNAL_EXN("Range data type not supported");
+  }
+
+#undef GET_RANGE_PARAM
+
+  if (delta == 0)
+    INTERNAL_EXN("Delta can not be zero");
+
+  output_shape.dim(0) = ceil((limit - start) / delta);
+
+  return output_shape;
+}
+
+} // namespace sinf
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleRange.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRange.test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "luci/Service/CircleNodeClone.h"
+#include "luci/Service/CircleShapeInference.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,111 @@ TEST(CloneNodeTest, clone_Range)
 
   auto cloned_range = dynamic_cast<luci::CircleRange *>(cloned);
   ASSERT_NE(nullptr, cloned_range);
+}
+
+TEST(ShapeRuleTest, range_const_param)
+{
+  luci::CircleConst start, limit, delta;
+  luci::CircleRange range;
+
+  start.dtype(loco::DataType::S32);
+  start.size<loco::DataType::S32>(1);
+  start.at<loco::DataType::S32>(0) = 0;
+  start.shape_status(luci::ShapeStatus::VALID);
+
+  limit.dtype(loco::DataType::S32);
+  limit.size<loco::DataType::S32>(1);
+  limit.at<loco::DataType::S32>(0) = 10;
+  limit.shape_status(luci::ShapeStatus::VALID);
+
+  delta.dtype(loco::DataType::S32);
+  delta.size<loco::DataType::S32>(1);
+  delta.at<loco::DataType::S32>(0) = 2;
+  delta.shape_status(luci::ShapeStatus::VALID);
+
+  range.start(&start);
+  range.limit(&limit);
+  range.delta(&delta);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&range, shape));
+  ASSERT_EQ(1, shape.rank());
+  ASSERT_TRUE(shape.dim(0).known());
+  ASSERT_EQ(5, shape.dim(0).value());
+}
+
+TEST(ShapeRuleTest, range_zero_delta_NEG)
+{
+  luci::CircleConst start, limit, delta;
+  luci::CircleRange range;
+
+  start.dtype(loco::DataType::S32);
+  start.size<loco::DataType::S32>(1);
+  start.at<loco::DataType::S32>(0) = 0;
+  start.shape_status(luci::ShapeStatus::VALID);
+
+  limit.dtype(loco::DataType::S32);
+  limit.size<loco::DataType::S32>(1);
+  limit.at<loco::DataType::S32>(0) = 10;
+  limit.shape_status(luci::ShapeStatus::VALID);
+
+  delta.dtype(loco::DataType::S32);
+  delta.size<loco::DataType::S32>(1);
+  delta.at<loco::DataType::S32>(0) = 0;
+  delta.shape_status(luci::ShapeStatus::VALID);
+
+  range.start(&start);
+  range.limit(&limit);
+  range.delta(&delta);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&range, shape));
+}
+
+TEST(ShapeRuleTest, range_non_const_param)
+{
+  luci::CircleInput start, limit, delta;
+  luci::CircleRange range;
+
+  start.dtype(loco::DataType::S32);
+  start.shape({1});
+  start.shape_status(luci::ShapeStatus::VALID);
+
+  limit.dtype(loco::DataType::S32);
+  limit.shape({1});
+  limit.shape_status(luci::ShapeStatus::VALID);
+
+  delta.dtype(loco::DataType::S32);
+  delta.shape({1});
+  delta.shape_status(luci::ShapeStatus::VALID);
+
+  range.start(&start);
+  range.limit(&limit);
+  range.delta(&delta);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&range, shape));
+  ASSERT_EQ(1, shape.rank());
+  ASSERT_FALSE(shape.dim(0).known());
+  ASSERT_EQ(0, shape.dim(0).value());
+}
+
+TEST(ShapeRuleTest, range_nullptr_input_NEG)
+{
+  luci::CircleRange range;
+
+  range.start(nullptr);
+  range.limit(nullptr);
+  range.delta(nullptr);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(&range, shape));
 }

--- a/compiler/luci/service/src/Nodes/CircleRange.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRange.test.cpp
@@ -126,13 +126,22 @@ TEST(ShapeRuleTest, range_non_const_param)
   ASSERT_EQ(0, shape.dim(0).value());
 }
 
-TEST(ShapeRuleTest, range_nullptr_input_NEG)
+TEST(ShapeRuleTest, range_nullptr_start_NEG)
 {
+  luci::CircleInput limit, delta;
   luci::CircleRange range;
 
+  limit.dtype(loco::DataType::S32);
+  limit.shape({1});
+  limit.shape_status(luci::ShapeStatus::VALID);
+
+  delta.dtype(loco::DataType::S32);
+  delta.shape({1});
+  delta.shape_status(luci::ShapeStatus::VALID);
+
   range.start(nullptr);
-  range.limit(nullptr);
-  range.delta(nullptr);
+  range.limit(&limit);
+  range.delta(&delta);
 
   loco::TensorShape shape;
   luci::sinf::Rule shape_inf_rule;


### PR DESCRIPTION
This supports shape inference for non-constant parameters of Range. 
In cases where the parameters (start, limit, or delta) are non-constant values, the output will have a dynamic shape, represented as '?'

ONE-DCO-1.0-Signed-off-by: bokyeong lee <[kyeong8139@gmail.com](mailto:kyeong8139@gmail.com)>