### PR TITLE
[nnpackage, res] Removed activation function from RmsNorm schema

### DIFF
--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -1523,7 +1523,6 @@ table InstanceNormOptions {
 
 table RmsNormOptions {
   epsilon:float;
-  fused_activation_function:ActivationFunctionType;
 }
 
 // An OperatorCode can be an enum value (BuiltinOperator) if the operator is a

--- a/res/CircleSchema/0.9/circle_schema.fbs
+++ b/res/CircleSchema/0.9/circle_schema.fbs
@@ -1523,7 +1523,6 @@ table InstanceNormOptions {
 
 table RmsNormOptions {
   epsilon:float;
-  fused_activation_function:ActivationFunctionType;
 }
 
 // An OperatorCode can be an enum value (BuiltinOperator) if the operator is a


### PR DESCRIPTION
This commit removes "activation function" from RmsNorm parameter schema.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967