### PR TITLE
[nnpackage,res] Add RmsNorm op to circle schema

### DIFF
--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -286,6 +286,7 @@ table Tensor {
 // set of acceptable options.
 // LINT.IfChange
 enum BuiltinOperator : int32 {
+  RMS_NORM = -6,
   GRU = -5,
   BCQ_GATHER = -4,
   BCQ_FULLY_CONNECTED = -3,
@@ -635,6 +636,7 @@ union BuiltinOptions {
   BitcastOptions,
   BitwiseXorOptions,
   RightShiftOptions,
+  RmsNormOptions = 250,
   GRUOptions = 251,
   BCQGatherOptions = 252,
   BCQFullyConnectedOptions = 253,
@@ -1515,6 +1517,11 @@ table BCQFullyConnectedOptions {
 }
 
 table InstanceNormOptions {
+  epsilon:float;
+  fused_activation_function:ActivationFunctionType;
+}
+
+table RmsNormOptions {
   epsilon:float;
   fused_activation_function:ActivationFunctionType;
 }

--- a/res/CircleSchema/0.9/circle_schema.fbs
+++ b/res/CircleSchema/0.9/circle_schema.fbs
@@ -286,6 +286,7 @@ table Tensor {
 // set of acceptable options.
 // LINT.IfChange
 enum BuiltinOperator : int32 {
+  RMS_NORM = -6,
   GRU = -5,
   BCQ_GATHER = -4,
   BCQ_FULLY_CONNECTED = -3,
@@ -635,6 +636,7 @@ union BuiltinOptions {
   BitcastOptions,
   BitwiseXorOptions,
   RightShiftOptions,
+  RmsNormOptions = 250,
   GRUOptions = 251,
   BCQGatherOptions = 252,
   BCQFullyConnectedOptions = 253,
@@ -1515,6 +1517,11 @@ table BCQFullyConnectedOptions {
 }
 
 table InstanceNormOptions {
+  epsilon:float;
+  fused_activation_function:ActivationFunctionType;
+}
+
+table RmsNormOptions {
   epsilon:float;
   fused_activation_function:ActivationFunctionType;
 }


### PR DESCRIPTION
To support RmsNorm
- RmsNorm op added to circle schema (nnpackage and res)

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967

ONE-DCO-1.0-Signed-off-by: seockho.kim [seockho.kim@samsung.com](mailto:seockho.kim@samsung.com)