### PR TITLE
[DRAFT][common-artifacts] Exclude Net_Gather_SparseToDense_AddV2_000

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -7,6 +7,7 @@
 ## TensorFlowLiteRecipes
 optimize(Add_STR_000) # STRING is not supported
 optimize(Add_STR_001) # STRING is not supported
+optimize(Net_Gather_SparseToDense_AddV2_000) # Constant folding is not generally supported
 
 ## CircleRecipes
 


### PR DESCRIPTION
This will exclude optimize for Net_Gather_SparseToDense_AddV2_000.

Related: https://github.com/Samsung/ONE/pull/13999#discussion_r1756157207

ONE-DCO-1.0-Signed-off-by: Jongwon Yang <yjw963@gmail.com>