### PR TITLE
[infra/onert] Rename onert library name

### DIFF
--- a/packaging/nnfw.pc.in
+++ b/packaging/nnfw.pc.in
@@ -1,5 +1,5 @@
 Name: nnfw
 Description: onert API
 Version: @version@
-Libs: -L@libdir@ -lnnfw-dev
+Libs: -L@libdir@ -lonert
 Cflags: -I@includedir@/nnfw

--- a/runtime/contrib/android/api/Prebuilt.mk
+++ b/runtime/contrib/android/api/Prebuilt.mk
@@ -7,10 +7,10 @@ endif
 
 # libnnfw
 include $(CLEAR_VARS)
-LOCAL_MODULE := nnfw-dev
-PREBUILT_LIB += nnfw-dev
+LOCAL_MODULE := onert
+PREBUILT_LIB += onert
 LOCAL_SRC_FILES := \
-		$(ONERT_PREBUILT_LIB_DIR)/libnnfw-dev.so
+		$(ONERT_PREBUILT_LIB_DIR)/libonert.so
 include $(PREBUILT_SHARED_LIBRARY)
 
 # libonert_core

--- a/runtime/onert/api/nnfw/CMakeLists.txt
+++ b/runtime/onert/api/nnfw/CMakeLists.txt
@@ -23,6 +23,7 @@ endif (ANDROID)
 target_include_directories(${ONERT_DEV} PUBLIC include)
 set_target_properties(${ONERT_DEV} PROPERTIES
   PUBLIC_HEADER "${NNFW_API_HEADERS}"
+  OUTPUT_NAME onert
   INSTALL_RPATH "$ORIGIN:$ORIGIN/nnfw")
 
 install(TARGETS ${ONERT_DEV}


### PR DESCRIPTION
This commit renames onert library name from `libnnfw-dev.so` to `libonert.so`.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>