### PR TITLE
[fme-detect] Revise the way it finds patterns

### DIFF
--- a/compiler/fme-detect/src/EqualizePatternFinder.cpp
+++ b/compiler/fme-detect/src/EqualizePatternFinder.cpp
@@ -117,6 +117,27 @@ struct GetFusability final : public luci::CircleNodeMutableVisitor<Fusability>
     }
     return f;
   }
+
+  Fusability visit(luci::CircleFullyConnected *node)
+  {
+    Fusability f;
+    {
+      f.pre_scale = true;
+      if (node->fusedActivationFunction() == luci::FusedActFunc::NONE)
+      {
+        f.post_scale = true;
+        f.post_shift = true;
+      }
+      // Negative scale is not fusable across ReLU, but fme-detect does not
+      // know the scale value. So, we assume that the scale is positive.
+      // NOTE If a pattern has negative scales, fm-equalize rejects the pattern
+      else if (node->fusedActivationFunction() == luci::FusedActFunc::RELU)
+      {
+        f.post_scale = true;
+      }
+    }
+    return f;
+  }
 };
 
 Fusability fusability(luci::CircleNode *node)
@@ -135,6 +156,7 @@ struct Forwardable
 };
 
 // Return Forwardable of node
+// Note that the degree of effect may vary from layer to layer.
 Forwardable forwardable(luci::CircleNode *node)
 {
   if (node == nullptr)
@@ -145,10 +167,13 @@ Forwardable forwardable(luci::CircleNode *node)
     case luci::CircleOpcode::PAD:
       return {true, false};
     case luci::CircleOpcode::MAX_POOL_2D:
-      // Assumption: all scale values are positive.
       return {true, true};
-    case luci::CircleOpcode::SLICE:
-      return {true, true};
+    case luci::CircleOpcode::RELU:
+      return {true, false};
+    case luci::CircleOpcode::LEAKY_RELU:
+      return {true, false};
+    case luci::CircleOpcode::GELU:
+      return {true, false};
     default:
       return {false, false};
   }
@@ -168,13 +193,13 @@ void match(luci::CircleNode *front, std::vector<EqualizePattern> &res)
     auto back = loco::must_cast<luci::CircleNode *>(succ);
     auto back_fusability = fusability(back);
 
-    // If 'back' is not fusable with PreScale/Shift, we check if PreScale/Shift
+    // If 'back' is not fusable with PreScale, we check if PreScale
     // can forward across 'back'
     // TODO Generalize this code to support multiple forwardable Ops
-    if ((not back_fusability.pre_scale) and (not back_fusability.pre_shift))
+    if (not back_fusability.pre_scale)
     {
       auto f = forwardable(back);
-      if (f.scale_forwardable or f.shift_forwardable)
+      if (f.scale_forwardable)
       {
         auto succ_succs = loco::succs(back);
         // Only support single successor for simplicity
@@ -184,10 +209,17 @@ void match(luci::CircleNode *front, std::vector<EqualizePattern> &res)
         auto next_back = loco::must_cast<luci::CircleNode *>(next_succ);
         back_fusability = fusability(next_back);
         back_fusability.pre_scale &= f.scale_forwardable;
-        back_fusability.pre_shift &= f.shift_forwardable;
+        back = next_back;
       }
     }
 
+    if (front_fusability.post_scale and back_fusability.pre_scale)
+    {
+      res.emplace_back(front->name(), back->name(), EqualizePattern::Type::ScaleOnly);
+    }
+
+    // TODO Let's consider "shift" when it is necessary.
+#if 0
     // Create EqualizePattern based on fusability
     // ScaleShift
     //   front: fusable_post_shift and fusable_post_scale
@@ -211,6 +243,7 @@ void match(luci::CircleNode *front, std::vector<EqualizePattern> &res)
     {
       res.emplace_back(front->name(), back->name(), EqualizePattern::Type::ScaleOnly);
     }
+#endif
   }
 }
 

--- a/compiler/fme-detect/src/EqualizePatternFinder.test.cpp
+++ b/compiler/fme-detect/src/EqualizePatternFinder.test.cpp
@@ -447,7 +447,7 @@ TEST(EqualizePatternFinderTest, conv_pad_conv)
 
   EXPECT_EQ(1, res.size());
   EXPECT_EQ("conv1", res[0].front);
-  EXPECT_EQ("pad", res[0].back);
+  EXPECT_EQ("conv2", res[0].back);
   EXPECT_EQ(EqualizePattern::Type::ScaleOnly, res[0].type);
 }
 
@@ -483,7 +483,7 @@ TEST(EqualizePatternFinderTest, conv_maxpool_conv)
 
   EXPECT_EQ(1, res.size());
   EXPECT_EQ("conv1", res[0].front);
-  EXPECT_EQ("maxpool", res[0].back);
+  EXPECT_EQ("conv2", res[0].back);
   EXPECT_EQ(EqualizePattern::Type::ScaleOnly, res[0].type);
 }
 
@@ -503,7 +503,7 @@ TEST(EqualizePatternFinderTest, conv_relu_pad_conv)
 
   EXPECT_EQ(1, res.size());
   EXPECT_EQ("conv1", res[0].front);
-  EXPECT_EQ("pad", res[0].back);
+  EXPECT_EQ("conv2", res[0].back);
   EXPECT_EQ(EqualizePattern::Type::ScaleOnly, res[0].type);
 }
 
@@ -541,25 +541,6 @@ TEST(EqualizePatternFinderTest, conv_tanh_pad_conv_NEG)
   EXPECT_EQ(0, res.size());
 }
 
-TEST(EqualizePatternFinderTest, tconv_slice_instnorm)
-{
-  EqualizePatternFinder::Context ctx;
-  {
-    ctx._allow_dup_op = true;
-  }
-  EqualizePatternFinder epf(ctx);
-
-  TConvSliceInstnormGraph g;
-  g.init();
-
-  auto res = epf.find(g.g());
-
-  EXPECT_EQ(1, res.size());
-  EXPECT_EQ("tconv", res[0].front);
-  EXPECT_EQ("slice", res[0].back);
-  EXPECT_EQ(EqualizePattern::Type::ShiftOnly, res[0].type);
-}
-
 TEST(EqualizePatternFinderTest, tconv_slice_NEG)
 {
   EqualizePatternFinder::Context ctx;
@@ -575,28 +556,6 @@ TEST(EqualizePatternFinderTest, tconv_slice_NEG)
   auto res = epf.find(g.g());
 
   EXPECT_EQ(0, res.size());
-}
-
-TEST(EqualizePatternFinderTest, dup_op)
-{
-  EqualizePatternFinder::Context ctx;
-  {
-    ctx._allow_dup_op = true;
-  }
-  EqualizePatternFinder epf(ctx);
-
-  ConvConvINGraph g;
-  g.init();
-
-  auto res = epf.find(g.g());
-
-  EXPECT_EQ(2, res.size());
-  EXPECT_EQ("conv1", res[0].front);
-  EXPECT_EQ("instnorm", res[0].back);
-  EXPECT_EQ(EqualizePattern::Type::ShiftOnly, res[0].type);
-  EXPECT_EQ("conv1", res[1].front);
-  EXPECT_EQ("conv2", res[1].back);
-  EXPECT_EQ(EqualizePattern::Type::ScaleOnly, res[1].type);
 }
 
 TEST(EqualizePatternFinderTest, dup_op_NEG)


### PR DESCRIPTION
This commit revises the way it finds equalize patterns.

1. Add more ops for fusubility.
2. Remove "shift" related logic.
3. Pattern's front and back are written without forwarded ops. 

Draft: #13659
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>