### PR TITLE
[fme-apply] Revise overall codes

### DIFF
--- a/compiler/fme-apply/src/EqualizePattern.h
+++ b/compiler/fme-apply/src/EqualizePattern.h
@@ -35,8 +35,8 @@ struct EqualizePattern
   std::string front;
   std::string back;
   Type type = Type::Invalid;
-  std::vector<float> scale; // channel-wise scale
-  std::vector<float> shift; // channel-wise shift
+  std::vector<float> act_scale; // activation channel scales
+  std::vector<float> scale;     // channel-wise scale
 };
 
 } // namespace fme_apply

--- a/compiler/fme-apply/src/EqualizePatternCheck.test.cpp
+++ b/compiler/fme-apply/src/EqualizePatternCheck.test.cpp
@@ -86,7 +86,7 @@ TEST(EqualizePatternCheckTest, simple)
     pattern.back = "conv2";
     pattern.type = EqualizePattern::Type::ScaleOnly;
     for (uint32_t i = 0; i < 16; i++)
-      pattern.scale.push_back(1.0);
+      pattern.act_scale.push_back(1.0);
   }
   p.emplace_back(pattern);
 
@@ -96,16 +96,16 @@ TEST(EqualizePatternCheckTest, simple)
   EXPECT_NO_THROW(check_patterns_valid(g.g(), p));
 }
 
-TEST(EqualizePatternCheckTest, negative_scale_across_relu_scaleonly_NEG)
+TEST(EqualizePatternCheckTest, invalid_names_NEG)
 {
   std::vector<EqualizePattern> p;
   EqualizePattern pattern;
   {
     pattern.front = "conv1";
-    pattern.back = "conv2";
+    pattern.back = "conv3"; // invalid
     pattern.type = EqualizePattern::Type::ScaleOnly;
     for (uint32_t i = 0; i < 16; i++)
-      pattern.scale.push_back(-1.0); // Negative value
+      pattern.act_scale.push_back(1.0);
   }
   p.emplace_back(pattern);
 
@@ -116,16 +116,16 @@ TEST(EqualizePatternCheckTest, negative_scale_across_relu_scaleonly_NEG)
   EXPECT_ANY_THROW(check_patterns_valid(g.g(), p));
 }
 
-TEST(EqualizePatternCheckTest, negative_scale_across_relu_scalshift_NEG)
+TEST(EqualizePatternCheckTest, invalid_scale_NEG)
 {
   std::vector<EqualizePattern> p;
   EqualizePattern pattern;
   {
     pattern.front = "conv1";
     pattern.back = "conv2";
-    pattern.type = EqualizePattern::Type::ScaleShift;
+    pattern.type = EqualizePattern::Type::ScaleOnly;
     for (uint32_t i = 0; i < 16; i++)
-      pattern.scale.push_back(-1.0); // Negative value
+      pattern.scale.push_back(1.0); // invalid
   }
   p.emplace_back(pattern);
 

--- a/compiler/fme-apply/src/EqualizePatternRead.cpp
+++ b/compiler/fme-apply/src/EqualizePatternRead.cpp
@@ -101,14 +101,7 @@ std::vector<EqualizePattern> read(const std::string &filename)
       switch (p.type)
       {
         case EqualizePattern::Type::ScaleOnly:
-          p.scale = get_fp32_array("scale");
-          break;
-        case EqualizePattern::Type::ShiftOnly:
-          p.shift = get_fp32_array("shift");
-          break;
-        case EqualizePattern::Type::ScaleShift:
-          p.scale = get_fp32_array("scale");
-          p.shift = get_fp32_array("shift");
+          p.act_scale = get_fp32_array("act_scale");
           break;
         default:
           throw std::runtime_error("Unsupported EqualizePattern type");

--- a/compiler/fme-apply/src/EqualizePatternRead.test.cpp
+++ b/compiler/fme-apply/src/EqualizePatternRead.test.cpp
@@ -58,7 +58,7 @@ TEST_F(EqualizePatternReadTest, simple)
                                "\"front\": \"f\","
                                "\"back\": \"b\","
                                "\"type\": \"ScaleOnly\","
-                               "\"scale\": [1.0, 2.0, 3.0]"
+                               "\"act_scale\": [4.0, 5.0, 6.0]"
                                "}"
                                "]";
 
@@ -70,11 +70,10 @@ TEST_F(EqualizePatternReadTest, simple)
   EXPECT_EQ("f", patterns[0].front);
   EXPECT_EQ("b", patterns[0].back);
   EXPECT_EQ(EqualizePattern::Type::ScaleOnly, patterns[0].type);
-  EXPECT_EQ(3, patterns[0].scale.size());
-  EXPECT_FLOAT_EQ(1.0, patterns[0].scale[0]);
-  EXPECT_FLOAT_EQ(2.0, patterns[0].scale[1]);
-  EXPECT_FLOAT_EQ(3.0, patterns[0].scale[2]);
-  EXPECT_TRUE(patterns[0].shift.empty());
+  EXPECT_EQ(3, patterns[0].act_scale.size());
+  EXPECT_FLOAT_EQ(4.0, patterns[0].act_scale[0]);
+  EXPECT_FLOAT_EQ(5.0, patterns[0].act_scale[1]);
+  EXPECT_FLOAT_EQ(6.0, patterns[0].act_scale[2]);
 }
 
 TEST_F(EqualizePatternReadTest, no_file_NEG) { EXPECT_ANY_THROW(fme_apply::read(_filename)); }

--- a/compiler/fme-apply/src/FMEqualizer.cpp
+++ b/compiler/fme-apply/src/FMEqualizer.cpp
@@ -37,8 +37,8 @@ using namespace fme_apply;
 namespace
 {
 
-// Throw exception if virtual Op (Scale/Shift) exists
-void check_no_scale_shift(loco::Graph *g)
+// Throw exception if virtual Op (Scale) exists
+void check_no_scale(loco::Graph *g)
 {
   for (auto node : loco::active_nodes(loco::output_nodes(g)))
   {
@@ -50,8 +50,8 @@ void check_no_scale_shift(loco::Graph *g)
       continue;
 
     const auto code = custom->custom_code();
-    if (code == "PreScale" or code == "PreShift" or code == "PostScale" or code == "PostShift")
-      throw std::runtime_error("Virtual node(" + code + ") remains. " + custom->name());
+    if (code == "scale")
+      throw std::runtime_error("Virtual node(" + code + ") remains.");
   }
 }
 
@@ -60,7 +60,7 @@ void check_no_scale_shift(loco::Graph *g)
 namespace fme_apply
 {
 
-void FMEqualizer::equalize(loco::Graph *g, const std::vector<EqualizePattern> &p)
+void FMEqualizer::equalize(loco::Graph *g, std::vector<EqualizePattern> &p)
 {
   THROW_UNLESS(g != nullptr, "Invalid argument g");
 
@@ -78,7 +78,7 @@ void FMEqualizer::equalize(loco::Graph *g, const std::vector<EqualizePattern> &p
   phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
-  // Fuse Pre/Post Scale/Shift
+  // Fuse Pre/Post Scale
   phase.emplace_back(std::make_unique<fme_apply::FusePreScalePass>());
   phase.emplace_back(std::make_unique<fme_apply::FusePostScalePass>());
 
@@ -88,7 +88,7 @@ void FMEqualizer::equalize(loco::Graph *g, const std::vector<EqualizePattern> &p
   phase_runner.run(phase);
 
   // Check if all Scale/Shift nodes are removed
-  check_no_scale_shift(g);
+  check_no_scale(g);
 }
 
 } // namespace fme_apply

--- a/compiler/fme-apply/src/FMEqualizer.h
+++ b/compiler/fme-apply/src/FMEqualizer.h
@@ -27,7 +27,7 @@ namespace fme_apply
 class FMEqualizer final
 {
 public:
-  void equalize(loco::Graph *g, const std::vector<EqualizePattern> &p);
+  void equalize(loco::Graph *g, std::vector<EqualizePattern> &p);
 };
 
 } // namespace fme_apply

--- a/compiler/fme-apply/src/InsertScaleShift.cpp
+++ b/compiler/fme-apply/src/InsertScaleShift.cpp
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
 #include "InsertScaleShift.h"
 #include "EqualizePattern.h"
+#include "Support.Misc.h"
 
 #include <luci/IR/CircleNode.h>
 #include <luci/IR/CircleNodeVisitor.h>
@@ -30,61 +35,6 @@ using namespace fme_apply;
 namespace
 {
 
-/**
- * Create Scale/Shift Op
- *
- * @param node input of the created Scale/Shift Op
- * @param val value of Scale/Shift parameter (channel-wise const)
- * @param code One of PreScale/PostScale/PreShift/PostShift
- * @return CircleCustom node with code
- */
-luci::CircleCustom *create_scale_or_shift(luci::CircleNode *node, const std::vector<float> &val,
-                                          const std::string &code)
-{
-  assert(node); // FIX_CALLER_UNLESS
-
-  THROW_UNLESS(node->rank() == 4, "Node rank is not four");
-
-  // Assume NHWC (index of C: 3)
-  auto channel_size = node->dim(3).value();
-  THROW_UNLESS(val.size() == channel_size, "Channel and scale/shift size mismatch");
-
-  // Create parameter
-  auto param = node->graph()->nodes()->create<luci::CircleConst>();
-  {
-    param->name(node->name() + "_" + code + "_param");
-    param->dtype(loco::DataType::FLOAT32);
-    param->rank(1);
-    param->dim(0).set(channel_size);
-    param->size<loco::DataType::FLOAT32>(channel_size);
-    for (uint32_t i = 0; i < channel_size; i++)
-    {
-      param->at<loco::DataType::FLOAT32>(i) = val[i];
-    }
-    param->shape_status(luci::ShapeStatus::VALID);
-    luci::add_origin(param, luci::get_origin(node));
-  }
-
-  // Create Scale/Shift Op
-  auto ss = node->graph()->nodes()->create<luci::CircleCustom>(2, 1);
-  {
-    ss->name(node->name() + "_" + code);
-    ss->dtype(loco::DataType::FLOAT32);
-    ss->rank(node->rank());
-    for (uint32_t i = 0; i < node->rank(); i++)
-      ss->dim(i).set(node->dim(i).value());
-    ss->custom_code(code);
-
-    ss->inputs(0, node);
-    ss->inputs(1, param);
-
-    ss->shape_status(luci::ShapeStatus::VALID);
-    luci::add_origin(ss, luci::get_origin(node));
-  }
-
-  return ss;
-}
-
 std::vector<float> reciprocal(const std::vector<float> &val)
 {
   std::vector<float> res(val.size());
@@ -98,134 +48,284 @@ std::vector<float> reciprocal(const std::vector<float> &val)
   return res;
 }
 
-std::vector<float> minus(const std::vector<float> &val)
+bool calculate_smooth_quant_scale(luci::CircleNode *node, EqualizePattern *p)
 {
-  std::vector<float> res(val.size());
-  for (uint32_t i = 0; i < res.size(); i++)
+  if (p->scale.size() != 0)
   {
-    res[i] = -val[i];
+    throw std::runtime_error("scale should be empty at this moment.");
   }
-  return res;
-}
 
-// Create PreScale and insert it after node
-luci::CircleCustom *create_pre_scale(luci::CircleNode *node, const EqualizePattern *p)
-{
-  auto param = reciprocal(p->scale);
+  luci::CircleConst *weight = nullptr;
+  switch (node->opcode())
+  {
+    case luci::CircleOpcode::CONV_2D:
+    {
+      auto conv = loco::must_cast<luci::CircleConv2D *>(node);
+      weight = dynamic_cast<luci::CircleConst *>(conv->filter());
+      break;
+    }
+    case luci::CircleOpcode::DEPTHWISE_CONV_2D:
+    {
+      auto conv = loco::must_cast<luci::CircleDepthwiseConv2D *>(node);
+      weight = dynamic_cast<luci::CircleConst *>(conv->filter());
+      break;
+    }
+    case luci::CircleOpcode::FULLY_CONNECTED:
+    {
+      auto fc = loco::must_cast<luci::CircleFullyConnected *>(node);
+      weight = dynamic_cast<luci::CircleConst *>(fc->weights());
+      break;
+    }
+    case luci::CircleOpcode::TRANSPOSE_CONV:
+    {
+      auto conv = loco::must_cast<luci::CircleTransposeConv *>(node);
+      weight = dynamic_cast<luci::CircleConst *>(conv->filter());
+      break;
+    }
+    default:
+    {
+      throw std::runtime_error("(calculate_smooth_quant_scale) NYI operator: " + node->name());
+    }
+  }
 
-  return create_scale_or_shift(node, param, "PreScale");
-}
+  if (not weight)
+    return false;
+  if (weight->dtype() != loco::DataType::FLOAT32)
+    return false;
 
-// Create PostScale and insert it after node
-luci::CircleCustom *create_post_scale(luci::CircleNode *node, const EqualizePattern *p)
-{
-  return create_scale_or_shift(node, p->scale, "PostScale");
-}
+  auto act_scale = p->act_scale;
+  switch (node->opcode())
+  {
+    case luci::CircleOpcode::CONV_2D:
+    case luci::CircleOpcode::DEPTHWISE_CONV_2D:
+    case luci::CircleOpcode::TRANSPOSE_CONV:
+    {
+      auto weight_rank = weight->rank();
+      if (weight_rank != 4)
+        return false;
 
-// Create PreShift and insert it after node
-luci::CircleCustom *create_pre_shift(luci::CircleNode *node, const EqualizePattern *p)
-{
-  auto param = minus(p->shift);
+      if (act_scale.size() != weight->dim(3).value())
+      {
+        throw std::runtime_error(
+          "Mismatch between 'act_scale' size and 'filter' input channel size" +
+          std::to_string(act_scale.size()) + " != " + std::to_string(weight->dim(3).value()));
+      }
 
-  return create_scale_or_shift(node, param, "PreShift");
-}
+      // Find filter max along with In-channel dimension
+      auto weight_size = weight->size<loco::DataType::FLOAT32>();
+      const auto weight_O = weight->dim(0).value();
+      const auto weight_H = weight->dim(1).value();
+      const auto weight_W = weight->dim(2).value();
+      const auto weight_I = weight->dim(3).value();
+      const auto norm_dim = weight_O * weight_H * weight_W;
+      std::vector<float> weight_max(weight_I, std::numeric_limits<float>::min());
+      uint32_t cur = 0;
+      for (uint32_t i = 0; i < weight_I; i++)
+      {
+        cur = i;
+        for (uint32_t j = 0; j < norm_dim; j++)
+        {
+          weight_max.at(i) = std::max(weight_max.at(i), weight->at<loco::DataType::FLOAT32>(cur));
+          cur += weight_I;
+        }
+      }
+      // Check if it properly iterates the filter.
+      assert(cur - weight_I == weight_size - 1);
 
-// Create PostShift and insert it after node
-luci::CircleCustom *create_post_shift(luci::CircleNode *node, const EqualizePattern *p)
-{
-  return create_scale_or_shift(node, p->shift, "PostShift");
+      // TODO parameterize "alpha"
+      auto alpha = 0.5f;
+      assert(p->act_scale.size() == weight_max.size());
+      for (uint32_t i = 0; i < p->act_scale.size(); i++)
+      {
+        p->scale.push_back(std::max(
+          std::pow(p->act_scale.at(i), alpha) / std::pow(weight_max.at(i), (1 - alpha)), 1e-5f));
+      }
+      break;
+    }
+    case luci::CircleOpcode::FULLY_CONNECTED:
+    {
+      auto weight_rank = weight->rank();
+      if (weight_rank != 2)
+        return false;
+
+      if (act_scale.size() != weight->dim(1).value())
+      {
+        throw std::runtime_error(
+          "Mismatch between 'act_scale' size and 'filter' input channel size" +
+          std::to_string(act_scale.size()) + " != " + std::to_string(weight->dim(1).value()));
+      }
+
+      // Find filter max along with In-channel dimension
+      auto weight_size = weight->size<loco::DataType::FLOAT32>();
+      const auto weight_O = weight->dim(0).value();
+      const auto weight_I = weight->dim(1).value();
+      std::vector<float> weight_max(weight_I, std::numeric_limits<float>::min());
+      uint32_t cur = 0;
+      for (uint32_t i = 0; i < weight_I; i++)
+      {
+        cur = i;
+        for (uint32_t j = 0; j < weight_O; j++)
+        {
+          weight_max.at(i) = std::max(weight_max.at(i), weight->at<loco::DataType::FLOAT32>(cur));
+          cur += weight_I;
+        }
+      }
+      // Check if it properly iterates the filter.
+      assert(cur - weight_I == weight_size - 1);
+
+      // TODO parameterize "alpha"
+      auto alpha = 0.5f;
+      assert(p->act_scale.size() == weight_max.size());
+      for (uint32_t i = 0; i < p->act_scale.size(); i++)
+      {
+        p->scale.push_back(std::max(
+          std::pow(p->act_scale.at(i), alpha) / std::pow(weight_max.at(i), (1 - alpha)), 1e-5f));
+      }
+      break;
+    }
+    default:
+    {
+      throw std::runtime_error("(calculate_smooth_quant_scale) NYI operator: " + node->name());
+    }
+  }
+
+  return true;
 }
 
 struct InsertScaleShiftVisitor final : public luci::CircleNodeMutableVisitor<void>
 {
-  InsertScaleShiftVisitor(const EqualizePattern *p) : _pattern(p)
+  InsertScaleShiftVisitor(EqualizePattern *p) : _pattern(p)
   {
     // DO NOTHING
   }
 
 private:
-  const EqualizePattern *_pattern = nullptr;
+  EqualizePattern *_pattern = nullptr;
 
 private:
-  // Generate scale/shift Ops and return the last one
-  // lnode: 'front' of EqualizePattern
-  // Never return nullptr
-  luci::CircleCustom *gen_scale_shift(loco::Node *lnode) const
+  void insert_scale_before(luci::CircleNode *node, const std::vector<float> &scale)
   {
-    auto node = loco::must_cast<luci::CircleNode *>(lnode);
+    assert(node);
+    auto previous_node = loco::must_cast<luci::CircleNode *>(get_input(node));
 
-    assert(node->name() == _pattern->front); // FIX_CALLER_UNLESS
-
-    luci::CircleCustom *bottom = nullptr;
-
-    switch (_pattern->type)
+    // Create const for scale
+    auto param = node->graph()->nodes()->create<luci::CircleConst>();
     {
-      case EqualizePattern::Type::ScaleOnly:
+      param->name(node->name() + "_scale_const");
+      param->dtype(loco::DataType::FLOAT32);
+      param->rank(1);
+      param->dim(0).set(scale.size());
+      param->size<loco::DataType::FLOAT32>(scale.size());
+      for (uint32_t i = 0; i < scale.size(); i++)
       {
-        auto post_scale = create_post_scale(node, _pattern);
-        bottom = create_pre_scale(post_scale, _pattern);
-        break;
+        param->at<loco::DataType::FLOAT32>(i) = scale.at(i);
       }
-      case EqualizePattern::Type::ShiftOnly:
-      {
-        auto post_shift = create_post_shift(node, _pattern);
-        bottom = create_pre_shift(post_shift, _pattern);
-        break;
-      }
-      case EqualizePattern::Type::ScaleShift:
-      {
-        auto post_scale = create_post_scale(node, _pattern);
-        auto post_shift = create_post_shift(post_scale, _pattern);
-        auto pre_shift = create_pre_shift(post_shift, _pattern);
-        bottom = create_pre_scale(pre_shift, _pattern);
-        break;
-      }
-      default:
-        throw std::runtime_error("Unsupported EqualizePattern type");
+      param->shape_status(luci::ShapeStatus::VALID);
+      luci::add_origin(param, luci::get_origin(node));
     }
 
-    assert(bottom != nullptr); // FIX_ME_UNLESS
+    // Create Scale Op
+    auto ss = node->graph()->nodes()->create<luci::CircleCustom>(2, 1);
+    {
+      ss->name(node->name() + "_scale");
+      ss->dtype(loco::DataType::FLOAT32);
+      ss->rank(previous_node->rank());
+      for (uint32_t i = 0; i < previous_node->rank(); i++)
+        ss->dim(i).set(previous_node->dim(i).value());
+      ss->custom_code("scale");
 
-    return bottom;
+      ss->inputs(0, previous_node);
+      ss->inputs(1, param);
+
+      ss->shape_status(luci::ShapeStatus::VALID);
+      luci::add_origin(ss, luci::get_origin(node));
+    }
+    set_input(node, ss);
   }
 
+  void insert_scale_after(luci::CircleNode *node, const std::vector<float> &scale)
+  {
+    if (not node)
+    {
+      throw std::runtime_error("(insert_scale_after) Invalid node.");
+    }
+
+    // Create const for scale
+    auto param = node->graph()->nodes()->create<luci::CircleConst>();
+    {
+      param->name(node->name() + "_scale_const");
+      param->dtype(loco::DataType::FLOAT32);
+      param->rank(1);
+      param->dim(0).set(scale.size());
+      param->size<loco::DataType::FLOAT32>(scale.size());
+      for (uint32_t i = 0; i < scale.size(); i++)
+      {
+        param->at<loco::DataType::FLOAT32>(i) = scale.at(i);
+      }
+      param->shape_status(luci::ShapeStatus::VALID);
+      luci::add_origin(param, luci::get_origin(node));
+    }
+
+    // NOTE. Get a node user before setting CircleCustom("scale")'s input.
+    auto uses = loco::succs(node);
+    if (uses.size() != 1)
+    {
+      throw std::runtime_error("Not support multiple output nodes.");
+    }
+
+    // Create Scale Op
+    auto ss = node->graph()->nodes()->create<luci::CircleCustom>(2, 1);
+    {
+      ss->name(node->name() + "_scale");
+      ss->dtype(loco::DataType::FLOAT32);
+      ss->rank(node->rank());
+      for (uint32_t i = 0; i < node->rank(); i++)
+        ss->dim(i).set(node->dim(i).value());
+      ss->custom_code("scale");
+
+      ss->inputs(0, node);
+      ss->inputs(1, param);
+
+      ss->shape_status(luci::ShapeStatus::VALID);
+      luci::add_origin(ss, luci::get_origin(node));
+    }
+
+    set_input(loco::must_cast<luci::CircleNode *>(*uses.begin()), ss);
+  }
+
+private:
+  void insert(luci::CircleNode *node)
+  {
+    assert(_pattern->scale.size() ==
+           0); // scale for smooth qaunt is not calculated yet at this moment.
+    auto valid = ::calculate_smooth_quant_scale(node, _pattern);
+    auto back_node = node;
+    // Find front node.
+    const auto support_depth = 2;
+    auto front_node = find_arg_with_name(node, _pattern->front, support_depth);
+    if (not front_node)
+    {
+      throw std::runtime_error("Cannot find front node: " + _pattern->front);
+    }
+    insert_scale_after(front_node, reciprocal(_pattern->scale));
+    insert_scale_before(back_node, _pattern->scale);
+  }
+
+private:
   void visit(luci::CircleOutput *) {}
 
-  void visit(luci::CircleNode *node) { throw std::runtime_error("NYI operator: " + node->name()); }
-
-  void visit(luci::CircleConv2D *node)
+  void visit(luci::CircleNode *node)
   {
-    auto bottom = gen_scale_shift(node->input());
-    node->input(bottom);
+    throw std::runtime_error("(InsertScaleShiftVisitor) NYI operator: " + node->name());
   }
 
-  void visit(luci::CircleDepthwiseConv2D *node)
-  {
-    auto bottom = gen_scale_shift(node->input());
-    node->input(bottom);
-  }
+  void visit(luci::CircleConv2D *node) { insert(node); }
 
-  void visit(luci::CircleTransposeConv *node)
-  {
-    auto bottom = gen_scale_shift(node->outBackprop());
-    node->outBackprop(bottom);
-  }
+  void visit(luci::CircleDepthwiseConv2D *node) { insert(node); }
 
-  void visit(luci::CircleInstanceNorm *node)
-  {
-    auto bottom = gen_scale_shift(node->input());
-    node->input(bottom);
-  }
-  void visit(luci::CirclePad *node)
-  {
-    auto bottom = gen_scale_shift(node->input());
-    node->input(bottom);
-  }
-  void visit(luci::CircleSlice *node)
-  {
-    auto bottom = gen_scale_shift(node->input());
-    node->input(bottom);
-  }
+  void visit(luci::CircleFullyConnected *node) { insert(node); }
+
+  void visit(luci::CircleTransposeConv *node) { insert(node); }
 };
 
 } // namespace
@@ -238,9 +338,9 @@ void InsertScaleShift::run(loco::Graph *g)
   // Create a map for pattern matching
   // { back(string) -> EqualizationPattern*}
   // This assumes that each EqualizePattern has a unique 'back'
-  std::map<std::string, const EqualizePattern *> pattern_by_back;
+  std::map<std::string, EqualizePattern *> pattern_by_back;
   {
-    for (const auto &pattern : _patterns)
+    for (auto &pattern : _patterns)
     {
       auto back = pattern.back;
       pattern_by_back[back] = &pattern;

--- a/compiler/fme-apply/src/InsertScaleShift.h
+++ b/compiler/fme-apply/src/InsertScaleShift.h
@@ -30,7 +30,7 @@ namespace fme_apply
 class InsertScaleShift
 {
 public:
-  InsertScaleShift(const std::vector<EqualizePattern> &patterns) : _patterns{patterns}
+  InsertScaleShift(std::vector<EqualizePattern> &patterns) : _patterns{patterns}
   {
     // DO NOTHING
   }
@@ -39,7 +39,7 @@ public:
   void run(loco::Graph *graph);
 
 private:
-  const std::vector<EqualizePattern> &_patterns;
+  std::vector<EqualizePattern> &_patterns;
 };
 
 } // namespace fme_apply

--- a/compiler/fme-apply/src/Support.Cast.cpp
+++ b/compiler/fme-apply/src/Support.Cast.cpp
@@ -19,64 +19,19 @@
 namespace fme_apply
 {
 
-luci::CircleCustom *to_pre_scale(loco::Node *node)
+luci::CircleCustom *to_scale(loco::Node *node)
 {
-  auto pre_scale = dynamic_cast<luci::CircleCustom *>(node);
-  if (not pre_scale)
+  auto scale = dynamic_cast<luci::CircleCustom *>(node);
+  if (not scale)
     return nullptr;
 
-  if (pre_scale->custom_code() != "PreScale")
+  if (scale->custom_code() != "scale")
     return nullptr;
 
   // TODO Return false?
-  assert(pre_scale->numInputs() == 2); // FIX_PreScale_UNLESS
+  assert(scale->numInputs() == 2); // FIX_PreScale_UNLESS
 
-  return pre_scale;
-}
-
-luci::CircleCustom *to_post_scale(loco::Node *node)
-{
-  auto post_scale = dynamic_cast<luci::CircleCustom *>(node);
-  if (not post_scale)
-    return nullptr;
-
-  if (post_scale->custom_code() != "PostScale")
-    return nullptr;
-
-  // TODO Return false?
-  assert(post_scale->numInputs() == 2); // FIX_PostScale_UNLESS
-
-  return post_scale;
-}
-
-luci::CircleCustom *to_pre_shift(loco::Node *node)
-{
-  auto pre_shift = dynamic_cast<luci::CircleCustom *>(node);
-  if (not pre_shift)
-    return nullptr;
-
-  if (pre_shift->custom_code() != "PreShift")
-    return nullptr;
-
-  // TODO Return false?
-  assert(pre_shift->numInputs() == 2); // FIX_PreShift_UNLESS
-
-  return pre_shift;
-}
-
-luci::CircleCustom *to_post_shift(loco::Node *node)
-{
-  auto post_shift = dynamic_cast<luci::CircleCustom *>(node);
-  if (not post_shift)
-    return nullptr;
-
-  if (post_shift->custom_code() != "PostShift")
-    return nullptr;
-
-  // TODO Return false?
-  assert(post_shift->numInputs() == 2); // FIX_PostShift_UNLESS
-
-  return post_shift;
+  return scale;
 }
 
 } // namespace fme_apply

--- a/compiler/fme-apply/src/Support.Cast.h
+++ b/compiler/fme-apply/src/Support.Cast.h
@@ -23,21 +23,9 @@
 namespace fme_apply
 {
 
-// Cast loco::Node* to CircleCustom(PreScale)*
+// Cast loco::Node* to CircleCustom(scale)*
 // Return nullptr if impossible
-luci::CircleCustom *to_pre_scale(loco::Node *node);
-
-// Cast loco::Node* to CircleCustom(PostScale)*
-// Return nullptr if impossible
-luci::CircleCustom *to_post_scale(loco::Node *node);
-
-// Cast loco::Node* to CircleCustom(PreShift)*
-// Return nullptr if impossible
-luci::CircleCustom *to_pre_shift(loco::Node *node);
-
-// Cast loco::Node* to CircleCustom(PostShift)*
-// Return nullptr if impossible
-luci::CircleCustom *to_post_shift(loco::Node *node);
+luci::CircleCustom *to_scale(loco::Node *node);
 
 } // namespace fme_apply
 

--- a/compiler/fme-apply/src/Support.Cast.test.cpp
+++ b/compiler/fme-apply/src/Support.Cast.test.cpp
@@ -20,82 +20,22 @@
 
 using namespace fme_apply;
 
-TEST(SupportCastTest, pre_scale)
+TEST(SupportCastTest, to_scale_simple)
 {
   loco::Graph g;
   auto node = g.nodes()->create<luci::CircleCustom>(2, 1);
-  node->custom_code("PreScale");
+  node->custom_code("scale");
 
-  EXPECT_EQ(node, to_pre_scale(g.nodes()->at(0)));
+  EXPECT_EQ(node, to_scale(g.nodes()->at(0)));
 }
 
-TEST(SupportCastTest, pre_scale_null_NEG) { EXPECT_EQ(nullptr, to_pre_scale(nullptr)); }
+TEST(SupportCastTest, to_scale_null_NEG) { EXPECT_EQ(nullptr, to_scale(nullptr)); }
 
-TEST(SupportCastTest, pre_scale_wrong_code_NEG)
+TEST(SupportCastTest, to_scale_wrong_code_NEG)
 {
   loco::Graph g;
   auto node = g.nodes()->create<luci::CircleCustom>(2, 1);
   node->custom_code("wrong");
 
-  EXPECT_EQ(nullptr, to_pre_scale(g.nodes()->at(0)));
-}
-
-TEST(SupportCastTest, pre_shift)
-{
-  loco::Graph g;
-  auto node = g.nodes()->create<luci::CircleCustom>(2, 1);
-  node->custom_code("PreShift");
-
-  EXPECT_EQ(node, to_pre_shift(g.nodes()->at(0)));
-}
-
-TEST(SupportCastTest, pre_shift_null_NEG) { EXPECT_EQ(nullptr, to_pre_shift(nullptr)); }
-
-TEST(SupportCastTest, pre_shift_wrong_code_NEG)
-{
-  loco::Graph g;
-  auto node = g.nodes()->create<luci::CircleCustom>(2, 1);
-  node->custom_code("wrong");
-
-  EXPECT_EQ(nullptr, to_pre_shift(g.nodes()->at(0)));
-}
-
-TEST(SupportCastTest, post_scale)
-{
-  loco::Graph g;
-  auto node = g.nodes()->create<luci::CircleCustom>(2, 1);
-  node->custom_code("PostScale");
-
-  EXPECT_EQ(node, to_post_scale(g.nodes()->at(0)));
-}
-
-TEST(SupportCastTest, post_scale_null_NEG) { EXPECT_EQ(nullptr, to_post_scale(nullptr)); }
-
-TEST(SupportCastTest, post_scale_wrong_code_NEG)
-{
-  loco::Graph g;
-  auto node = g.nodes()->create<luci::CircleCustom>(2, 1);
-  node->custom_code("wrong");
-
-  EXPECT_EQ(nullptr, to_post_scale(g.nodes()->at(0)));
-}
-
-TEST(SupportCastTest, post_shift)
-{
-  loco::Graph g;
-  auto node = g.nodes()->create<luci::CircleCustom>(2, 1);
-  node->custom_code("PostShift");
-
-  EXPECT_EQ(node, to_post_shift(g.nodes()->at(0)));
-}
-
-TEST(SupportCastTest, post_shift_null_NEG) { EXPECT_EQ(nullptr, to_post_shift(nullptr)); }
-
-TEST(SupportCastTest, post_shift_wrong_code_NEG)
-{
-  loco::Graph g;
-  auto node = g.nodes()->create<luci::CircleCustom>(2, 1);
-  node->custom_code("wrong");
-
-  EXPECT_EQ(nullptr, to_post_shift(g.nodes()->at(0)));
+  EXPECT_EQ(nullptr, to_scale(g.nodes()->at(0)));
 }

--- a/compiler/fme-apply/src/Support.Misc.cpp
+++ b/compiler/fme-apply/src/Support.Misc.cpp
@@ -34,4 +34,160 @@ void copy_shape(luci::CircleNode *from, luci::CircleNode *to)
   }
 }
 
+/**
+ * It returns given node's input.
+ */
+loco::Node *get_input(luci::CircleNode *node)
+{
+  switch (node->opcode())
+  {
+    case luci::CircleOpcode::CONV_2D:
+    {
+      auto conv = loco::must_cast<luci::CircleConv2D *>(node);
+      return conv->input();
+    }
+    case luci::CircleOpcode::DEPTHWISE_CONV_2D:
+    {
+      auto dconv = loco::must_cast<luci::CircleDepthwiseConv2D *>(node);
+      return dconv->input();
+    }
+    case luci::CircleOpcode::FULLY_CONNECTED:
+    {
+      auto fc = loco::must_cast<luci::CircleFullyConnected *>(node);
+      return fc->input();
+    }
+    case luci::CircleOpcode::GELU:
+    {
+      auto gelu = loco::must_cast<luci::CircleGelu *>(node);
+      return gelu->features();
+    }
+    case luci::CircleOpcode::LEAKY_RELU:
+    {
+      auto relu = loco::must_cast<luci::CircleLeakyRelu *>(node);
+      return relu->features();
+    }
+    case luci::CircleOpcode::MAX_POOL_2D:
+    {
+      auto maxpool = loco::must_cast<luci::CircleMaxPool2D *>(node);
+      return maxpool->value();
+    }
+    case luci::CircleOpcode::PAD:
+    {
+      auto pad = loco::must_cast<luci::CirclePad *>(node);
+      return pad->input();
+    }
+    case luci::CircleOpcode::RELU:
+    {
+      auto relu = loco::must_cast<luci::CircleLeakyRelu *>(node);
+      return relu->features();
+    }
+    case luci::CircleOpcode::TRANSPOSE_CONV:
+    {
+      auto tconv = loco::must_cast<luci::CircleTransposeConv *>(node);
+      return tconv->outBackprop();
+    }
+    default:
+    {
+      throw std::runtime_error("(get_input) NYI operator: " + node->name());
+    }
+  }
+}
+
+/**
+ * It sets given 'input' to node's input.
+ */
+void set_input(luci::CircleNode *node, luci::CircleCustom *input)
+{
+  if (input == nullptr)
+  {
+    throw std::runtime_error("Invalid input.");
+  }
+
+  switch (node->opcode())
+  {
+    case luci::CircleOpcode::CONV_2D:
+    {
+      auto conv = loco::must_cast<luci::CircleConv2D *>(node);
+      conv->input(input);
+      break;
+    }
+    case luci::CircleOpcode::DEPTHWISE_CONV_2D:
+    {
+      auto dconv = loco::must_cast<luci::CircleDepthwiseConv2D *>(node);
+      dconv->input(input);
+      break;
+    }
+    case luci::CircleOpcode::FULLY_CONNECTED:
+    {
+      auto fc = loco::must_cast<luci::CircleFullyConnected *>(node);
+      fc->input(input);
+      break;
+    }
+    case luci::CircleOpcode::GELU:
+    {
+      auto gelu = loco::must_cast<luci::CircleGelu *>(node);
+      gelu->features(input);
+      break;
+    }
+    case luci::CircleOpcode::LEAKY_RELU:
+    {
+      auto relu = loco::must_cast<luci::CircleLeakyRelu *>(node);
+      relu->features(input);
+      break;
+    }
+    case luci::CircleOpcode::MAX_POOL_2D:
+    {
+      auto maxpool = loco::must_cast<luci::CircleMaxPool2D *>(node);
+      maxpool->value(input);
+      break;
+    }
+    case luci::CircleOpcode::PAD:
+    {
+      auto pad = loco::must_cast<luci::CirclePad *>(node);
+      pad->input(input);
+      break;
+    }
+    case luci::CircleOpcode::RELU:
+    {
+      auto relu = loco::must_cast<luci::CircleLeakyRelu *>(node);
+      relu->features(input);
+      break;
+    }
+    case luci::CircleOpcode::TRANSPOSE_CONV:
+    {
+      auto tconv = loco::must_cast<luci::CircleTransposeConv *>(node);
+      tconv->outBackprop(input);
+      break;
+    }
+    default:
+    {
+      throw std::runtime_error("(set_input) NYI operator: " + node->name());
+    }
+  }
+}
+
+/**
+ * It returns one of given node's arguments whose name is "name".
+ *
+ * According to the depth, it finds from more preceded nodes.
+ */
+luci::CircleNode *find_arg_with_name(const luci::CircleNode *node, const std::string &name,
+                                     const uint32_t &depth)
+{
+  if (depth == 0)
+    return nullptr;
+
+  const auto arity = node->arity();
+  for (uint32_t idx = 0; idx < arity; idx++)
+  {
+    auto front_node = loco::must_cast<luci::CircleNode *>(node->arg(idx));
+    if (front_node->name() == name)
+      return front_node;
+    front_node = find_arg_with_name(front_node, name, depth - 1);
+    if (front_node)
+      return front_node;
+  }
+  return nullptr;
+}
+
 } // namespace fme_apply

--- a/compiler/fme-apply/src/Support.Misc.h
+++ b/compiler/fme-apply/src/Support.Misc.h
@@ -23,6 +23,10 @@ namespace fme_apply
 {
 
 void copy_shape(luci::CircleNode *from, luci::CircleNode *to);
+loco::Node *get_input(luci::CircleNode *node);
+void set_input(luci::CircleNode *node, luci::CircleCustom *scale);
+luci::CircleNode *find_arg_with_name(const luci::CircleNode *node, const std::string &name,
+                                     const uint32_t &depth = 1);
 
 } // namespace fme_apply
 

--- a/compiler/fme-apply/src/Support.Misc.test.cpp
+++ b/compiler/fme-apply/src/Support.Misc.test.cpp
@@ -58,3 +58,46 @@ TEST(SupportMiscTest, copy_shape_to_null_NEG)
 
   EXPECT_ANY_THROW(copy_shape(from, nullptr));
 }
+
+TEST(SupportMiscTest, get_input_simple)
+{
+  loco::Graph g;
+
+  auto input_node = g.nodes()->create<luci::CircleCustom>(2, 1);
+
+  auto node = g.nodes()->create<luci::CircleConv2D>();
+  node->shape({1, 2, 3, 4});
+  node->input(input_node);
+
+  auto ret = get_input(node);
+  EXPECT_EQ(ret, input_node);
+}
+
+TEST(SupportMiscTest, set_input_simple)
+{
+  loco::Graph g;
+
+  auto input_node = g.nodes()->create<luci::CircleCustom>(2, 1);
+
+  auto node = g.nodes()->create<luci::CircleConv2D>();
+  node->shape({1, 2, 3, 4});
+
+  set_input(node, input_node);
+  EXPECT_EQ(node->input(), input_node);
+}
+
+TEST(SupportMiscTest, find_arg_with_name_simple)
+{
+  loco::Graph g;
+
+  auto input_node = g.nodes()->create<luci::CircleCustom>(2, 1);
+  input_node->name("input_node");
+
+  auto node = g.nodes()->create<luci::CircleConv2D>();
+  node->shape({1, 2, 3, 4});
+  node->input(input_node);
+
+  auto ret = find_arg_with_name(node, "input_node");
+
+  EXPECT_EQ(ret, input_node);
+}

--- a/compiler/fme-apply/src/pass/FusePostScalePass.cpp
+++ b/compiler/fme-apply/src/pass/FusePostScalePass.cpp
@@ -34,155 +34,438 @@ struct FusePostScale final : public luci::CircleNodeMutableVisitor<bool>
 {
   bool visit(luci::CircleNode *) { return false; }
 
-  bool visit(luci::CircleDepthwiseConv2D *node)
-  {
-    if (node->fusedActivationFunction() != luci::FusedActFunc::NONE and
-        node->fusedActivationFunction() != luci::FusedActFunc::RELU)
-      return false;
-
-    bool changed = false;
-    for (auto succ : loco::succs(node))
-    {
-      auto post_scale = to_post_scale(succ);
-      if (not post_scale)
-        continue;
-
-      auto param =
-        loco::must_cast<luci::CircleConst *>(post_scale->inputs(1)); // FIX_PostScale_UNLESS
-      auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
-      auto bias = loco::must_cast<luci::CircleConst *>(node->bias());
-
-      uint32_t filter_i = filter->dim(0).value();
-      uint32_t filter_h = filter->dim(1).value();
-      uint32_t filter_w = filter->dim(2).value();
-      uint32_t filter_o = filter->dim(3).value();
-
-      if (filter_o != param->size<loco::DataType::FLOAT32>())
-      {
-        assert(false); // FIX_PostScale_Unless
-        return false;
-      }
-
-      auto cloned_dconv = luci::clone_node(node, node->graph());
-      assert(cloned_dconv != nullptr); // FIX_CALLER_UNLESS
-      auto fused_dconv = loco::must_cast<luci::CircleDepthwiseConv2D *>(cloned_dconv);
-      auto fused_filter = luci::clone(filter);
-      auto fused_bias = luci::clone(bias);
-
-      // Add random string to make unique name
-      fused_dconv->name(node->name() + "_postscale_" + random_str());
-      fused_filter->name(filter->name() + "_postscale_" + random_str());
-      fused_bias->name(bias->name() + "_postscale_" + random_str());
-
-      add_origin(fused_dconv, luci::get_origin(node));
-      add_origin(fused_filter, luci::get_origin(filter));
-      add_origin(fused_bias, luci::get_origin(bias));
-
-      // Multiply param to weights
-      for (uint32_t b = 0; b < filter_i; b++)
-      {
-        for (uint32_t h = 0; h < filter_h; h++)
-        {
-          for (uint32_t w = 0; w < filter_w; w++)
-          {
-            for (uint32_t c = 0; c < filter_o; c++)
-            {
-              uint32_t offset =
-                b * filter_h * filter_w * filter_o + h * filter_w * filter_o + w * filter_o + c;
-              float scale = param->at<loco::DataType::FLOAT32>(c);
-              assert(scale > 0.0); // Defensive guard
-
-              fused_filter->at<loco::DataType::FLOAT32>(offset) =
-                fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
-            }
-          }
-        }
-      }
-
-      // Multiply param to bias
-      for (uint32_t c = 0; c < filter_o; ++c)
-      {
-        float scale = param->at<loco::DataType::FLOAT32>(c);
-        fused_bias->at<loco::DataType::FLOAT32>(c) =
-          fused_bias->at<loco::DataType::FLOAT32>(c) * scale;
-      }
-
-      fused_dconv->input(node->input());
-      fused_dconv->filter(fused_filter);
-      fused_dconv->bias(fused_bias);
-
-      loco::replace(post_scale).with(fused_dconv);
-      changed = true;
-    }
-
-    return changed;
-  }
-
   bool visit(luci::CircleConv2D *node)
   {
     if (node->fusedActivationFunction() != luci::FusedActFunc::NONE and
         node->fusedActivationFunction() != luci::FusedActFunc::RELU)
       return false;
 
-    bool changed = false;
-
-    for (auto succ : loco::succs(node))
+    luci::CircleCustom *post_scale = nullptr;
+    bool multi_custom = false;
+    auto succs = loco::succs(node);
+    for (const auto succ : succs)
     {
-      auto post_scale = to_post_scale(succ);
-      if (not post_scale)
-        continue;
-
-      auto param =
-        loco::must_cast<luci::CircleConst *>(post_scale->inputs(1)); // FIX_PostScale_UNLESS
-      auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
-      auto bias = loco::must_cast<luci::CircleConst *>(node->bias());
-
-      uint32_t filter_o = filter->dim(0).value();
-      uint32_t filter_h = filter->dim(1).value();
-      uint32_t filter_w = filter->dim(2).value();
-      uint32_t filter_i = filter->dim(3).value();
-
-      if (filter_o != param->size<loco::DataType::FLOAT32>())
+      post_scale = to_scale(succ);
+      if (multi_custom && post_scale)
       {
-        assert(false); // FIX_PostScale_Unless
-        return false;
+        throw std::runtime_error("Do not allow multiple scales.");
       }
-
-      auto cloned_conv = luci::clone_node(node, node->graph());
-      assert(cloned_conv != nullptr); // FIX_CALLER_UNLESS
-      auto fused_conv = loco::must_cast<luci::CircleConv2D *>(cloned_conv);
-      auto fused_filter = luci::clone(filter);
-      auto fused_bias = luci::clone(bias);
-
-      fused_conv->name(node->name() + "_postscale_" + random_str());
-      fused_filter->name(filter->name() + "_postscale_" + random_str());
-      fused_bias->name(bias->name() + "_postscale_" + random_str());
-
-      add_origin(fused_conv, luci::get_origin(node));
-      add_origin(fused_filter, luci::get_origin(filter));
-      add_origin(fused_bias, luci::get_origin(bias));
-
-      // Multiply param to weights
-      for (uint32_t c = 0; c < filter_o; c++)
+      if (post_scale)
       {
-        float scale = param->at<loco::DataType::FLOAT32>(c);
-        assert(scale > 0.0); // Defensive guard
+        multi_custom = true;
+      }
+    }
+    if (not post_scale)
+      return false;
 
-        for (uint32_t h = 0; h < filter_h; h++)
+    auto param =
+      loco::must_cast<luci::CircleConst *>(post_scale->inputs(1)); // FIX_PostScale_UNLESS
+    auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
+    auto bias = loco::must_cast<luci::CircleConst *>(node->bias());
+
+    uint32_t filter_o = filter->dim(0).value();
+    uint32_t filter_h = filter->dim(1).value();
+    uint32_t filter_w = filter->dim(2).value();
+    uint32_t filter_i = filter->dim(3).value();
+
+    if (filter_o != param->size<loco::DataType::FLOAT32>())
+    {
+      throw std::runtime_error(
+        "Mismatch between scale size and filter output channel size: " + std::to_string(filter_o) +
+        " != " + std::to_string(param->size<loco::DataType::FLOAT32>()));
+    }
+
+    auto cloned_conv = luci::clone_node(node, node->graph());
+    assert(cloned_conv != nullptr); // FIX_CALLER_UNLESS
+    auto fused_conv = loco::must_cast<luci::CircleConv2D *>(cloned_conv);
+    auto fused_filter = luci::clone(filter);
+    auto fused_bias = luci::clone(bias);
+
+    fused_conv->name(node->name() + "_fused_" + random_str());
+    fused_filter->name(filter->name() + "_fused_" + random_str());
+    fused_bias->name(bias->name() + "_fused_" + random_str());
+
+    add_origin(fused_conv, luci::get_origin(node));
+    add_origin(fused_filter, luci::get_origin(filter));
+    add_origin(fused_bias, luci::get_origin(bias));
+
+    // Multiply param to weights
+    for (uint32_t c = 0; c < filter_o; c++)
+    {
+      float scale = param->at<loco::DataType::FLOAT32>(c);
+      assert(scale > 0.0); // Defensive guard
+
+      for (uint32_t h = 0; h < filter_h; h++)
+      {
+        for (uint32_t w = 0; w < filter_w; w++)
         {
-          for (uint32_t w = 0; w < filter_w; w++)
+          for (uint32_t b = 0; b < filter_i; b++)
           {
-            for (uint32_t b = 0; b < filter_i; b++)
-            {
-              uint32_t offset =
-                c * filter_h * filter_w * filter_i + h * filter_w * filter_i + w * filter_i + b;
+            uint32_t offset =
+              c * filter_h * filter_w * filter_i + h * filter_w * filter_i + w * filter_i + b;
 
-              fused_filter->at<loco::DataType::FLOAT32>(offset) =
-                fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
-            }
+            fused_filter->at<loco::DataType::FLOAT32>(offset) =
+              fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
           }
         }
       }
+    }
+
+    // Multiply param to bias
+    for (uint32_t c = 0; c < filter_o; ++c)
+    {
+      float scale = param->at<loco::DataType::FLOAT32>(c);
+      fused_bias->at<loco::DataType::FLOAT32>(c) =
+        fused_bias->at<loco::DataType::FLOAT32>(c) * scale;
+    }
+
+    fused_conv->input(node->input());
+    fused_conv->filter(fused_filter);
+    fused_conv->bias(fused_bias);
+
+    loco::replace(post_scale).with(fused_conv);
+
+    return true;
+  }
+
+  bool visit(luci::CircleDepthwiseConv2D *node)
+  {
+    if (node->fusedActivationFunction() != luci::FusedActFunc::NONE and
+        node->fusedActivationFunction() != luci::FusedActFunc::RELU)
+      return false;
+
+    luci::CircleCustom *post_scale = nullptr;
+    bool multi_custom = false;
+    auto succs = loco::succs(node);
+    for (const auto succ : succs)
+    {
+      post_scale = to_scale(succ);
+      if (multi_custom && post_scale)
+      {
+        throw std::runtime_error("Do not allow multiple scales.");
+      }
+      if (post_scale)
+      {
+        multi_custom = true;
+      }
+    }
+    if (not post_scale)
+      return false;
+
+    auto param =
+      loco::must_cast<luci::CircleConst *>(post_scale->inputs(1)); // FIX_PostScale_UNLESS
+    auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
+    auto bias = loco::must_cast<luci::CircleConst *>(node->bias());
+
+    uint32_t filter_i = filter->dim(0).value();
+    uint32_t filter_h = filter->dim(1).value();
+    uint32_t filter_w = filter->dim(2).value();
+    uint32_t filter_o = filter->dim(3).value();
+
+    if (filter_o != param->size<loco::DataType::FLOAT32>())
+    {
+      assert(false); // FIX_PostScale_Unless
+      return false;
+    }
+
+    auto cloned_dconv = luci::clone_node(node, node->graph());
+    assert(cloned_dconv != nullptr); // FIX_CALLER_UNLESS
+    auto fused_dconv = loco::must_cast<luci::CircleDepthwiseConv2D *>(cloned_dconv);
+    auto fused_filter = luci::clone(filter);
+    auto fused_bias = luci::clone(bias);
+
+    // Add random string to make unique name
+    fused_dconv->name(node->name() + "_postscale_" + random_str());
+    fused_filter->name(filter->name() + "_postscale_" + random_str());
+    fused_bias->name(bias->name() + "_postscale_" + random_str());
+
+    add_origin(fused_dconv, luci::get_origin(node));
+    add_origin(fused_filter, luci::get_origin(filter));
+    add_origin(fused_bias, luci::get_origin(bias));
+
+    // Multiply param to weights
+    for (uint32_t b = 0; b < filter_i; b++)
+    {
+      for (uint32_t h = 0; h < filter_h; h++)
+      {
+        for (uint32_t w = 0; w < filter_w; w++)
+        {
+          for (uint32_t c = 0; c < filter_o; c++)
+          {
+            uint32_t offset =
+              b * filter_h * filter_w * filter_o + h * filter_w * filter_o + w * filter_o + c;
+            float scale = param->at<loco::DataType::FLOAT32>(c);
+            assert(scale > 0.0); // Defensive guard
+
+            fused_filter->at<loco::DataType::FLOAT32>(offset) =
+              fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
+          }
+        }
+      }
+    }
+
+    // Multiply param to bias
+    for (uint32_t c = 0; c < filter_o; ++c)
+    {
+      float scale = param->at<loco::DataType::FLOAT32>(c);
+      fused_bias->at<loco::DataType::FLOAT32>(c) =
+        fused_bias->at<loco::DataType::FLOAT32>(c) * scale;
+    }
+
+    fused_dconv->input(node->input());
+    fused_dconv->filter(fused_filter);
+    fused_dconv->bias(fused_bias);
+
+    loco::replace(post_scale).with(fused_dconv);
+
+    return true;
+  }
+
+  bool visit(luci::CircleFullyConnected *node)
+  {
+    if (node->fusedActivationFunction() != luci::FusedActFunc::NONE and
+        node->fusedActivationFunction() != luci::FusedActFunc::RELU)
+      return false;
+
+    luci::CircleCustom *post_scale = nullptr;
+    bool multi_custom = false;
+    auto succs = loco::succs(node);
+    for (const auto succ : succs)
+    {
+      post_scale = to_scale(succ);
+      if (multi_custom && post_scale)
+      {
+        throw std::runtime_error("Do not allow multiple scales.");
+      }
+      if (post_scale)
+      {
+        multi_custom = true;
+      }
+    }
+    if (not post_scale)
+      return false;
+
+    auto param =
+      loco::must_cast<luci::CircleConst *>(post_scale->inputs(1)); // FIX_PostScale_UNLESS
+    auto filter = loco::must_cast<luci::CircleConst *>(node->weights());
+    auto bias = loco::must_cast<luci::CircleConst *>(node->bias());
+
+    uint32_t filter_o = filter->dim(0).value();
+    uint32_t filter_i = filter->dim(1).value();
+
+    const auto param_size = param->size<loco::DataType::FLOAT32>();
+    if (filter_o != param_size)
+    {
+      throw std::runtime_error("Mismatch between scale size and filter output channel size: " +
+                               std::to_string(filter_o) + " != " + std::to_string(param_size));
+    }
+    const auto bias_size = bias->size<loco::DataType::FLOAT32>();
+    if (bias_size != param_size)
+    {
+      throw std::runtime_error("Mismatch between scale size and bias size: " +
+                               std::to_string(bias_size) + " != " + std::to_string(param_size));
+    }
+
+    auto cloned_fc = luci::clone_node(node, node->graph());
+    assert(cloned_fc != nullptr); // FIX_CALLER_UNLESS
+    auto fused_fc = loco::must_cast<luci::CircleFullyConnected *>(cloned_fc);
+    auto fused_filter = luci::clone(filter);
+    auto fused_bias = luci::clone(bias);
+
+    fused_fc->name(node->name() + "_fused_" + random_str());
+    fused_filter->name(filter->name() + "_fused_" + random_str());
+    fused_bias->name(bias->name() + "_fused_" + random_str());
+
+    add_origin(fused_fc, luci::get_origin(node));
+    add_origin(fused_filter, luci::get_origin(filter));
+    add_origin(fused_bias, luci::get_origin(bias));
+
+    // Multiply param to weights
+    for (uint32_t o = 0; o < filter_o; o++)
+    {
+      float scale = param->at<loco::DataType::FLOAT32>(o);
+      assert(scale > 0.0); // Defensive guard
+      for (uint32_t i = 0; i < filter_i; i++)
+      {
+        uint32_t offset = o * filter_i + i;
+
+        fused_filter->at<loco::DataType::FLOAT32>(offset) =
+          fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
+      }
+    }
+
+    // Multiply param to bias
+    for (uint32_t c = 0; c < filter_o; ++c)
+    {
+      float scale = param->at<loco::DataType::FLOAT32>(c);
+      fused_bias->at<loco::DataType::FLOAT32>(c) =
+        fused_bias->at<loco::DataType::FLOAT32>(c) * scale;
+    }
+
+    fused_fc->input(node->input());
+    fused_fc->weights(fused_filter);
+    fused_fc->bias(fused_bias);
+
+    loco::replace(post_scale).with(fused_fc);
+
+    return true;
+  }
+
+  bool visit(luci::CircleInstanceNorm *node)
+  {
+    if (node->fusedActivationFunction() != luci::FusedActFunc::NONE and
+        node->fusedActivationFunction() != luci::FusedActFunc::RELU)
+      return false;
+
+    luci::CircleCustom *post_scale = nullptr;
+    bool multi_custom = false;
+    auto succs = loco::succs(node);
+    for (const auto succ : succs)
+    {
+      post_scale = to_scale(succ);
+      if (multi_custom && post_scale)
+      {
+        throw std::runtime_error("Do not allow multiple scales.");
+      }
+      if (post_scale)
+      {
+        multi_custom = true;
+      }
+    }
+    if (not post_scale)
+      return false;
+
+    auto param =
+      loco::must_cast<luci::CircleConst *>(post_scale->inputs(1)); // FIX_PostScale_UNLESS
+    auto gamma = loco::must_cast<luci::CircleConst *>(node->gamma());
+    auto beta = loco::must_cast<luci::CircleConst *>(node->beta());
+
+    const auto gamma_size = gamma->size<loco::DataType::FLOAT32>();
+    const auto beta_size = beta->size<loco::DataType::FLOAT32>();
+    assert(gamma_size == beta_size);
+    const auto param_size = param->size<loco::DataType::FLOAT32>();
+    if (gamma_size != param_size)
+    {
+      throw std::runtime_error("Mismatch between scale size and gamma size: " +
+                               std::to_string(gamma_size) + " != " + std::to_string(param_size));
+    }
+
+    auto cloned_instnorm = luci::clone_node(node, node->graph());
+    assert(cloned_instnorm != nullptr); // FIX_CALLER_UNLESS
+    auto fused_instnorm = loco::must_cast<luci::CircleInstanceNorm *>(cloned_instnorm);
+    auto fused_gamma = luci::clone(gamma);
+    auto fused_beta = luci::clone(beta);
+
+    fused_instnorm->name(node->name() + "_fused_" + random_str());
+    fused_gamma->name(gamma->name() + "_fused_" + random_str());
+    fused_beta->name(beta->name() + "_fused_" + random_str());
+
+    add_origin(fused_instnorm, luci::get_origin(node));
+    add_origin(fused_gamma, luci::get_origin(gamma));
+    add_origin(fused_beta, luci::get_origin(beta));
+
+    // Multiply param to gamma and beta
+    for (uint32_t idx = 0; idx < gamma_size; idx++)
+    {
+      float scale = param->at<loco::DataType::FLOAT32>(idx);
+      assert(scale > 0.0); // Defensive guard
+
+      fused_gamma->at<loco::DataType::FLOAT32>(idx) =
+        fused_gamma->at<loco::DataType::FLOAT32>(idx) * scale;
+      fused_beta->at<loco::DataType::FLOAT32>(idx) =
+        fused_beta->at<loco::DataType::FLOAT32>(idx) * scale;
+    }
+
+    fused_instnorm->input(node->input());
+    fused_instnorm->gamma(fused_gamma);
+    fused_instnorm->beta(fused_beta);
+
+    loco::replace(post_scale).with(fused_instnorm);
+
+    return true;
+  }
+
+  bool visit(luci::CircleTransposeConv *node)
+  {
+    luci::CircleCustom *post_scale = nullptr;
+    bool multi_custom = false;
+    auto succs = loco::succs(node);
+    for (const auto succ : succs)
+    {
+      post_scale = to_scale(succ);
+      if (multi_custom && post_scale)
+      {
+        throw std::runtime_error("Do not allow multiple scales.");
+      }
+      if (post_scale)
+      {
+        multi_custom = true;
+      }
+    }
+    if (not post_scale)
+      return false;
+
+    auto param =
+      loco::must_cast<luci::CircleConst *>(post_scale->inputs(1)); // FIX_PostScale_UNLESS
+    auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
+    auto bias = dynamic_cast<luci::CircleConst *>(node->bias());
+    // Non-const bias is not supported
+    if (not bias)
+    {
+      if (nullptr == dynamic_cast<luci::CircleOutputExclude *>(node->bias()))
+        return false;
+    }
+
+    uint32_t filter_o = filter->dim(0).value();
+    uint32_t filter_h = filter->dim(1).value();
+    uint32_t filter_w = filter->dim(2).value();
+    uint32_t filter_i = filter->dim(3).value();
+
+    if (filter_o != param->size<loco::DataType::FLOAT32>())
+    {
+      throw std::runtime_error(
+        "Mismatch between scale size and filter output channel size: " + std::to_string(filter_o) +
+        " != " + std::to_string(param->size<loco::DataType::FLOAT32>()));
+    }
+
+    auto cloned_tconv = luci::clone_node(node, node->graph());
+    assert(cloned_tconv != nullptr); // FIX_CALLER_UNLESS
+    auto fused_tconv = loco::must_cast<luci::CircleTransposeConv *>(cloned_tconv);
+    auto fused_filter = luci::clone(filter);
+
+    fused_tconv->name(node->name() + "_fused_" + random_str());
+    fused_filter->name(filter->name() + "_fused_" + random_str());
+
+    add_origin(fused_tconv, luci::get_origin(node));
+    add_origin(fused_filter, luci::get_origin(filter));
+
+    // Multiply param to weights
+    for (uint32_t c = 0; c < filter_o; c++)
+    {
+      float scale = param->at<loco::DataType::FLOAT32>(c);
+      assert(scale > 0.0); // Defensive guard
+
+      for (uint32_t h = 0; h < filter_h; h++)
+      {
+        for (uint32_t w = 0; w < filter_w; w++)
+        {
+          for (uint32_t b = 0; b < filter_i; b++)
+          {
+            uint32_t offset =
+              c * filter_h * filter_w * filter_i + h * filter_w * filter_i + w * filter_i + b;
+
+            fused_filter->at<loco::DataType::FLOAT32>(offset) =
+              fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
+          }
+        }
+      }
+    }
+
+    if (bias)
+    {
+      auto fused_bias = luci::clone(bias);
+      fused_bias->name(bias->name() + "_fused_" + random_str());
+      add_origin(fused_bias, luci::get_origin(bias));
 
       // Multiply param to bias
       for (uint32_t c = 0; c < filter_o; ++c)
@@ -191,108 +474,16 @@ struct FusePostScale final : public luci::CircleNodeMutableVisitor<bool>
         fused_bias->at<loco::DataType::FLOAT32>(c) =
           fused_bias->at<loco::DataType::FLOAT32>(c) * scale;
       }
-
-      fused_conv->input(node->input());
-      fused_conv->filter(fused_filter);
-      fused_conv->bias(fused_bias);
-
-      loco::replace(post_scale).with(fused_conv);
-      changed = true;
+      fused_tconv->bias(fused_bias);
     }
 
-    return changed;
-  }
+    fused_tconv->outBackprop(node->outBackprop());
+    fused_tconv->filter(fused_filter);
+    fused_tconv->inputSizes(node->inputSizes());
 
-  bool visit(luci::CircleTransposeConv *node)
-  {
-    bool changed = false;
+    loco::replace(post_scale).with(fused_tconv);
 
-    for (auto succ : loco::succs(node))
-    {
-      auto post_scale = to_post_scale(succ);
-      if (not post_scale)
-        continue;
-
-      auto param =
-        loco::must_cast<luci::CircleConst *>(post_scale->inputs(1)); // FIX_PostScale_UNLESS
-      auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
-      auto bias = dynamic_cast<luci::CircleConst *>(node->bias());
-      // Non-const bias is not supported
-      if (not bias)
-      {
-        if (nullptr == dynamic_cast<luci::CircleOutputExclude *>(node->bias()))
-          continue;
-      }
-
-      uint32_t filter_o = filter->dim(0).value();
-      uint32_t filter_h = filter->dim(1).value();
-      uint32_t filter_w = filter->dim(2).value();
-      uint32_t filter_i = filter->dim(3).value();
-
-      if (filter_o != param->size<loco::DataType::FLOAT32>())
-      {
-        assert(false); // FIX_PostScale_Unless
-        return false;
-      }
-
-      auto cloned_tconv = luci::clone_node(node, node->graph());
-      assert(cloned_tconv != nullptr); // FIX_CALLER_UNLESS
-      auto fused_tconv = loco::must_cast<luci::CircleTransposeConv *>(cloned_tconv);
-      auto fused_filter = luci::clone(filter);
-
-      fused_tconv->name(node->name() + "_postscale_" + random_str());
-      fused_filter->name(filter->name() + "_postscale_" + random_str());
-
-      add_origin(fused_tconv, luci::get_origin(node));
-      add_origin(fused_filter, luci::get_origin(filter));
-
-      // Multiply param to weights
-      for (uint32_t c = 0; c < filter_o; c++)
-      {
-        float scale = param->at<loco::DataType::FLOAT32>(c);
-        assert(scale > 0.0); // Defensive guard
-
-        for (uint32_t h = 0; h < filter_h; h++)
-        {
-          for (uint32_t w = 0; w < filter_w; w++)
-          {
-            for (uint32_t b = 0; b < filter_i; b++)
-            {
-              uint32_t offset =
-                c * filter_h * filter_w * filter_i + h * filter_w * filter_i + w * filter_i + b;
-
-              fused_filter->at<loco::DataType::FLOAT32>(offset) =
-                fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
-            }
-          }
-        }
-      }
-
-      if (bias)
-      {
-        auto fused_bias = luci::clone(bias);
-        fused_bias->name(bias->name() + "_postscale_" + random_str());
-        add_origin(fused_bias, luci::get_origin(bias));
-
-        // Multiply param to bias
-        for (uint32_t c = 0; c < filter_o; ++c)
-        {
-          float scale = param->at<loco::DataType::FLOAT32>(c);
-          fused_bias->at<loco::DataType::FLOAT32>(c) =
-            fused_bias->at<loco::DataType::FLOAT32>(c) * scale;
-        }
-        fused_tconv->bias(fused_bias);
-      }
-
-      fused_tconv->outBackprop(node->outBackprop());
-      fused_tconv->filter(fused_filter);
-      fused_tconv->inputSizes(node->inputSizes());
-
-      loco::replace(post_scale).with(fused_tconv);
-      changed = true;
-    }
-
-    return changed;
+    return true;
   }
 };
 

--- a/compiler/fme-apply/src/pass/FusePostScalePass.h
+++ b/compiler/fme-apply/src/pass/FusePostScalePass.h
@@ -25,25 +25,18 @@ namespace fme_apply
 {
 
 /**
- * @brief Pass to fuse CircleCustom(PostScale) to preceding Ops
+ * @brief Pass to fuse CircleCustom(PostScale) to succeeding Ops
  *
  * BEFORE
  *
- *             [Node1]
- *               |
- *              [Op]
- *             /    \
- *    [PostScale]    [Node2]
+ *         [Node]
+ *           |
+ *       [PostScale]
  *
  * AFTER
  *
- *       [Node1]
- *        /  \
- *    [Op']   [Op]
- *              |
- *            [Node2]
+ *        [Node'] (Weights are updated)
  *
- * NOTE Op' is clone of Op with updated weights/bias.
  */
 class FusePostScalePass : public logo::Pass
 {

--- a/compiler/fme-apply/src/pass/FusePostScalePass.test.cpp
+++ b/compiler/fme-apply/src/pass/FusePostScalePass.test.cpp
@@ -83,7 +83,7 @@ public:
     _postscale->inputs(
       1, create_const_node(g, loco::DataType::FLOAT32, {3} /* shape */, {2, 2, 2} /* value */));
     _postscale->shape({1, 4, 4, 3});
-    _postscale->custom_code("PostScale");
+    _postscale->custom_code("scale");
     _postscale->name("postscale");
   }
 
@@ -140,7 +140,7 @@ public:
     _postscale->inputs(
       1, create_const_node(g, loco::DataType::FLOAT32, {3} /* shape */, {2, 2, 2} /* value */));
     _postscale->shape({1, 4, 4, 3});
-    _postscale->custom_code("PostScale");
+    _postscale->custom_code("scale");
     _postscale->name("postscale");
   }
 
@@ -196,7 +196,7 @@ public:
     _postscale->inputs(
       1, create_const_node(g, loco::DataType::FLOAT32, {3} /* shape */, {2, 2, 2} /* value */));
     _postscale->shape({1, 4, 4, 3});
-    _postscale->custom_code("PostScale");
+    _postscale->custom_code("scale");
     _postscale->name("postscale");
   }
 

--- a/compiler/fme-apply/src/pass/FusePreScalePass.cpp
+++ b/compiler/fme-apply/src/pass/FusePreScalePass.cpp
@@ -35,13 +35,12 @@ struct FusePreScale final : public luci::CircleNodeMutableVisitor<bool>
 
   bool visit(luci::CircleConv2D *node)
   {
-    auto pre_scale = to_pre_scale(node->input());
+    auto pre_scale = to_scale(node->input());
     if (not pre_scale)
       return false;
 
     auto param = loco::must_cast<luci::CircleConst *>(pre_scale->inputs(1)); // FIX_PreScale_UNLESS
     auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
-    auto bias = loco::must_cast<luci::CircleConst *>(node->bias());
 
     uint32_t filter_o = filter->dim(0).value();
     uint32_t filter_h = filter->dim(1).value();
@@ -50,12 +49,13 @@ struct FusePreScale final : public luci::CircleNodeMutableVisitor<bool>
 
     if (filter_i != param->size<loco::DataType::FLOAT32>())
     {
-      assert(false); // FIX_PreScale_Unless
-      return false;
+      throw std::runtime_error(
+        "Mismatch between scale size and filter input channel size: " + std::to_string(filter_i) +
+        " != " + std::to_string(param->size<loco::DataType::FLOAT32>()));
     }
 
     auto fused_filter = luci::clone(filter);
-    fused_filter->name(filter->name() + "_prescale");
+    fused_filter->name(filter->name() + "_fused");
     add_origin(fused_filter, luci::get_origin(filter));
 
     // Multiply param to weights
@@ -85,60 +85,9 @@ struct FusePreScale final : public luci::CircleNodeMutableVisitor<bool>
     return true;
   }
 
-  bool visit(luci::CircleTransposeConv *node)
-  {
-    auto pre_scale = to_pre_scale(node->outBackprop());
-    if (not pre_scale)
-      return false;
-
-    auto param = loco::must_cast<luci::CircleConst *>(pre_scale->inputs(1)); // FIX_PreScale_UNLESS
-    auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
-
-    uint32_t filter_o = filter->dim(0).value();
-    uint32_t filter_h = filter->dim(1).value();
-    uint32_t filter_w = filter->dim(2).value();
-    uint32_t filter_i = filter->dim(3).value();
-
-    if (filter_i != param->size<loco::DataType::FLOAT32>())
-    {
-      assert(false); // FIX_PreScale_Unless
-      return false;
-    }
-
-    auto fused_filter = luci::clone(filter);
-    fused_filter->name(filter->name() + "_prescale");
-    add_origin(fused_filter, luci::get_origin(filter));
-
-    // Multiply param to weights
-    for (uint32_t c = 0; c < filter_o; c++)
-    {
-      for (uint32_t h = 0; h < filter_h; h++)
-      {
-        for (uint32_t w = 0; w < filter_w; w++)
-        {
-          for (uint32_t b = 0; b < filter_i; b++)
-          {
-            uint32_t offset =
-              c * filter_h * filter_w * filter_i + h * filter_w * filter_i + w * filter_i + b;
-            float scale = param->at<loco::DataType::FLOAT32>(b);
-            assert(scale > 0.0); // Defensive guard
-
-            fused_filter->at<loco::DataType::FLOAT32>(offset) =
-              fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
-          }
-        }
-      }
-    }
-
-    node->outBackprop(pre_scale->inputs(0));
-    node->filter(fused_filter);
-
-    return true;
-  }
-
   bool visit(luci::CircleDepthwiseConv2D *node)
   {
-    auto pre_scale = to_pre_scale(node->input());
+    auto pre_scale = to_scale(node->input());
     if (not pre_scale)
       return false;
 
@@ -152,8 +101,9 @@ struct FusePreScale final : public luci::CircleNodeMutableVisitor<bool>
 
     if (in_channel != param->size<loco::DataType::FLOAT32>())
     {
-      assert(false); // FIX_PreScale_Unless
-      return false;
+      throw std::runtime_error(
+        "Mismatch between scale size and filter input channel size: " + std::to_string(in_channel) +
+        " != " + std::to_string(param->size<loco::DataType::FLOAT32>()));
     }
 
     assert(in_channel * depth_multiplier == out_channel); // FIX_ME_UNLESS
@@ -193,6 +143,101 @@ struct FusePreScale final : public luci::CircleNodeMutableVisitor<bool>
     }
 
     node->input(pre_scale->inputs(0));
+    node->filter(fused_filter);
+
+    return true;
+  }
+
+  bool visit(luci::CircleFullyConnected *node)
+  {
+    auto pre_scale = to_scale(node->input());
+    if (not pre_scale)
+      return false;
+
+    auto param = loco::must_cast<luci::CircleConst *>(pre_scale->inputs(1)); // FIX_PreScale_UNLESS
+    auto filter = loco::must_cast<luci::CircleConst *>(node->weights());
+
+    uint32_t filter_o = filter->dim(0).value();
+    uint32_t filter_i = filter->dim(1).value();
+
+    if (filter_i != param->size<loco::DataType::FLOAT32>())
+    {
+      throw std::runtime_error(
+        "Mismatch between scale size and filter input channel size: " + std::to_string(filter_i) +
+        " != " + std::to_string(param->size<loco::DataType::FLOAT32>()));
+    }
+
+    auto fused_filter = luci::clone(filter);
+    fused_filter->name(filter->name() + "_fused");
+    add_origin(fused_filter, luci::get_origin(filter));
+
+    // Multiply param to weights
+    for (uint32_t o = 0; o < filter_o; o++)
+    {
+      for (uint32_t i = 0; i < filter_i; i++)
+      {
+        uint32_t offset = o * filter_i + i;
+        float scale = param->at<loco::DataType::FLOAT32>(i);
+        assert(scale > 0.0); // Defensive guard
+
+        fused_filter->at<loco::DataType::FLOAT32>(offset) =
+          fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
+      }
+    }
+
+    node->input(pre_scale->inputs(0));
+    node->weights(fused_filter);
+
+    return true;
+  }
+
+  bool visit(luci::CircleTransposeConv *node)
+  {
+    auto pre_scale = to_scale(node->outBackprop());
+    if (not pre_scale)
+      return false;
+
+    auto param = loco::must_cast<luci::CircleConst *>(pre_scale->inputs(1)); // FIX_PreScale_UNLESS
+    auto filter = loco::must_cast<luci::CircleConst *>(node->filter());
+
+    uint32_t filter_o = filter->dim(0).value();
+    uint32_t filter_h = filter->dim(1).value();
+    uint32_t filter_w = filter->dim(2).value();
+    uint32_t filter_i = filter->dim(3).value();
+
+    if (filter_i != param->size<loco::DataType::FLOAT32>())
+    {
+      throw std::runtime_error(
+        "Mismatch between scale size and filter input channel size: " + std::to_string(filter_i) +
+        " != " + std::to_string(param->size<loco::DataType::FLOAT32>()));
+    }
+
+    auto fused_filter = luci::clone(filter);
+    fused_filter->name(filter->name() + "_fused");
+    add_origin(fused_filter, luci::get_origin(filter));
+
+    // Multiply param to weights
+    for (uint32_t c = 0; c < filter_o; c++)
+    {
+      for (uint32_t h = 0; h < filter_h; h++)
+      {
+        for (uint32_t w = 0; w < filter_w; w++)
+        {
+          for (uint32_t b = 0; b < filter_i; b++)
+          {
+            uint32_t offset =
+              c * filter_h * filter_w * filter_i + h * filter_w * filter_i + w * filter_i + b;
+            float scale = param->at<loco::DataType::FLOAT32>(b);
+            assert(scale > 0.0); // Defensive guard
+
+            fused_filter->at<loco::DataType::FLOAT32>(offset) =
+              fused_filter->at<loco::DataType::FLOAT32>(offset) * scale;
+          }
+        }
+      }
+    }
+
+    node->outBackprop(pre_scale->inputs(0));
     node->filter(fused_filter);
 
     return true;

--- a/compiler/fme-apply/src/pass/FusePreScalePass.h
+++ b/compiler/fme-apply/src/pass/FusePreScalePass.h
@@ -25,21 +25,17 @@ namespace fme_apply
 {
 
 /**
- * @brief Pass to fuse CircleCustom(PreScale) to succeeding Ops
+ * @brief Pass to fuse CircleCustom(PreScale) to preceding Ops
  *
  * BEFORE
  *
- *      [Node]
- *        |
  *    [PreScale]
  *        |
- *       [Op]
+ *      [Node]
  *
  * AFTER
  *
- *      [Node]
- *        |
- *      [Op'] (Weights are updated)
+ *     [Node'] (Weights are updated)
  *
  */
 class FusePreScalePass : public logo::Pass

--- a/compiler/fme-apply/src/pass/FusePreScalePass.test.cpp
+++ b/compiler/fme-apply/src/pass/FusePreScalePass.test.cpp
@@ -69,7 +69,7 @@ public:
     _prescale->inputs(
       1, create_const_node(g, loco::DataType::FLOAT32, {3} /* shape */, {2, 2, 2} /* value */));
     _prescale->shape({1, 4, 4, 3});
-    _prescale->custom_code("PreScale");
+    _prescale->custom_code("scale");
     _prescale->name("prescale");
 
     std::vector<float> filter_val(3 * 3 * 3 * 3 /* size */, 1.0 /*value */);
@@ -126,7 +126,7 @@ public:
     _prescale->inputs(
       1, create_const_node(g, loco::DataType::FLOAT32, {3} /* shape */, {2, 2, 2} /* value */));
     _prescale->shape({1, 4, 4, 3});
-    _prescale->custom_code("PreScale");
+    _prescale->custom_code("scale");
     _prescale->name("prescale");
 
     std::vector<float> filter_val(3 * 3 * 3 * 3 /* size */, 1.0 /*value */);
@@ -182,7 +182,7 @@ public:
     _prescale->inputs(
       1, create_const_node(g, loco::DataType::FLOAT32, {3} /* shape */, {2, 2, 2} /* value */));
     _prescale->shape({1, 4, 4, 3});
-    _prescale->custom_code("PreScale");
+    _prescale->custom_code("scale");
     _prescale->name("prescale");
 
     std::vector<float> filter_val(1 * 3 * 3 * 3 /* size */, 1.0 /*value */);
@@ -235,7 +235,7 @@ TEST(FusePreScalePassTest, prescale_conv)
   auto conv = dynamic_cast<luci::CircleConv2D *>(g.output()->from());
   EXPECT_NE(nullptr, conv);
 
-  auto pre_scale = to_pre_scale(conv->input());
+  auto pre_scale = to_scale(conv->input());
   EXPECT_EQ(nullptr, pre_scale); // No pre_scale
 
   // Check weights
@@ -270,7 +270,7 @@ TEST(FusePreScalePassTest, prescale_tconv)
   auto tconv = dynamic_cast<luci::CircleTransposeConv *>(g.output()->from());
   EXPECT_NE(nullptr, tconv);
 
-  auto pre_scale = to_pre_scale(tconv->outBackprop());
+  auto pre_scale = to_scale(tconv->outBackprop());
   EXPECT_EQ(nullptr, pre_scale); // No pre_scale
 
   // Check weights
@@ -305,7 +305,7 @@ TEST(FusePreScalePassTest, prescale_dconv)
   auto dconv = dynamic_cast<luci::CircleDepthwiseConv2D *>(g.output()->from());
   EXPECT_NE(nullptr, dconv);
 
-  auto pre_scale = to_pre_scale(dconv->input());
+  auto pre_scale = to_scale(dconv->input());
   EXPECT_EQ(nullptr, pre_scale); // No pre_scale
 
   // Check weights


### PR DESCRIPTION
This commit revises overall codes.

- Remove shift and Add act_scale.
- Add smooth quant algorithm.
- Find front node in person instead of forwarding scale node.
- Support more ops in fusion passes. 

Draft: #13659
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>