### PR TITLE
[DRAFT][luci/service] Support dynamic shape inference for reshape

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -20,30 +20,6 @@
 #include "CircleShapeInferenceHelper.h"
 #include "CircleCloneNode.h"
 
-#include <luci/Log.h>
-
-namespace
-{
-
-std::ostream &operator<<(std::ostream &os, const loco::TensorShape &tensor_shape)
-{
-  os << "[";
-  for (uint32_t r = 0; r < tensor_shape.rank(); ++r)
-  {
-    if (r)
-      os << ",";
-
-    if (tensor_shape.dim(r).known())
-      os << tensor_shape.dim(r).value();
-    else
-      os << "?";
-  }
-  os << "]";
-  return os;
-}
-
-} // namespace
-
 namespace luci
 {
 
@@ -65,93 +41,121 @@ luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleReshape *node)
 namespace sinf
 {
 
+/**
+ * @note  CircleReshape always has two inputs: `tensor` and `shape`.
+ *        The `shape` input can be CircleConst, CircleOutputDummy, or CircleNode.
+ *        - If the `shape` input is CircleConst, the shape is inferred from the constant.
+ *        - If the `shape` input is CircleOutputDummy, the shape is inferred from
+ *          the attribute if it exists. If the attribute does not exist,
+ *          the shape is inferred from the node iteself.
+ *        - If the `shape` input is CircleNode, the dynamic shape is propagated.
+ */
 loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
 {
-  LOGGER(l);
-
   const loco::DataType S32 = loco::DataType::S32;
 
-  loco::TensorShape shape_by_input;
+  // CircleReshape node must have `shape` input
+  LUCI_ASSERT(node->shape(), "2nd input shape() should not be nullptr");
+
+  bool should_infer = true;
+  loco::TensorShape output_shape;
   {
-    LUCI_ASSERT(node->shape(), "2nd input shape() should not be nullptr");
-
-    // Only support node's shape() is CircleConst with S32
-    // TODO support other node with other types
-    auto const_shape_node = dynamic_cast<luci::CircleConst *>(node->shape());
-    if (const_shape_node != nullptr)
+    // Check if `shape` is CircleConst
+    auto const_shape = dynamic_cast<luci::CircleConst *>(node->shape());
+    if (const_shape != nullptr)
     {
-      LUCI_ASSERT(const_shape_node->dtype() == S32, "Only support int32 CircleConst");
+      LUCI_ASSERT(const_shape->dtype() == S32, "Only support int32 CircleConst");
+      output_shape.rank(const_shape->size<S32>());
 
-      shape_by_input.rank(const_shape_node->size<S32>());
-
-      for (uint32_t axis = 0; axis < shape_by_input.rank(); ++axis)
+      for (uint32_t axis = 0; axis < output_shape.rank(); ++axis)
       {
-        shape_by_input.dim(axis) = const_shape_node->at<S32>(axis);
+        output_shape.dim(axis) = const_shape->at<S32>(axis);
+        if (const_shape->at<S32>(axis) < 0)
+        {
+          output_shape.dim(axis).unset();
+        }
       }
     }
     else
     {
-      // We use shape from the node itself
-      loco::TensorShape shape;
-      shape.rank(node->rank());
-      for (uint32_t r = 0; r < node->rank(); ++r)
+      // Check if `shape` is CircleOutputDummy
+      auto dummy_shape = dynamic_cast<luci::CircleOutputDummy *>(node->shape());
+      if (dummy_shape != nullptr)
       {
-        // TODO remove this copy from `use_own(node);`
-        // Shape inference rules in this file did not consider unknown dimension.
-        // If some node has unknown dimension, 0 is inserted and wrong shape
-        // inference was done as a result.
-        // To fix this, new shape inference algorithm is being implemented.
-        // Until new inference algorithm is fully implemented, unknown dimension
-        // would be represented as 1 along with TFLite expression.
-        shape.dim(r) = node->dim(r).known() ? node->dim(r).value() : 1;
+        if (node->newShape()->rank() > 0)
+        {
+          output_shape.rank(node->newShape()->rank());
+
+          for (uint32_t axis = 0; axis < output_shape.rank(); ++axis)
+          {
+            output_shape.dim(axis) = node->newShape()->dim(axis);
+            if (node->newShape()->dim(axis) < 0)
+            {
+              output_shape.dim(axis).unset();
+            }
+          }
+        }
+        else
+        {
+          output_shape = circle_shape(node);
+        }
       }
-      shape_by_input = shape;
+      else
+      {
+        // Check if `shape` is CircleNode
+        auto node_shape = dynamic_cast<luci::CircleNode *>(node->shape());
+        if (node_shape != nullptr)
+        {
+          output_shape.rank(node_shape->dim(0).value());
+
+          for (uint32_t axis = 0; axis < output_shape.rank(); ++axis)
+          {
+            output_shape.dim(axis).unset();
+          }
+
+          should_infer = false;
+        }
+      }
     }
   }
 
-  loco::TensorShape shape_by_attr;
-  {
-    shape_by_attr.rank(node->newShape()->rank());
-
-    for (uint32_t axis = 0; axis < shape_by_attr.rank(); ++axis)
-    {
-      shape_by_attr.dim(axis) = node->newShape()->dim(axis);
-    }
-  }
-
-  if (!(shape_by_input == shape_by_attr))
-  {
-    INFO(l) << "CircleReshape: Two new shape information mismatched : " << std::endl;
-    INFO(l) << "   shape_by_input : " << shape_by_input << std::endl;
-    INFO(l) << "   shape_by_attr : " << shape_by_attr << std::endl;
-  }
-
-  loco::TensorShape output_shape = shape_by_input;
-
-  // One of the dimensions can have special value -1, meaning its actual value should be inferred.
   const auto input = loco::must_cast<luci::CircleNode *>(node->tensor());
   const auto input_shape = circle_shape(input);
   uint32_t input_element_count = 1;
-  uint32_t output_element_count = 1;
-  uint32_t unknown_dim_index = UINT32_MAX;
-  for (uint32_t i = 0; i < input_shape.rank(); ++i)
-    input_element_count *= (input_shape.dim(i).known() ? input_shape.dim(i).value() : 1);
-  for (uint32_t dim_index = 0; dim_index < output_shape.rank(); ++dim_index)
+  for (uint32_t axis = 0; axis < input_shape.rank(); ++axis)
   {
-    const uint32_t dim_value = output_shape.dim(dim_index).value();
-    if (static_cast<int>(dim_value) == -1)
+    if (input_shape.dim(axis).known())
     {
-      LUCI_ASSERT(unknown_dim_index == UINT32_MAX, "More than one unknown dimension");
-      unknown_dim_index = dim_index;
+      input_element_count *= input_shape.dim(axis).value();
     }
     else
     {
-      output_element_count *= dim_value;
+      should_infer = false;
+      break;
     }
   }
-  if (unknown_dim_index != UINT32_MAX)
+
+  if (should_infer)
   {
-    output_shape.dim(unknown_dim_index) = input_element_count / output_element_count;
+    uint32_t output_element_count = 1;
+    uint32_t unknown_dim_index = UINT32_MAX;
+    for (uint32_t dim_index = 0; dim_index < output_shape.rank(); ++dim_index)
+    {
+      if (output_shape.dim(dim_index).known() == false)
+      {
+        LUCI_ASSERT(unknown_dim_index == UINT32_MAX, "More than one unknown dimension");
+        unknown_dim_index = dim_index;
+      }
+      else
+      {
+        const uint32_t dim_value = output_shape.dim(dim_index).value();
+        output_element_count *= dim_value;
+      }
+    }
+    if (unknown_dim_index != UINT32_MAX)
+    {
+      output_shape.dim(unknown_dim_index) = input_element_count / output_element_count;
+    }
   }
 
   return output_shape;

--- a/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
@@ -39,7 +39,125 @@ TEST(CloneNodeTest, clone_Reshape)
   ASSERT_EQ(node_reshape->newShape()->dim(1), cloned_reshape->newShape()->dim(1));
 }
 
-TEST(ShapeRuleTest, reshape_by_input_const_static)
+TEST(ShapeRuleTest, reshape_by_circle_const)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  auto tensor_input = g->nodes()->create<luci::CircleInput>();
+  auto shape_input = g->nodes()->create<luci::CircleConst>();
+
+  tensor_input->dtype(loco::DataType::S32);
+  tensor_input->shape({2, 3, 4});
+  tensor_input->shape_status(luci::ShapeStatus::VALID);
+
+  shape_input->dtype(loco::DataType::S32);
+  shape_input->size<loco::DataType::S32>(2);
+  shape_input->at<loco::DataType::S32>(0) = -1;
+  shape_input->at<loco::DataType::S32>(1) = 4;
+  shape_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_reshape->tensor(tensor_input);
+  node_reshape->shape(shape_input);
+
+  loco::TensorShape output_shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(node_reshape, output_shape));
+
+  ASSERT_EQ(2, output_shape.rank());
+  ASSERT_TRUE(output_shape.dim(0).known());
+  ASSERT_TRUE(output_shape.dim(1).known());
+  ASSERT_EQ(6, output_shape.dim(0).value());
+  ASSERT_EQ(4, output_shape.dim(1).value());
+}
+
+TEST(ShapeRuleTest, reshape_by_circle_dummy)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  auto tensor_input = g->nodes()->create<luci::CircleInput>();
+  auto shape_input = g->nodes()->create<luci::CircleOutputDummy>();
+
+  tensor_input->dtype(loco::DataType::S32);
+  tensor_input->shape({2, 3, 4});
+  tensor_input->shape_status(luci::ShapeStatus::VALID);
+
+  shape_input->dtype(loco::DataType::S32);
+  shape_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_reshape->tensor(tensor_input);
+  node_reshape->shape(shape_input);
+  node_reshape->newShape()->rank(2);
+  node_reshape->newShape()->dim(0) = -1;
+  node_reshape->newShape()->dim(1) = 4;
+
+  loco::TensorShape output_shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(node_reshape, output_shape));
+
+  ASSERT_EQ(2, output_shape.rank());
+  ASSERT_TRUE(output_shape.dim(0).known());
+  ASSERT_TRUE(output_shape.dim(1).known());
+  ASSERT_EQ(6, output_shape.dim(0).value());
+  ASSERT_EQ(4, output_shape.dim(1).value());
+}
+
+TEST(ShapeRuleTest, reshape_by_circle_node)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  auto tensor_input = g->nodes()->create<luci::CircleInput>();
+  auto shape_input = g->nodes()->create<luci::CircleInput>();
+
+  tensor_input->dtype(loco::DataType::S32);
+  tensor_input->shape({2, 3, 4});
+  tensor_input->shape_status(luci::ShapeStatus::VALID);
+
+  shape_input->dtype(loco::DataType::S32);
+  shape_input->shape({2});
+  shape_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_reshape->tensor(tensor_input);
+  node_reshape->shape(shape_input);
+
+  loco::TensorShape output_shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(node_reshape, output_shape));
+
+  ASSERT_EQ(2, output_shape.rank());
+  ASSERT_FALSE(output_shape.dim(0).known());
+  ASSERT_FALSE(output_shape.dim(1).known());
+}
+
+TEST(ShapeRuleTest, reshape_input_tensor_undefined_NEG)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  auto tensor_input = g->nodes()->create<luci::CircleInput>();
+  auto shape_by_input = g->nodes()->create<luci::CircleConst>();
+
+  tensor_input->dtype(loco::DataType::S32);
+  tensor_input->shape({2, 3, 4});
+  tensor_input->shape_status(luci::ShapeStatus::UNDEFINED);
+
+  shape_by_input->dtype(loco::DataType::S32);
+  shape_by_input->size<loco::DataType::S32>(2);
+  shape_by_input->at<loco::DataType::S32>(0) = 6;
+  shape_by_input->at<loco::DataType::S32>(1) = 4;
+  shape_by_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_reshape->tensor(tensor_input);
+  node_reshape->shape(shape_by_input);
+
+  loco::TensorShape output_shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_FALSE(shape_inf_rule.infer(node_reshape, output_shape));
+}
+
+TEST(ShapeRuleTest, reshape_input_shape_undefined_NEG)
 {
   auto g = loco::make_graph();
   auto node_reshape = g->nodes()->create<luci::CircleReshape>();
@@ -54,7 +172,7 @@ TEST(ShapeRuleTest, reshape_by_input_const_static)
   shape_by_input->size<loco::DataType::S32>(2);
   shape_by_input->at<loco::DataType::S32>(0) = 6;
   shape_by_input->at<loco::DataType::S32>(1) = 4;
-  shape_by_input->shape_status(luci::ShapeStatus::VALID);
+  shape_by_input->shape_status(luci::ShapeStatus::UNDEFINED);
 
   node_reshape->tensor(tensor_input);
   node_reshape->shape(shape_by_input);
@@ -62,43 +180,5 @@ TEST(ShapeRuleTest, reshape_by_input_const_static)
   loco::TensorShape output_shape;
   luci::sinf::Rule shape_inf_rule;
 
-  ASSERT_TRUE(shape_inf_rule.infer(node_reshape, output_shape));
-
-  ASSERT_EQ(2, output_shape.rank());
-  ASSERT_TRUE(output_shape.dim(0).known());
-  ASSERT_TRUE(output_shape.dim(1).known());
-  ASSERT_EQ(6, output_shape.dim(0).value());
-  ASSERT_EQ(4, output_shape.dim(1).value());
-}
-
-TEST(ShapeRuleTest, reshape_by_input_const_dynamic)
-{
-  auto g = loco::make_graph();
-  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
-  auto tensor_input = g->nodes()->create<luci::CircleInput>();
-  auto shape_by_input = g->nodes()->create<luci::CircleConst>();
-
-  tensor_input->dtype(loco::DataType::S32);
-  tensor_input->shape({2, 3, 4});
-  tensor_input->shape_status(luci::ShapeStatus::VALID);
-
-  shape_by_input->dtype(loco::DataType::S32);
-  shape_by_input->size<loco::DataType::S32>(2);
-  shape_by_input->at<loco::DataType::S32>(0) = -1;
-  shape_by_input->at<loco::DataType::S32>(1) = 4;
-  shape_by_input->shape_status(luci::ShapeStatus::VALID);
-
-  node_reshape->tensor(tensor_input);
-  node_reshape->shape(shape_by_input);
-
-  loco::TensorShape output_shape;
-  luci::sinf::Rule shape_inf_rule;
-
-  ASSERT_TRUE(shape_inf_rule.infer(node_reshape, output_shape));
-
-  ASSERT_EQ(2, output_shape.rank());
-  ASSERT_TRUE(output_shape.dim(0).known());
-  ASSERT_TRUE(output_shape.dim(1).known());
-  ASSERT_EQ(6, output_shape.dim(0).value());
-  ASSERT_EQ(4, output_shape.dim(1).value());
+  ASSERT_FALSE(shape_inf_rule.infer(node_reshape, output_shape));
 }


### PR DESCRIPTION
This commit supports dynamic shape inference for reshape operation

## Dynamic shape inference algorithm

_from: https://github.com/Samsung/ONE/issues/13927#issuecomment-2328295368, https://github.com/Samsung/ONE/issues/13927#issuecomment-2330856187_

- `CircleReshape` always has two inputs: `tensor` and `shape`.
  - otherwise, throw an error
- The `shape` input can be `CircleConst`, `CircleOutputDummy`, or `CircleNode`.
- When the `shape` input is `CircleConst`
  - The shape is inferred from the constant `shape`
  - `output_shape` would be static
  - e.g. `reshape(tensor, [2, 3]) --> [2, 3]`
- When the `shape` input is `CircleOutputDummy`
  - First, try to inference shape using node's attribute (`newShape`)
  - If there's no attribute (and no `shape` input), propagate the shape of node itself
- When the `shape` input is `CircleNode`
  - The shape is inferred by `shape` input's size (because the exact shape cannot be determined at compile time)
  - `output_shape` would be dynamic
  - e.g. `reshape(tensor, shape_node(with size 3)) --> [?, ?, ?]`
- If there is single unknown dimension in `output_shape` and input `tensor` is fully known, that dimension is inferred by the count of the elements

## When should not infer?

Unknown dimension of `output_shape` is NOT inferred (by the `should_infer`) when:
- the `shape` input is `CircleNode`. Because if it's not constant, the only thing we can infer at compile time is the size of dimensions.
- the `tensor` input is not fully known. Because shape inference of reshape is based on the sameness of elements count.

## Remaining `own_shape`?

_from: https://github.com/Samsung/ONE/pull/13935#discussion_r1753185943, https://github.com/Samsung/ONE/pull/13935#discussion_r1753123440_

The usage of `circle_shape` might seems to be remaining of `own_shape` which should be removed by the new shape inference algorithm.

First, this logic is used to support [this recipe](https://github.com/Samsung/ONE/blob/d8fa13140c8fc0413f5dbc7771f87a59d4f6067c/res/TensorFlowLiteRecipes/Reshape_003/test.recipe#L1-L18)(`Reshape_003`) which has **no attribute, no shape input**.
I've tried to revise this recipe according to [this comment](https://github.com/Samsung/ONE/issues/13927#issuecomment-2330871749), and have read the related PRs (https://github.com/Samsung/ONE/pull/1554, https://github.com/Samsung/ONE/issues/1519).
But it was hard to make a policy about **no attribute, no shape input** case.
So, we decided not to fix another code(importer, recipes) and do it best in shape inference logic.
As a result, I followed the suggestion from https://github.com/Samsung/ONE/issues/13927#issuecomment-2330856187.

## Neg test cases

_from: https://github.com/Samsung/ONE/issues/13977_

Some of the neg test cases might not directly related to the changes that have been made in this PR.
(which means the `false return` and `throws` are not made in `CircleReshape.cpp`.)
Please tell me if these are inappropriate. I'll remove them and open an separate issue.

---

Related: https://github.com/Samsung/ONE/issues/13927
Draft: https://github.com/Samsung/ONE/pull/13935
Depends on: https://github.com/Samsung/ONE/pull/13989

ONE-DCO-1.0-Signed-off-by: Jongwon Yang <yjw963@gmail.com>