### PR TITLE
[one-cmds] Revise codegen and profile

### DIFF
--- a/compiler/one-cmds/dummy-driver/CMakeLists.txt
+++ b/compiler/one-cmds/dummy-driver/CMakeLists.txt
@@ -1,7 +1,9 @@
 # dummy driver for interface test
 set(DUMMY_COMPILER_SRC src/dummy-compiler.cpp)
+set(DUMMY_V2_COMPILER_SRC src/dummyV2-compiler.cpp)
 set(DUMMY_DRIVER_SRC src/dummy-compile.cpp)
 set(DUMMY_V2_DRIVER_SRC src/dummyV2-compile.cpp)
+set(DUMMY_V3_DRIVER_SRC src/dummyV3-compile.cpp)
 set(HELP_DRIVER_SRC src/help-compile.cpp)
 set(DUMMY_INFER_SRC src/dummy-infer.cpp)
 set(DUMMY_INFER_V2_SRC src/dummy-inferV2.cpp)
@@ -17,8 +19,10 @@ set(DUMMY_ONNX_EXT src/dummy-onnx-ext.cpp)
 # Without command schema, codegen drivers have "-compile" suffix in their names.
 # Such restriction can be relieved with the command schema.
 add_executable(dummy-compiler ${DUMMY_COMPILER_SRC})
+add_executable(dummyV2-compiler ${DUMMY_V2_COMPILER_SRC})
 add_executable(dummy-compile ${DUMMY_DRIVER_SRC})
 add_executable(dummyV2-compile ${DUMMY_V2_DRIVER_SRC})
+add_executable(dummyV3-compile ${DUMMY_V3_DRIVER_SRC})
 add_executable(help-compile ${HELP_DRIVER_SRC})
 add_executable(dummy-infer ${DUMMY_INFER_SRC})
 add_executable(dummy-inferV2 ${DUMMY_INFER_V2_SRC})
@@ -31,8 +35,10 @@ add_executable(dummyEnv-compile ${DUMMY_ENV_SRC})
 add_executable(dummy-onnx-ext ${DUMMY_ONNX_EXT})
 
 set(DUMMY_COMPILER "${CMAKE_CURRENT_BINARY_DIR}/dummy-compiler")
+set(DUMMY_V2_COMPILER "${CMAKE_CURRENT_BINARY_DIR}/dummyV2-compiler")
 set(DUMMY_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/dummy-compile")
 set(DUMMY_V2_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/dummyV2-compile")
+set(DUMMY_V3_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/dummyV3-compile")
 set(HELP_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/help-compile")
 set(DUMMY_INFER "${CMAKE_CURRENT_BINARY_DIR}/dummy-infer")
 set(DUMMY_INFER_V2 "${CMAKE_CURRENT_BINARY_DIR}/dummy-inferV2")
@@ -49,6 +55,13 @@ install(FILES ${DUMMY_COMPILER}
                     GROUP_READ GROUP_EXECUTE
                     WORLD_READ WORLD_EXECUTE
         DESTINATION test)
+        
+install(FILES ${DUMMY_V2_COMPILER}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)
+
 install(FILES ${DUMMY_DRIVER}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
                     GROUP_READ GROUP_EXECUTE
@@ -56,6 +69,12 @@ install(FILES ${DUMMY_DRIVER}
         DESTINATION test)
 
 install(FILES ${DUMMY_V2_DRIVER}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)
+
+install(FILES ${DUMMY_V3_DRIVER}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
                     GROUP_READ GROUP_EXECUTE
                     WORLD_READ WORLD_EXECUTE

--- a/compiler/one-cmds/dummy-driver/src/dummyV2-compiler.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummyV2-compiler.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * dummyV2-compiler only tests its interface rather than its functionality.
+ *
+ * ./dummyV2-compiler --target ${TARGET_NAME} --command
+ */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+  if (argc != 4)
+    return EXIT_FAILURE;
+  std::string target_name{argv[2]};
+  std::string command_option{argv[3]};
+  if (command_option != "--command")
+    return EXIT_FAILURE;
+
+  std::cout << "dummyV2-compiler with " << target_name << " target" << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/compiler/one-cmds/dummy-driver/src/dummyV3-compile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummyV3-compile.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * dummyV3-compile only tests its interface rather than its functionality.
+ *
+ * ./dummyV3-compile --target ${TARGET_NAME} --command
+ */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+  if (argc != 4)
+    return EXIT_FAILURE;
+  std::string target_name{argv[2]};
+  std::string command_option{argv[3]};
+  if (command_option != "--command")
+    return EXIT_FAILURE;
+
+  std::cout << "dummyV3-compile with " << target_name << " target" << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -35,6 +35,9 @@ import onelib.utils as oneutils
 # TODO Find better way to suppress trackback on error
 sys.tracebacklimit = 0
 
+COMMAND_KEYS = ['__command', 'command']
+BACKEND_KEY = 'BACKEND'
+
 
 def _get_parser(backends_list):
     codegen_usage = 'one-codegen [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] [--] [COMMANDS FOR BACKEND]'
@@ -60,113 +63,17 @@ def _get_parser(backends_list):
     return parser
 
 
-def _verify_arg(parser, args, cfg_args, cfg_target_args, backend_args, unknown_args):
-    """verify given arguments"""
-    cmd_backend_exist = oneutils.is_valid_attr(args, 'backend')
-    cmd_target_exist = oneutils.is_valid_attr(args, 'target')
-    if cmd_backend_exist and cmd_target_exist:
-        parser.error(
-            '\'backend\' option and \'target\' option cannot be used simultaneously.')
-    cfg_backend_exist = oneutils.is_valid_attr(cfg_args, 'backend')
-    cfg_backends_exist = oneutils.is_valid_attr(cfg_args, 'backends')
-    target_exist = cmd_target_exist or oneutils.is_valid_attr(cfg_target_args, 'target')
+def _verify_arg(parser, cmd_codegen_args, cfg_codegen_args, cfg_backend_args,
+                cmd_backend_args):
+    """
+    Verify given arguments.
 
-    # check if required arguments is given
-    missing = []
-    if not cmd_backend_exist and not cfg_backend_exist and not cfg_backends_exist:
-        if target_exist:
-            target_to_run = None
-            if oneutils.is_valid_attr(cfg_target_args, 'target'):
-                target_to_run = getattr(cfg_target_args, 'target')
-            # overwrite the value if it exists as command line option has higher priority.
-            if oneutils.is_valid_attr(args, 'target'):
-                target_to_run = args.target
-            given_backend = backends.get_backend_from_target_conf(target_to_run)
-            if not given_backend:
-                parser.error(f'Not found {target_to_run} target.')
-        else:
-            missing.append('[-b/--backend | -T/--target]')
-    if len(missing):
-        parser.error('the following arguments are required: ' + ' '.join(missing))
-
-    if not oneutils.is_valid_attr(args, 'config'):
-        if not backend_args and not unknown_args:
-            parser.error('commands for the backend is missing.')
-
-    if cfg_backend_exist and cfg_backends_exist:
-        parser.error(
-            '\'backend\' option and \'backends\' option cannot be used simultaneously.')
-
-    # Check if given backend from command line exists in the configuration file
-    if cmd_backend_exist and cfg_backend_exist:
-        if args.backend != cfg_args.backend:
-            parser.error('Not found the command of given backend')
-
-    if cfg_backend_exist and not oneutils.is_valid_attr(cfg_args, 'command'):
-        parser.error('\'command\' key is missing in the configuration file.')
-
-    if cfg_backends_exist:
-        cfg_backends = getattr(cfg_args, 'backends').split(',')
-        # check if commands of given backends exist
-        for b in cfg_backends:
-            if not oneutils.is_valid_attr(cfg_args, b):
-                parser.error('Not found the command for ' + b)
-
-        # Check if given backend from command line exists in the configuration file
-        if cmd_backend_exist:
-            if args.backend not in cfg_backends:
-                parser.error('Not found the command of given backend')
-
-
-def _parse_arg(parser):
-    codegen_args = []
-    backend_args = []
-    unknown_args = []
-    argv = copy.deepcopy(sys.argv)
-    # delete file name
-    del argv[0]
-    # split by '--'
-    args = [list(y) for x, y in itertools.groupby(argv, lambda z: z == '--') if not x]
-    if len(args) == 0:
-        codegen_args = parser.parse_args(codegen_args)
-    # one-codegen has two interfaces
-    # 1. one-codegen [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] [COMMANDS FOR BACKEND]
-    if len(args) == 1:
-        codegen_args = args[0]
-        codegen_args, unknown_args = parser.parse_known_args(codegen_args)
-    # 2. one-codegen [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] -- [COMMANDS FOR BACKEND]
-    if len(args) == 2:
-        codegen_args = args[0]
-        backend_args = args[1]
-        codegen_args = parser.parse_args(codegen_args)
-    # print version
-    if len(args) and codegen_args.version:
-        oneutils.print_version_and_exit(__file__)
-
-    return codegen_args, backend_args, unknown_args
-
-
-def main():
-    # get backend list
-    backends_list = backends.get_list('*-compile')
-
-    # parse arguments
-    parser = _get_parser(backends_list)
-    args, backend_args, unknown_args = _parse_arg(parser)
-
-    # parse configuration file
-    cfg_args = SimpleNamespace()
-    oneutils.parse_cfg(args.config, 'one-codegen', cfg_args)
-    cfg_target_args = SimpleNamespace()
-    oneutils.parse_cfg(args.config, 'backend', cfg_target_args, quiet=True)
-
-    # parse configuration file (args has arguments parsed from command line + cfg)
-    # oneutils.parse_cfg(args.config, 'one-codegen', args)
-
-    # verify arguments
-    _verify_arg(parser, args, cfg_args, cfg_target_args, backend_args, unknown_args)
-    '''
-    one-codegen defines its behavior for below cases.
+      cmd_codegen_args: arguments from command line.
+      cfg_codegen_args: arguments from onecc configuration file in [one-codegen] section
+      cfg_backend_args: arguments from onecc configuration file in [backend] section
+      cmd_backend_args: arguments from command line for backend driver
+    
+    # one-codegen defines its behavior for below cases.
 
     [1] one-codegen -h
     [2] one-codegen -v
@@ -188,106 +95,277 @@ def main():
     [16] one-codegen -T {target} -- ${command} (ignore command schema)
 
     All other cases are not allowed or an undefined behavior.
-    '''
-    # decide target
-    target_to_run = None
-    if oneutils.is_valid_attr(cfg_target_args, 'target'):
-        target_to_run = getattr(cfg_target_args, 'target')
-    # overwrite the value if it exists as command line option has higher priority.
-    if oneutils.is_valid_attr(args, 'target'):
-        target_to_run = args.target
 
-    cmd_overwrite = False
-    parser = None
-    # decide which backend to run
-    if oneutils.is_valid_attr(args, 'config'):
-        # [9], [10]
-        if backend_args and not unknown_args:
-            given_backends = [args.backend]
-            cmd_overwrite = True
-        else:
-            # [7], [8]
-            if oneutils.is_valid_attr(args, 'backend'):
-                given_backends = [args.backend]
-                if oneutils.is_valid_attr(cfg_args, 'backend'):
-                    assert (oneutils.is_valid_attr(cfg_args, 'command'))
-                    setattr(cfg_args, args.backend, cfg_args.command)
+    # We allow a few styles in [one-codegen] section.
+
+    [Style 1]
+    backend=##
+    command=##
+
+    [Style 2]
+    backends=dummy1,dummy2
+    dummy1=##
+    dummy2=##
+
+    [Style 3]
+    option1=##
+    option2=##
+
+    NOTE Style 3 refers to a style that has a command schema.
+    """
+    cmd_backend_exist = oneutils.is_valid_attr(cmd_codegen_args, 'backend')
+    cmd_target_exist = oneutils.is_valid_attr(cmd_codegen_args, 'target')
+    cfg_backend_exist = oneutils.is_valid_attr(cfg_codegen_args, 'backend')
+    cfg_backends_exist = oneutils.is_valid_attr(cfg_codegen_args, 'backends')
+    target_exist = cmd_target_exist or oneutils.is_valid_attr(cfg_backend_args, 'target')
+    cmd_key_exist = any(
+        oneutils.is_valid_attr(cfg_codegen_args, cmd_key) for cmd_key in COMMAND_KEYS)
+
+    backend = None
+    # get backend from target configuration
+    if target_exist:
+        target = None
+        if oneutils.is_valid_attr(cfg_backend_args, 'target'):
+            target = getattr(cfg_backend_args, 'target')
+        # overwrite the value if it exists in command line option as it has higher priority.
+        if oneutils.is_valid_attr(cmd_codegen_args, 'target'):
+            target = cmd_codegen_args.target
+        assert target
+        backend = backends.get_value_from_target_conf(target, BACKEND_KEY)
+
+    # backend information should exist.
+    missing = []
+    if all(not e
+           for e in [backend, cmd_backend_exist, cfg_backend_exist, cfg_backends_exist]):
+        missing.append('[-b/--backend | -T/--target]')
+    if len(missing):
+        parser.error('the following arguments are required: ' + ' '.join(missing))
+
+    ### verify commnad line
+    if cmd_backend_exist and cmd_target_exist:
+        parser.error(
+            '\'backend\' option and \'target\' option cannot be used simultaneously.')
+    # if config option is not given, both backend and command option should be given.
+    if not oneutils.is_valid_attr(cmd_codegen_args, 'config'):
+        if not cmd_backend_args:
+            parser.error('Not found the command for given backend')
+    # if command for backend driver is given in commnad line, backend option should be given as well.
+    if cmd_backend_args:
+        if all(not e for e in [backend, cmd_backend_exist]):
+            parser.error('[-b/--backend | -T/--target] option is missing.')
+
+    ### verify onecc configuration file
+    use_command_schema = False
+    if oneutils.is_valid_attr(cmd_codegen_args, 'config'):
+        # Style 3
+        if target_exist and backend:
+            cmd_parser = oneutils.get_arg_parser(backend, cmd="codegen", target=target)
+            if not cmd_parser:
+                use_command_schema = False
             else:
-                # get backend information
-                given_backend = backends.get_backend_from_target_conf(target_to_run)
-                # check if command schema for the backend exists
-                # 1. if it exists, run the command according to the schema.
-                # 2. if it doesn't exist, insert "--target ${TARGET}" at the beginning of the given command.
-                parser = oneutils.get_arg_parser(given_backend,
-                                                 cmd="codegen",
-                                                 target=target_to_run)
-                # [11], [13]
-                if target_to_run and parser:
-                    if oneutils.is_valid_attr(cfg_args, 'command'):
-                        given_backends = [given_backend]
-                        setattr(cfg_args, given_backend, cfg_args.command)
-                        # If "command" key exists with target option, command schema is not used. ${BACKEND}-compile will be run as before.
+                # check if given keys in conf file are from the command schema.
+                schema_option_names = cmd_parser.get_option_names(flatten=True,
+                                                                  without_dash=True)
+                if oneutils.is_valid_attr(cfg_codegen_args, '__command'):
+                    use_command_schema = False
+                elif oneutils.is_valid_attr(cfg_codegen_args, 'command'):
+                    if 'command' in schema_option_names:
+                        use_command_schema = True
+                    else:
                         print(
                             "WARNING: 'command' key in the [one-codegen] will be deprecated as of September 1, 2025."
                         )
-                    else:
-                        # DO NOTHING
-                        pass
-                # [12], [14]
+                        use_command_schema = False
                 else:
-                    # [3]
-                    if oneutils.is_valid_attr(cfg_args, 'backend'):
-                        assert (oneutils.is_valid_attr(cfg_args, 'command'))
-                        given_backends = [cfg_args.backend]
-                        setattr(cfg_args, cfg_args.backend, cfg_args.command)
-                    # [4]
-                    if oneutils.is_valid_attr(cfg_args, 'backends'):
-                        given_backends = cfg_args.backends.split(',')
-    else:
-        assert (backend_args or unknown_args)
-        # [5], [6]
-        if oneutils.is_valid_attr(args, 'backend'):
-            given_backends = [args.backend]
-        # [15], [16]
-        else:
-            assert oneutils.is_valid_attr(args, 'target')
-            given_backends = [backends.get_backend_from_target_conf(target_to_run)]
+                    for cfg_codegen_arg in vars(cfg_codegen_args):
+                        if cfg_codegen_arg not in schema_option_names:
+                            cmd_parser.print_help()
+                            parser.error('Invalid option in [one-codegen] section')
+                    use_command_schema = True
 
-    # make commands
-    # 1. if command schema exists
-    if parser and not oneutils.is_valid_attr(cfg_args, 'command'):
-        codegen_cmd = parser.make_cmd(cfg_args)
-        # run backend driver
-        oneutils.run(codegen_cmd, err_prefix=parser.driver)
-    # 2. if command schema doesn't exist
-    else:
-        for given_backend in given_backends:
-            # make a command to run given backend driver
-            codegen_path = None
-            backend_base = given_backend + '-compile'
-            for cand in backends_list:
-                if ntpath.basename(cand) == backend_base:
-                    codegen_path = cand
-            if not codegen_path:
-                # Find backend from system path
-                codegen_path = shutil.which(backend_base)
+        if not use_command_schema:
+            # both backend and backends keys are in [one-codgen] section
+            if cfg_backend_exist and cfg_backends_exist:
+                parser.error(
+                    '\'backend\' and \'backends\' keys cannot be used simultaneously.')
 
-            if not codegen_path:
-                raise FileNotFoundError(backend_base + ' not found')
+            # Style 2
+            if cfg_backends_exist:
+                # backends and [command, __command] key in [one-codegen] section
+                if cmd_key_exist:
+                    parser.error(
+                        '\'backends\' and \'(__)command\' keys cannot be used simultaneously.'
+                    )
 
-            codegen_cmd = [codegen_path]
-            # "--target" option is intentionally inserted at the beginning of the command.
-            # It would match the command of backends' tool.
-            if target_to_run:
-                codegen_cmd += ['--target', target_to_run]
-            if not cmd_overwrite and oneutils.is_valid_attr(cfg_args, given_backend):
-                codegen_cmd += getattr(cfg_args, given_backend).split()
+                # commands for given backends should exist
+                cfg_backends = getattr(cfg_codegen_args, 'backends').split(',')
+                for b in cfg_backends:
+                    if not oneutils.is_valid_attr(cfg_codegen_args, b):
+                        parser.error('Not found the command for ' + b)
+
+                # Check if given backend from command line exists in the configuration file
+                if cmd_backend_exist:
+                    if cmd_codegen_args.backend not in cfg_backends:
+                        parser.error('Not found the command for given backend')
+            # Style 1
             else:
-                codegen_cmd += backend_args
-                codegen_cmd += unknown_args
+                # both backend and command should exist.
+                assert any(e for e in [backend, cmd_backend_exist, cfg_backend_exist])
+                if not cmd_key_exist:
+                    parser.error('Not found the command for given backend')
+
+
+def _parse_arg(parser):
+    # args for `one-codegen`
+    codegen_args = []
+    # args for backend tool
+    backend_args = []
+    argv = copy.deepcopy(sys.argv)
+    # delete file name
+    del argv[0]
+    # split by '--'
+    args = [list(y) for x, y in itertools.groupby(argv, lambda z: z == '--') if not x]
+    if len(args) == 0:
+        codegen_args = parser.parse_args(codegen_args)
+    # one-codegen has two interfaces
+    # 1. one-codegen [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] [COMMANDS FOR BACKEND]
+    if len(args) == 1:
+        codegen_args = args[0]
+        codegen_args, backend_args = parser.parse_known_args(codegen_args)
+    # 2. one-codegen [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] -- [COMMANDS FOR BACKEND]
+    if len(args) == 2:
+        codegen_args = args[0]
+        backend_args = args[1]
+        codegen_args = parser.parse_args(codegen_args)
+    # print version
+    if len(args) and codegen_args.version:
+        oneutils.print_version_and_exit(__file__)
+
+    return codegen_args, backend_args
+
+
+def main():
+    # get backend list
+    backends_list = backends.get_list('*-compile')
+
+    # parse arguments
+    parser = _get_parser(backends_list)
+    cmd_codegen_args, cmd_backend_args = _parse_arg(parser)
+
+    # parse configuration file
+    cfg_codegen_args = SimpleNamespace()
+    oneutils.parse_cfg(cmd_codegen_args.config, 'one-codegen', cfg_codegen_args)
+    cfg_backend_args = SimpleNamespace()
+    oneutils.parse_cfg(cmd_codegen_args.config, 'backend', cfg_backend_args, quiet=True)
+
+    # verify arguments
+    _verify_arg(parser, cmd_codegen_args, cfg_codegen_args, cfg_backend_args,
+                cmd_backend_args)
+    """
+    get target and backend
+
+    NOTE each retrieval should be processed in order for the priorities. Values that have
+         lower priority will be overwritten by those that have higher priority.
+    """
+    ### get target
+    # NOTE each step overwrites existing `backend_to_run` for considering priorities.
+    target_to_run = None
+    # 1. get target from onecc configuration
+    if oneutils.is_valid_attr(cfg_backend_args, 'target'):
+        target_to_run = getattr(cfg_backend_args, 'target')
+    # 2. get target from command line
+    if oneutils.is_valid_attr(cmd_codegen_args, 'target'):
+        target_to_run = cmd_codegen_args.target
+
+    ### get backend
+    backend_to_run = []
+    parser = None
+    # 1. get backend from target configuration
+    if target_to_run:
+        backend = backends.get_value_from_target_conf(target_to_run, BACKEND_KEY)
+        backend_to_run.append(backend)
+        # check if given backend has command schema
+        # NOTE command schema could exist only if target is given.
+        parser = oneutils.get_arg_parser(backend, cmd="codegen", target=target_to_run)
+    # 2. get backend from onecc configuration
+    if oneutils.is_valid_attr(cmd_codegen_args, 'config'):
+        if parser:
+            # command schema exist (Style 3)
+            # "backend" key assumes one of backend options
+            # DO NOTHING
+            pass
+        else:
+            assert oneutils.is_valid_attr(cfg_codegen_args,
+                                          'backend') or oneutils.is_valid_attr(
+                                              cfg_codegen_args, 'backends')
+            # Style 1
+            if oneutils.is_valid_attr(cfg_codegen_args, 'backend'):
+                backend_to_run = [cfg_codegen_args.backend]
+            # Style 2
+            if oneutils.is_valid_attr(cfg_codegen_args, 'backends'):
+                backend_to_run = cfg_codegen_args.backends.split(',')
+    # 3. get backend from command line
+    if oneutils.is_valid_attr(cmd_codegen_args, 'backend'):
+        backend_to_run = [cmd_codegen_args.backend]
+
+    ### make commands
+    use_command_schema = False
+    if parser:
+        schema_option_names = parser.get_option_names(flatten=True, without_dash=True)
+        if oneutils.is_valid_attr(cfg_codegen_args, '__command'):
+            use_command_schema = False
+        elif oneutils.is_valid_attr(cfg_codegen_args, 'command'):
+            if 'command' in schema_option_names:
+                use_command_schema = True
+            else:
+                use_command_schema = False
+        else:
+            use_command_schema = True
+
+    # if reserved keys exist, run without command schema.
+    if use_command_schema:
+        codegen_cmd = parser.make_cmd(cfg_codegen_args)
+        oneutils.run(codegen_cmd, err_prefix=parser.driver)
+    else:
+        for backend in backend_to_run:
+            # get driver for the backend
+            codegen_driver = f'{backend}-compile'
+            codegen_path = None
+            for cand in backends_list:
+                if ntpath.basename(cand) == codegen_driver:
+                    codegen_path = cand
+                    break
+            if not codegen_path:
+                # find backend from system path
+                codegen_path = shutil.which(codegen_driver)
+            if not codegen_path:
+                raise FileNotFoundError(codegen_driver + ' not found')
+
+            codegen_cmd_base = [codegen_path]
+            # "--target" option is intentionally inserted at the beginning of the command.
+            # it would match the command of backends' tool.
+            if target_to_run:
+                codegen_cmd_base += ['--target', target_to_run]
+
+            # Style 2
+            if oneutils.is_valid_attr(cfg_codegen_args, backend):
+                codegen_cmd = codegen_cmd_base + getattr(cfg_codegen_args,
+                                                         backend).split()
+            # Style 1, Style 3(without command schema)
+            else:
+                if oneutils.is_valid_attr(cfg_codegen_args, '__command'):
+                    codegen_cmd = codegen_cmd_base + getattr(cfg_codegen_args,
+                                                             '__command').split()
+                elif oneutils.is_valid_attr(cfg_codegen_args, 'command'):
+                    codegen_cmd = codegen_cmd_base + getattr(cfg_codegen_args,
+                                                             'command').split()
+
+            # if backend command exists in command line arguments, overwrite the ones from onecc configuration file.
+            if cmd_backend_args:
+                codegen_cmd = codegen_cmd_base + cmd_backend_args
 
             # run backend driver
-            oneutils.run(codegen_cmd, err_prefix=backend_base)
+            oneutils.run(codegen_cmd, err_prefix=codegen_driver)
 
 
 if __name__ == '__main__':

--- a/compiler/one-cmds/one-profile
+++ b/compiler/one-cmds/one-profile
@@ -35,44 +35,8 @@ import onelib.utils as oneutils
 # TODO Find better way to suppress trackback on error
 sys.tracebacklimit = 0
 
-
-def _get_backends_list():
-    """
-    [one hierarchy]
-    one
-    ├── backends
-    ├── bin
-    ├── doc
-    ├── include
-    ├── lib
-    └── test
-
-    The list where `one-profile` finds its backends
-    - `bin` folder where `one-profile` exists
-    - `backends` folder
-
-    NOTE If there are backends of the same name in different places,
-     the closer to the top in the list, the higher the priority.
-    """
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    backend_set = set()
-
-    # bin folder
-    files = [f for f in glob.glob(dir_path + '/*-profile')]
-    # backends folder
-    files += [
-        f for f in glob.glob(dir_path + '/../backends/**/*-profile', recursive=True)
-    ]
-    # TODO find backends in `$PATH`
-
-    backends_list = []
-    for cand in files:
-        base = ntpath.basename(cand)
-        if not base in backend_set and os.path.isfile(cand) and os.access(cand, os.X_OK):
-            backend_set.add(base)
-            backends_list.append(cand)
-
-    return backends_list
+COMMAND_KEYS = ['__command', 'command']
+BACKEND_KEY = 'BACKEND'
 
 
 def _get_parser(backends_list):
@@ -99,109 +63,17 @@ def _get_parser(backends_list):
     return parser
 
 
-def _verify_arg(parser, args, cfg_args, cfg_target_args, backend_args, unknown_args):
-    """verify given arguments"""
-    cmd_backend_exist = oneutils.is_valid_attr(args, 'backend')
-    cmd_target_exist = oneutils.is_valid_attr(args, 'target')
-    if cmd_backend_exist and cmd_target_exist:
-        parser.error(
-            '\'backend\' option and \'target\' option cannot be used simultaneously.')
-    cfg_backend_exist = oneutils.is_valid_attr(cfg_args, 'backend')
-    cfg_backends_exist = oneutils.is_valid_attr(cfg_args, 'backends')
-    target_exist = cmd_target_exist or oneutils.is_valid_attr(cfg_target_args, 'target')
+def _verify_arg(parser, cmd_profile_args, cfg_profile_args, cfg_backend_args,
+                cmd_backend_args):
+    """
+    Verify given arguments.
 
-    # check if required arguments is given
-    missing = []
-    if not cmd_backend_exist and not cfg_backend_exist and not cfg_backends_exist:
-        if target_exist:
-            target_to_run = None
-            if oneutils.is_valid_attr(cfg_target_args, 'target'):
-                target_to_run = getattr(cfg_target_args, 'target')
-            # overwrite the value if it exists as command line option has higher priority.
-            if oneutils.is_valid_attr(args, 'target'):
-                target_to_run = args.target
-            given_backend = backends.get_backend_from_target_conf(target_to_run)
-            if not given_backend:
-                parser.error(f'Not found {target_to_run} target.')
-        else:
-            missing.append('[-b/--backend | -T/--target]')
-    if len(missing):
-        parser.error('the following arguments are required: ' + ' '.join(missing))
-
-    if not oneutils.is_valid_attr(args, 'config'):
-        if not backend_args and not unknown_args:
-            parser.error('commands for the backend is missing.')
-
-    if cfg_backend_exist and cfg_backends_exist:
-        parser.error(
-            '\'backend\' option and \'backends\' option cannot be used simultaneously.')
-
-    # Check if given backend from command line exists in the configuration file
-    if cmd_backend_exist and cfg_backend_exist:
-        if args.backend != cfg_args.backend:
-            parser.error('Not found the command of given backend')
-
-    if cfg_backend_exist and not oneutils.is_valid_attr(cfg_args, 'command'):
-        parser.error('\'command\' key is missing in the configuration file.')
-
-    if cfg_backends_exist:
-        cfg_backends = getattr(cfg_args, 'backends').split(',')
-        # check if commands of given backends exist
-        for b in cfg_backends:
-            if not oneutils.is_valid_attr(cfg_args, b):
-                parser.error('Not found the command for ' + b)
-        # Check if given backend from command line exists in the configuration file
-        if cmd_backend_exist:
-            if args.backend not in cfg_backends:
-                parser.error('Not found the command of given backend')
-
-
-def _parse_arg(parser):
-    profile_args = []
-    backend_args = []
-    unknown_args = []
-    argv = copy.deepcopy(sys.argv)
-    # delete file name
-    del argv[0]
-    # split by '--'
-    args = [list(y) for x, y in itertools.groupby(argv, lambda z: z == '--') if not x]
-    if len(args) == 0:
-        profile_args = parser.parse_args(profile_args)
-    # one-profile has two interfaces
-    # 1. one-profile [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] [COMMANDS FOR BACKEND]
-    if len(args) == 1:
-        profile_args = args[0]
-        profile_args, unknown_args = parser.parse_known_args(profile_args)
-    # 2. one-profile [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] -- [COMMANDS FOR BACKEND]
-    if len(args) == 2:
-        profile_args = args[0]
-        backend_args = args[1]
-        profile_args = parser.parse_args(profile_args)
-    # print version
-    if len(args) and profile_args.version:
-        oneutils.print_version_and_exit(__file__)
-
-    return profile_args, backend_args, unknown_args
-
-
-def main():
-    # get backend list
-    backends_list = _get_backends_list()
-
-    # parse arguments
-    parser = _get_parser(backends_list)
-    args, backend_args, unknown_args = _parse_arg(parser)
-
-    # parse configuration file
-    cfg_args = SimpleNamespace()
-    oneutils.parse_cfg(args.config, 'one-profile', cfg_args)
-    cfg_target_args = SimpleNamespace()
-    oneutils.parse_cfg(args.config, 'backend', cfg_target_args, quiet=True)
-
-    # verify arguments
-    _verify_arg(parser, args, cfg_args, cfg_target_args, backend_args, unknown_args)
-    '''
-    one-profile defines its behavior for below cases.
+      cmd_profile_args: arguments from command line.
+      cfg_profile_args: arguments from onecc configuration file in [one-profile] section
+      cfg_backend_args: arguments from onecc configuration file in [backend] section
+      cmd_backend_args: arguments from command line for backend driver
+    
+    # one-profile defines its behavior for below cases.
 
     [1] one-profile -h
     [2] one-profile -v
@@ -219,107 +91,281 @@ def main():
     [12] one-profile -C {cfg} (w/ target, w/o command schema)
     [13] one-profile -C {cfg} -T {target} (w/ command schema)
     [14] one-profile -C {cfg} -T {target} (w/o command schema)
-    [15] one-profile -T {target} ${command}
-    [16] one-profile -T {target} -- ${command}
+    [15] one-profile -T {target} ${command} (ignore command schema)
+    [16] one-profile -T {target} -- ${command} (ignore command schema)
 
     All other cases are not allowed or an undefined behavior.
-    '''
-    # decide target
-    target_to_run = None
-    if oneutils.is_valid_attr(cfg_target_args, 'target'):
-        target_to_run = getattr(cfg_target_args, 'target')
-    # overwrite the value if it exists as command line option has higher priority.
-    if oneutils.is_valid_attr(args, 'target'):
-        target_to_run = args.target
 
-    cmd_overwrite = False
-    parser = None
-    # decide which backend to run
-    if oneutils.is_valid_attr(args, 'config'):
-        # [9], [10]
-        if backend_args and not unknown_args:
-            given_backends = [args.backend]
-            cmd_overwrite = True
-        else:
-            # [7], [8]
-            if oneutils.is_valid_attr(args, 'backend'):
-                given_backends = [args.backend]
-                if oneutils.is_valid_attr(cfg_args, 'backend'):
-                    assert (oneutils.is_valid_attr(cfg_args, 'command'))
-                    setattr(cfg_args, args.backend, cfg_args.command)
+    # We allow a few styles in [one-profile] section.
+
+    [Style 1]
+    backend=##
+    command=##
+
+    [Style 2]
+    backends=dummy1,dummy2
+    dummy1=##
+    dummy2=##
+
+    [Style 3]
+    option1=##
+    option2=##
+
+    NOTE Style 3 refers to a style that has a command schema.
+    """
+    cmd_backend_exist = oneutils.is_valid_attr(cmd_profile_args, 'backend')
+    cmd_target_exist = oneutils.is_valid_attr(cmd_profile_args, 'target')
+    cfg_backend_exist = oneutils.is_valid_attr(cfg_profile_args, 'backend')
+    cfg_backends_exist = oneutils.is_valid_attr(cfg_profile_args, 'backends')
+    target_exist = cmd_target_exist or oneutils.is_valid_attr(cfg_backend_args, 'target')
+    cmd_key_exist = any(
+        oneutils.is_valid_attr(cfg_profile_args, cmd_key) for cmd_key in COMMAND_KEYS)
+
+    backend = None
+    # get backend from target configuration
+    if target_exist:
+        target = None
+        if oneutils.is_valid_attr(cfg_backend_args, 'target'):
+            target = getattr(cfg_backend_args, 'target')
+        # overwrite the value if it exists in command line option as it has higher priority.
+        if oneutils.is_valid_attr(cmd_profile_args, 'target'):
+            target = cmd_profile_args.target
+        assert target
+        backend = backends.get_value_from_target_conf(target, BACKEND_KEY)
+
+    # backend information should exist.
+    missing = []
+    if all(not e
+           for e in [backend, cmd_backend_exist, cfg_backend_exist, cfg_backends_exist]):
+        missing.append('[-b/--backend | -T/--target]')
+    if len(missing):
+        parser.error('the following arguments are required: ' + ' '.join(missing))
+
+    ### verify commnad line
+    if cmd_backend_exist and cmd_target_exist:
+        parser.error(
+            '\'backend\' option and \'target\' option cannot be used simultaneously.')
+    # if config option is not given, both backend and command option should be given.
+    if not oneutils.is_valid_attr(cmd_profile_args, 'config'):
+        if not cmd_backend_args:
+            parser.error('Not found the command for given backend')
+    # if command for backend driver is given in commnad line, backend option should be given as well.
+    if cmd_backend_args:
+        if all(not e for e in [backend, cmd_backend_exist]):
+            parser.error('[-b/--backend | -T/--target] option is missing.')
+
+    ### verify onecc configuration file
+    use_command_schema = False
+    if oneutils.is_valid_attr(cmd_profile_args, 'config'):
+        # Style 3
+        if target_exist and backend:
+            cmd_parser = oneutils.get_arg_parser(backend, cmd="profile", target=target)
+            if not cmd_parser:
+                use_command_schema = False
             else:
-                # get backend information
-                given_backend = backends.get_backend_from_target_conf(target_to_run)
-                # check if command schema exists
-                # 1. if it exists, run the command according to the schema.
-                # 2. if it doesn't exist, insert "--target ${TARGET}" at the beginning of the given command.
-                parser = oneutils.get_arg_parser(given_backend,
-                                                 cmd="profile",
-                                                 target=target_to_run)
-                # [11], [13]
-                if target_to_run and parser:
-                    if oneutils.is_valid_attr(cfg_args, 'command'):
-                        given_backends = [given_backend]
-                        setattr(cfg_args, given_backend, cfg_args.command)
-                        # If "command" key exists with target option, command schema is not used. ${BACKEND}-profile will be run as before.
+                # check if given keys in conf file are from the command schema.
+                schema_option_names = cmd_parser.get_option_names(flatten=True,
+                                                                  without_dash=True)
+                if oneutils.is_valid_attr(cfg_profile_args, '__command'):
+                    use_command_schema = False
+                elif oneutils.is_valid_attr(cfg_profile_args, 'command'):
+                    if 'command' in schema_option_names:
+                        use_command_schema = True
+                    else:
                         print(
                             "WARNING: 'command' key in the [one-profile] will be deprecated as of September 1, 2025."
                         )
-                    else:
-                        # DO NOTHING
-                        pass
-                # [12], [14]
+                        use_command_schema = False
                 else:
-                    # [3]
-                    if oneutils.is_valid_attr(cfg_args, 'backend'):
-                        assert (oneutils.is_valid_attr(cfg_args, 'command'))
-                        given_backends = [cfg_args.backend]
-                        setattr(cfg_args, cfg_args.backend, cfg_args.command)
-                    # [4]
-                    if oneutils.is_valid_attr(cfg_args, 'backends'):
-                        given_backends = cfg_args.backends.split(',')
-    else:
-        assert (backend_args or unknown_args)
-        # [5], [6]
-        if oneutils.is_valid_attr(args, 'backend'):
-            given_backends = [args.backend]
-        # [15], [16]
-        else:
-            assert oneutils.is_valid_attr(args, 'target')
-            given_backends = [backends.get_backend_from_target_conf(target_to_run)]
+                    for cfg_profile_arg in vars(cfg_profile_args):
+                        if cfg_profile_arg not in schema_option_names:
+                            cmd_parser.print_help()
+                            parser.error('Invalid option in [one-profile] section')
+                    use_command_schema = True
 
-    # make commands
-    # 1. if command schema exists
-    if parser and not oneutils.is_valid_attr(cfg_args, 'command'):
-        profile_cmd = parser.make_cmd(cfg_args)
+        if not use_command_schema:
+            # both backend and backends keys are in [one-codgen] section
+            if cfg_backend_exist and cfg_backends_exist:
+                parser.error(
+                    '\'backend\' and \'backends\' keys cannot be used simultaneously.')
 
-        # run backend driver
-        oneutils.run(profile_cmd, err_prefix=parser.driver)
-    # 2. if command schema doesn't exist
-    else:
-        for given_backend in given_backends:
-            # make a command to run given backend driver
-            profile_path = None
-            backend_base = given_backend + '-profile'
-            for cand in backends_list:
-                if ntpath.basename(cand) == backend_base:
-                    profile_path = cand
-            if not profile_path:
-                raise FileNotFoundError(backend_base + ' not found')
+            # Style 2
+            if cfg_backends_exist:
+                # backends and [command, __command] key in [one-profile] section
+                if cmd_key_exist:
+                    parser.error(
+                        '\'backends\' and \'(__)command\' keys cannot be used simultaneously.'
+                    )
 
-            profile_cmd = [profile_path]
-            # "--target" option is intentionally inserted at the beginning of the command.
-            # It would match the command of backends' tool.
-            if target_to_run:
-                profile_cmd += ['--target', target_to_run]
-            if not cmd_overwrite and oneutils.is_valid_attr(cfg_args, given_backend):
-                profile_cmd += getattr(cfg_args, given_backend).split()
+                # commands for given backends should exist
+                cfg_backends = getattr(cfg_profile_args, 'backends').split(',')
+                for b in cfg_backends:
+                    if not oneutils.is_valid_attr(cfg_profile_args, b):
+                        parser.error('Not found the command for ' + b)
+
+                # Check if given backend from command line exists in the configuration file
+                if cmd_backend_exist:
+                    if cmd_profile_args.backend not in cfg_backends:
+                        parser.error('Not found the command for given backend')
+            # Style 1
             else:
-                profile_cmd += backend_args
-                profile_cmd += unknown_args
+                # both backend and command should exist.
+                assert any(e for e in [backend, cmd_backend_exist, cfg_backend_exist])
+                if not cmd_key_exist:
+                    parser.error('Not found the command for given backend')
+
+
+def _parse_arg(parser):
+    # args for `one-profile`
+    profile_args = []
+    # args for backend tool
+    backend_args = []
+    argv = copy.deepcopy(sys.argv)
+    # delete file name
+    del argv[0]
+    # split by '--'
+    args = [list(y) for x, y in itertools.groupby(argv, lambda z: z == '--') if not x]
+    if len(args) == 0:
+        profile_args = parser.parse_args(profile_args)
+    # one-profile has two interfaces
+    # 1. one-profile [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] [COMMANDS FOR BACKEND]
+    if len(args) == 1:
+        profile_args = args[0]
+        profile_args, backend_args = parser.parse_known_args(profile_args)
+    # 2. one-profile [-h] [-v] [-C CONFIG] [-b BACKEND | -T TARGET] -- [COMMANDS FOR BACKEND]
+    if len(args) == 2:
+        profile_args = args[0]
+        backend_args = args[1]
+        profile_args = parser.parse_args(profile_args)
+    # print version
+    if len(args) and profile_args.version:
+        oneutils.print_version_and_exit(__file__)
+
+    return profile_args, backend_args
+
+
+def main():
+    # get backend list
+    backends_list = backends.get_list('*-profile')
+
+    # parse arguments
+    parser = _get_parser(backends_list)
+    cmd_profile_args, cmd_backend_args = _parse_arg(parser)
+
+    # parse configuration file
+    cfg_profile_args = SimpleNamespace()
+    oneutils.parse_cfg(cmd_profile_args.config, 'one-profile', cfg_profile_args)
+    cfg_backend_args = SimpleNamespace()
+    oneutils.parse_cfg(cmd_profile_args.config, 'backend', cfg_backend_args, quiet=True)
+
+    # verify arguments
+    _verify_arg(parser, cmd_profile_args, cfg_profile_args, cfg_backend_args,
+                cmd_backend_args)
+    """
+    get target and backend
+
+    NOTE each retrieval should be processed in order for the priorities. Values that have
+         lower priority will be overwritten by those that have higher priority.
+    """
+    ### get target
+    # NOTE each step overwrites existing `backend_to_run` for considering priorities.
+    target_to_run = None
+    # 1. get target from onecc configuration
+    if oneutils.is_valid_attr(cfg_backend_args, 'target'):
+        target_to_run = getattr(cfg_backend_args, 'target')
+    # 2. get target from command line
+    if oneutils.is_valid_attr(cmd_profile_args, 'target'):
+        target_to_run = cmd_profile_args.target
+
+    ### get backend
+    backend_to_run = []
+    parser = None
+    # 1. get backend from target configuration
+    if target_to_run:
+        backend = backends.get_value_from_target_conf(target_to_run, BACKEND_KEY)
+        backend_to_run.append(backend)
+        # check if given backend has command schema
+        # NOTE command schema could exist only if target is given.
+        parser = oneutils.get_arg_parser(backend, cmd="profile", target=target_to_run)
+    # 2. get backend from onecc configuration
+    if oneutils.is_valid_attr(cmd_profile_args, 'config'):
+        if parser:
+            # command schema exist (Style 3)
+            # "backend" key assumes one of backend options
+            # DO NOTHING
+            pass
+        else:
+            assert oneutils.is_valid_attr(cfg_profile_args,
+                                          'backend') or oneutils.is_valid_attr(
+                                              cfg_profile_args, 'backends')
+            # Style 1
+            if oneutils.is_valid_attr(cfg_profile_args, 'backend'):
+                backend_to_run = [cfg_profile_args.backend]
+            # Style 2
+            if oneutils.is_valid_attr(cfg_profile_args, 'backends'):
+                backend_to_run = cfg_profile_args.backends.split(',')
+    # 3. get backend from command line
+    if oneutils.is_valid_attr(cmd_profile_args, 'backend'):
+        backend_to_run = [cmd_profile_args.backend]
+
+    ### make commands
+    use_command_schema = False
+    if parser:
+        schema_option_names = parser.get_option_names(flatten=True, without_dash=True)
+        if oneutils.is_valid_attr(cfg_profile_args, '__command'):
+            use_command_schema = False
+        elif oneutils.is_valid_attr(cfg_profile_args, 'command'):
+            if 'command' in schema_option_names:
+                use_command_schema = True
+            else:
+                use_command_schema = False
+        else:
+            use_command_schema = True
+
+    # if reserved keys exist, run without command schema.
+    if use_command_schema:
+        profile_cmd = parser.make_cmd(cfg_profile_args)
+        oneutils.run(profile_cmd, err_prefix=parser.driver)
+    else:
+        for backend in backend_to_run:
+            # get driver for the backend
+            profile_driver = f'{backend}-profile'
+            profile_path = None
+            for cand in backends_list:
+                if ntpath.basename(cand) == profile_driver:
+                    profile_path = cand
+                    break
+            if not profile_path:
+                # find backend from system path
+                profile_path = shutil.which(profile_driver)
+            if not profile_path:
+                raise FileNotFoundError(profile_driver + ' not found')
+
+            profile_cmd_base = [profile_path]
+            # "--target" option is intentionally inserted at the beginning of the command.
+            # it would match the command of backends' tool.
+            if target_to_run:
+                profile_cmd_base += ['--target', target_to_run]
+
+            # Style 2
+            if oneutils.is_valid_attr(cfg_profile_args, backend):
+                profile_cmd = profile_cmd_base + getattr(cfg_profile_args,
+                                                         backend).split()
+            # Style 1, Style 3(without command schema)
+            else:
+                if oneutils.is_valid_attr(cfg_profile_args, '__command'):
+                    profile_cmd = profile_cmd_base + getattr(cfg_profile_args,
+                                                             '__command').split()
+                elif oneutils.is_valid_attr(cfg_profile_args, 'command'):
+                    profile_cmd = profile_cmd_base + getattr(cfg_profile_args,
+                                                             'command').split()
+
+            # if backend command exists in command line arguments, overwrite the ones from onecc configuration file.
+            if cmd_backend_args:
+                profile_cmd = profile_cmd_base + cmd_backend_args
 
             # run backend driver
-            oneutils.run(profile_cmd, err_prefix=backend_base)
+            oneutils.run(profile_cmd, err_prefix=profile_driver)
 
 
 if __name__ == '__main__':

--- a/compiler/one-cmds/onelib/argumentparse.py
+++ b/compiler/one-cmds/onelib/argumentparse.py
@@ -139,7 +139,27 @@ class ArgumentParser():
 
         oneutils.run([driver_path, '-h'], err_prefix=self.driver)
 
+    def get_option_names(self, *, flatten=False, without_dash=False):
+        names = []
+        for action in self._actions:
+            names.append(action[0])
+
+        if flatten:
+            names = [name for name_l in names for name in name_l]
+        if without_dash:
+            names = [name.split('-')[-1] for name in names]
+
+        return names
+
     def check_if_valid_option_name(self, *args, **kwargs):
+        if any(a.startswith('---') for a in args):
+            raise RuntimeError(
+                "Invalid option name. Please use '-' or '--' prefix for optional arguments."
+            )
+        existing_options = self.get_option_names(flatten=True, without_dash=True)
+        args_without_dash = [arg.split('-')[-1] for arg in args]
+        if any(arg in existing_options for arg in args_without_dash):
+            raise RuntimeError('Duplicate option names')
         if not 'action' in kwargs:
             raise RuntimeError('"action" keyword argument is required')
 

--- a/compiler/one-cmds/onelib/backends.py
+++ b/compiler/one-cmds/onelib/backends.py
@@ -28,6 +28,7 @@ one
 ├── include
 ├── lib
 ├── optimization
+├── target
 └── test
 
 The list where `one-XXXX` finds its backends
@@ -36,6 +37,21 @@ The list where `one-XXXX` finds its backends
 
 NOTE If there are backends of the same name in different places,
     the closer to the top in the list, the higher the priority.
+
+[About TARGET and BACKEND]
+  "Target" refers to an instance from the core of the system and
+  "Backend" refers to an architecture. Say there is a NPU that has
+  multiple cores. Its cores may have different global buffer 
+  size, DSPM size and clock rate, etc, which are described in 
+  each configuration file of "Target". Even though they
+  are different target, they may follow same architecture, which means
+  they have same "Backend".
+
+[Path for TARGET configuration]
+  - /usr/share/one/target/${TARGET}.ini
+
+[Path for BACKEND tools]
+  - /usr/share/one/backends/${BACKEND}
 """
 
 
@@ -62,11 +78,11 @@ def get_list(cmdname):
     return backends_list
 
 
-def get_backend_from_target_conf(target: str):
+def get_value_from_target_conf(target: str, key: str):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     target_conf_path = dir_path + f'/../../target/{target}.ini'
     if not os.path.isfile(target_conf_path):
-        return None
+        raise FileNotFoundError(f"Not found given target configuration: {target}")
 
     # target config doesn't have section.
     # but, configparser needs configs to have one or more sections.
@@ -77,11 +93,16 @@ def get_backend_from_target_conf(target: str):
     parser.read_string(config_str)
     assert parser.has_section(DUMMY_SECTION)
 
-    BACKEND_KEY = 'BACKEND'
-    if BACKEND_KEY in parser[DUMMY_SECTION]:
-        return parser[DUMMY_SECTION][BACKEND_KEY]
+    # Check if target file is valid
+    TARGET_KEY = 'TARGET'
+    assert TARGET_KEY in parser[DUMMY_SECTION]
+    if target != parser[DUMMY_SECTION][TARGET_KEY]:
+        raise RuntimeError("Invalid target file.")
 
-    return None
+    if key in parser[DUMMY_SECTION]:
+        return parser[DUMMY_SECTION][key]
+
+    raise RuntimeError(f"Not found '{key}' key in target configuration.")
 
 
 def search_driver(driver):

--- a/compiler/one-cmds/tests/one-codegen_neg_004.test
+++ b/compiler/one-cmds/tests/one-codegen_neg_004.test
@@ -21,7 +21,7 @@ filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "error: 'command' key is missing in the configuration file" "${filename}.log"; then
+  if grep -q "error: Not found the command for given backend" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi

--- a/compiler/one-cmds/tests/one-codegen_neg_005.test
+++ b/compiler/one-cmds/tests/one-codegen_neg_005.test
@@ -21,7 +21,7 @@ filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "error: commands for the backend is missing" "${filename}.log"; then
+  if grep -q "error: Not found the command for given backend" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi

--- a/compiler/one-cmds/tests/one-codegen_neg_006.ini
+++ b/compiler/one-cmds/tests/one-codegen_neg_006.ini
@@ -1,0 +1,2 @@
+TARGET=one-codegen_neg_006
+BACKEND=dummy

--- a/compiler/one-cmds/tests/one-codegen_neg_006.test
+++ b/compiler/one-cmds/tests/one-codegen_neg_006.test
@@ -14,19 +14,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# commands for the backend is missing
+# use both backend and target option simultaneously.
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
+TARGET_ALREADY_EXIST=true
+
+targetfile="one-codegen_neg_006.ini"
+
+clean_envir()
+{
+  rm -rf ../target/${targetfile}
+  if [ "$TARGET_ALREADY_EXIST" = false ]; then
+    rm -rf ../target/
+  fi
+}
+
 trap_err_onexit()
 {
-  if grep -q "error: Not found the command for given backend" "${filename}.log"; then
+  if grep -q "'backend' option and 'target' option cannot be used simultaneously" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
+    clean_envir
     exit 0
   fi
 
   echo "${filename_ext} FAILED"
+  clean_envir
   exit 255
 }
 
@@ -34,8 +48,16 @@ trap trap_err_onexit ERR
 
 rm -f ${filename}.log
 
+if [ ! -d "../target/" ]; then
+  mkdir -p ../target/
+  TARGET_ALREADY_EXIST=false
+fi
+
+cp ${targetfile} ../target/
+
 # run test
-one-profile -b dummy > ${filename}.log 2>&1
+one-codegen -b dummy -T one-codegen_neg_006 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
+clean_envir
 exit 255

--- a/compiler/one-cmds/tests/one-profile_neg_004.test
+++ b/compiler/one-cmds/tests/one-profile_neg_004.test
@@ -21,7 +21,7 @@ filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "error: 'command' key is missing in the configuration file" "${filename}.log"; then
+  if grep -q "error: Not found the command for given backend" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi

--- a/compiler/one-cmds/tests/onecc_060.ini
+++ b/compiler/one-cmds/tests/onecc_060.ini
@@ -1,2 +1,2 @@
-TARGET=rose
+TARGET=onecc_060
 BACKEND=dummy

--- a/compiler/one-cmds/tests/onecc_066.cfg
+++ b/compiler/one-cmds/tests/onecc_066.cfg
@@ -5,7 +5,6 @@ one-codegen=True
 target=onecc_066
 
 [one-codegen]
-invalid_option=onecc_066
 verbose=True
 input=onecc_066.circle
 output=onecc_066.tvn

--- a/compiler/one-cmds/tests/onecc_066.test
+++ b/compiler/one-cmds/tests/onecc_066.test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Have invalid options in the [one-codegen]
+# valid option with command schema
 
 : '
 This test assumes below directories.
@@ -107,7 +107,7 @@ onecc -C ${configfile} > ${filename}.log 2>&1
 clean_envir
 
 if grep -q "${driver_name} with onecc_066 target" "${outputfile}"; then
-  if grep -q "HELP MESSAGE!!" "${filename}.log"; then
+  if ! grep -q "HELP MESSAGE!!" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi

--- a/compiler/one-cmds/tests/onecc_070.cfg
+++ b/compiler/one-cmds/tests/onecc_070.cfg
@@ -1,0 +1,8 @@
+[onecc]
+one-codegen=True
+
+[backend]
+target=onecc_070
+
+[one-codegen]
+command=True

--- a/compiler/one-cmds/tests/onecc_070.ini
+++ b/compiler/one-cmds/tests/onecc_070.ini
@@ -1,0 +1,2 @@
+TARGET=onecc_070
+BACKEND=dummy

--- a/compiler/one-cmds/tests/onecc_070.py
+++ b/compiler/one-cmds/tests/onecc_070.py
@@ -1,0 +1,11 @@
+from onelib import argumentparse
+from onelib.argumentparse import DriverName, NormalOption, TargetOption
+
+
+def command_schema():
+    parser = argumentparse.ArgumentParser()
+    parser.add_argument("dummyV2-compiler", action=DriverName)
+    parser.add_argument("--target", action=TargetOption)
+    parser.add_argument("--command", action=NormalOption, dtype=bool)
+
+    return parser

--- a/compiler/one-cmds/tests/onecc_070.test
+++ b/compiler/one-cmds/tests/onecc_070.test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# one-codegen -T {target} -- ${command}
+# `command` is part of command schema.
 
 : '
 This test assumes below directories.
@@ -22,6 +22,8 @@ This test assumes below directories.
 [one hierarchy]
     one
     ├── backends
+    │   └── command
+    │       └── codegen
     ├── bin
     ├── doc
     ├── include
@@ -31,22 +33,37 @@ This test assumes below directories.
     └── test # pwd
 '
 
+BACKENDS_ALREADY_EXIST=true
+CMD_ALREADY_EXIST=true
+DUMMY_ALREADY_EXIST=true
 TARGET_ALREADY_EXIST=true
+
+BACKEND_NAME="dummy"
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
-configfile="one-codegen_011.cfg"
-inputfile="one-codegen_011.circle"
-outputfile="one-codegen_011.tvn"
-targetfile="one-codegen_011.ini"
+driver_name="dummyV2-compiler"
+configfile="onecc_070.cfg"
+outputfile="onecc_070.tvn"
+targetfile="onecc_070.ini"
 
 clean_envir()
 {
-  rm -rf ../bin/dummy-compile
+  rm -rf ../bin/${driver_name}
   rm -rf ../target/${targetfile}
+  rm -rf "../backends/command/${BACKEND_NAME}/codegen.py"
   if [ "$TARGET_ALREADY_EXIST" = false ]; then
     rm -rf ../target/
+  fi
+  if [ "$DUMMY_ALREADY_EXIST" = false ]; then
+    rm -rf "../backends/command/${BACKEND_NAME}/"
+  fi
+  if [ "$CMD_ALREADY_EXIST" = false ]; then
+    rm -rf ../backends/command/
+  fi
+  if [ "$BACKENDS_ALREADY_EXIST" = false ]; then
+    rm -rf ../backends/
   fi
 }
 
@@ -59,26 +76,39 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
-rm -rf ${outputfile}
 rm -f ${filename}.log
+rm -rf ${outputfile}
 
 if [ ! -d "../target/" ]; then
   mkdir -p ../target/
   TARGET_ALREADY_EXIST=false
 fi
+if [ ! -d "../backends/" ]; then
+  mkdir -p ../backends/
+  BACKENDS_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/command/" ]; then
+  mkdir -p ../backends/command/
+  CMD_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/command/${BACKEND_NAME}/" ]; then
+  mkdir -p ../backends/command/${BACKEND_NAME}/
+  DUMMY_ALREADY_EXIST=false
+fi
 
-# copy dummy-compile to bin folder
-cp dummy-compile ../bin/dummy-compile
+# copy dummy tools to bin folder
+cp ${driver_name} ../bin/
 cp ${targetfile} ../target/
+cp onecc_070.py "../backends/command/${BACKEND_NAME}/codegen.py"
 
 # run test
-one-codegen -T one-codegen_011 -- -o ${outputfile} ${inputfile} > ${filename}.log 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 clean_envir
 
-if grep -q "dummy-compile with one-codegen_011 target" "${outputfile}"; then
-  echo "${filename_ext} SUCCESS"
-  exit 0
+if grep -q "${driver_name} with onecc_070 target" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
 fi
 
 trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_071.cfg
+++ b/compiler/one-cmds/tests/onecc_071.cfg
@@ -1,0 +1,8 @@
+[onecc]
+one-codegen=True
+
+[backend]
+target=onecc_071
+
+[one-codegen]
+__command=--command

--- a/compiler/one-cmds/tests/onecc_071.ini
+++ b/compiler/one-cmds/tests/onecc_071.ini
@@ -1,0 +1,2 @@
+TARGET=onecc_071
+BACKEND=dummyV3

--- a/compiler/one-cmds/tests/onecc_071.py
+++ b/compiler/one-cmds/tests/onecc_071.py
@@ -1,0 +1,11 @@
+from onelib import argumentparse
+from onelib.argumentparse import DriverName, NormalOption, TargetOption
+
+
+def command_schema():
+    parser = argumentparse.ArgumentParser()
+    parser.add_argument("dummyV2-compiler", action=DriverName)
+    parser.add_argument("--target", action=TargetOption)
+    parser.add_argument("--command", action=NormalOption, dtype=bool)
+
+    return parser

--- a/compiler/one-cmds/tests/onecc_071.test
+++ b/compiler/one-cmds/tests/onecc_071.test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# one-codegen -T {target} -- ${command}
+# `command` is part of command schema but do not want to use command schema.
 
 : '
 This test assumes below directories.
@@ -22,6 +22,8 @@ This test assumes below directories.
 [one hierarchy]
     one
     ├── backends
+    │   └── command
+    │       └── codegen
     ├── bin
     ├── doc
     ├── include
@@ -31,22 +33,37 @@ This test assumes below directories.
     └── test # pwd
 '
 
+BACKENDS_ALREADY_EXIST=true
+CMD_ALREADY_EXIST=true
+DUMMY_ALREADY_EXIST=true
 TARGET_ALREADY_EXIST=true
+
+BACKEND_NAME="dummyV3"
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
-configfile="one-codegen_011.cfg"
-inputfile="one-codegen_011.circle"
-outputfile="one-codegen_011.tvn"
-targetfile="one-codegen_011.ini"
+driver_name="${BACKEND_NAME}-compile"
+configfile="onecc_071.cfg"
+outputfile="onecc_071.tvn"
+targetfile="onecc_071.ini"
 
 clean_envir()
 {
-  rm -rf ../bin/dummy-compile
+  rm -rf ../bin/${driver_name}
   rm -rf ../target/${targetfile}
+  rm -rf "../backends/command/${BACKEND_NAME}/codegen.py"
   if [ "$TARGET_ALREADY_EXIST" = false ]; then
     rm -rf ../target/
+  fi
+  if [ "$DUMMY_ALREADY_EXIST" = false ]; then
+    rm -rf "../backends/command/${BACKEND_NAME}/"
+  fi
+  if [ "$CMD_ALREADY_EXIST" = false ]; then
+    rm -rf ../backends/command/
+  fi
+  if [ "$BACKENDS_ALREADY_EXIST" = false ]; then
+    rm -rf ../backends/
   fi
 }
 
@@ -59,26 +76,39 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
-rm -rf ${outputfile}
 rm -f ${filename}.log
+rm -rf ${outputfile}
 
 if [ ! -d "../target/" ]; then
   mkdir -p ../target/
   TARGET_ALREADY_EXIST=false
 fi
+if [ ! -d "../backends/" ]; then
+  mkdir -p ../backends/
+  BACKENDS_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/command/" ]; then
+  mkdir -p ../backends/command/
+  CMD_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/command/${BACKEND_NAME}/" ]; then
+  mkdir -p ../backends/command/${BACKEND_NAME}/
+  DUMMY_ALREADY_EXIST=false
+fi
 
-# copy dummy-compile to bin folder
-cp dummy-compile ../bin/dummy-compile
+# copy dummy tools to bin folder
+cp ${driver_name} ../bin/
 cp ${targetfile} ../target/
+cp onecc_071.py "../backends/command/${BACKEND_NAME}/codegen.py"
 
 # run test
-one-codegen -T one-codegen_011 -- -o ${outputfile} ${inputfile} > ${filename}.log 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 clean_envir
 
-if grep -q "dummy-compile with one-codegen_011 target" "${outputfile}"; then
-  echo "${filename_ext} SUCCESS"
-  exit 0
+if grep -q "${BACKEND_NAME}-compile with onecc_071 target" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
 fi
 
 trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_072.cfg
+++ b/compiler/one-cmds/tests/onecc_072.cfg
@@ -1,0 +1,9 @@
+[onecc]
+one-codegen=True
+
+[backend]
+target=onecc_072
+
+[one-codegen]
+backend=dummyV3
+__command=--command

--- a/compiler/one-cmds/tests/onecc_072.ini
+++ b/compiler/one-cmds/tests/onecc_072.ini
@@ -1,0 +1,2 @@
+TARGET=onecc_072
+BACKEND=dummyV2

--- a/compiler/one-cmds/tests/onecc_072.py
+++ b/compiler/one-cmds/tests/onecc_072.py
@@ -1,0 +1,11 @@
+from onelib import argumentparse
+from onelib.argumentparse import DriverName, NormalOption, TargetOption
+
+
+def command_schema():
+    parser = argumentparse.ArgumentParser()
+    parser.add_argument("dummyV2-compiler", action=DriverName)
+    parser.add_argument("--target", action=TargetOption)
+    parser.add_argument("--command", action=NormalOption, dtype=bool)
+
+    return parser

--- a/compiler/one-cmds/tests/onecc_072.test
+++ b/compiler/one-cmds/tests/onecc_072.test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# one-codegen -T {target} -- ${command}
+# one-codgen.backend is given.
 
 : '
 This test assumes below directories.
@@ -22,6 +22,8 @@ This test assumes below directories.
 [one hierarchy]
     one
     ├── backends
+    │   └── command
+    │       └── codegen
     ├── bin
     ├── doc
     ├── include
@@ -31,22 +33,37 @@ This test assumes below directories.
     └── test # pwd
 '
 
+BACKENDS_ALREADY_EXIST=true
+CMD_ALREADY_EXIST=true
+DUMMY_ALREADY_EXIST=true
 TARGET_ALREADY_EXIST=true
+
+BACKEND_NAME="dummyV3"
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
-configfile="one-codegen_011.cfg"
-inputfile="one-codegen_011.circle"
-outputfile="one-codegen_011.tvn"
-targetfile="one-codegen_011.ini"
+driver_name="dummyV3-compile"
+configfile="onecc_072.cfg"
+outputfile="onecc_072.tvn"
+targetfile="onecc_072.ini"
 
 clean_envir()
 {
-  rm -rf ../bin/dummy-compile
+  rm -rf ../bin/${driver_name}
   rm -rf ../target/${targetfile}
+  rm -rf "../backends/command/${BACKEND_NAME}/codegen.py"
   if [ "$TARGET_ALREADY_EXIST" = false ]; then
     rm -rf ../target/
+  fi
+  if [ "$DUMMY_ALREADY_EXIST" = false ]; then
+    rm -rf "../backends/command/${BACKEND_NAME}/"
+  fi
+  if [ "$CMD_ALREADY_EXIST" = false ]; then
+    rm -rf ../backends/command/
+  fi
+  if [ "$BACKENDS_ALREADY_EXIST" = false ]; then
+    rm -rf ../backends/
   fi
 }
 
@@ -59,26 +76,39 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
-rm -rf ${outputfile}
 rm -f ${filename}.log
+rm -rf ${outputfile}
 
 if [ ! -d "../target/" ]; then
   mkdir -p ../target/
   TARGET_ALREADY_EXIST=false
 fi
+if [ ! -d "../backends/" ]; then
+  mkdir -p ../backends/
+  BACKENDS_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/command/" ]; then
+  mkdir -p ../backends/command/
+  CMD_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/command/${BACKEND_NAME}/" ]; then
+  mkdir -p ../backends/command/${BACKEND_NAME}/
+  DUMMY_ALREADY_EXIST=false
+fi
 
-# copy dummy-compile to bin folder
-cp dummy-compile ../bin/dummy-compile
+# copy dummy tools to bin folder
+cp ${driver_name} ../bin/
 cp ${targetfile} ../target/
+cp onecc_072.py "../backends/command/${BACKEND_NAME}/codegen.py"
 
 # run test
-one-codegen -T one-codegen_011 -- -o ${outputfile} ${inputfile} > ${filename}.log 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 clean_envir
 
-if grep -q "dummy-compile with one-codegen_011 target" "${outputfile}"; then
-  echo "${filename_ext} SUCCESS"
-  exit 0
+if grep -q "${driver_name} with onecc_072 target" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
 fi
 
 trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_neg_028.test
+++ b/compiler/one-cmds/tests/onecc_neg_028.test
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# use 'backend' and 'backends' option simultaneously
+# use 'backend' and 'backends' keys simultaneously
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "option cannot be used simultaneously" "${filename}.log"; then
+  if grep -q "keys cannot be used simultaneously" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi

--- a/compiler/one-cmds/tests/onecc_neg_033.test
+++ b/compiler/one-cmds/tests/onecc_neg_033.test
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# use 'backend' and 'backends' option simultaneously
+# use 'backend' and 'backends' keys simultaneously
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "option cannot be used simultaneously" "${filename}.log"; then
+  if grep -q "keys cannot be used simultaneously" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi

--- a/compiler/one-cmds/tests/onecc_neg_039.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_039.cfg
@@ -1,0 +1,11 @@
+[onecc]
+one-codegen=True
+
+[backend]
+target=onecc_neg_039
+
+[one-codegen]
+invalid_option=onecc_neg_039
+verbose=True
+input=onecc_neg_039.circle
+output=onecc_neg_039.tvn

--- a/compiler/one-cmds/tests/onecc_neg_039.ini
+++ b/compiler/one-cmds/tests/onecc_neg_039.ini
@@ -1,0 +1,2 @@
+TARGET=onecc_neg_039
+BACKEND=dummy

--- a/compiler/one-cmds/tests/onecc_neg_039.py
+++ b/compiler/one-cmds/tests/onecc_neg_039.py
@@ -1,0 +1,13 @@
+from onelib import argumentparse
+from onelib.argumentparse import DriverName, NormalOption, TargetOption
+
+
+def command_schema():
+    parser = argumentparse.ArgumentParser()
+    parser.add_argument("dummy-compiler", action=DriverName)
+    parser.add_argument("--target", action=TargetOption)
+    parser.add_argument("--verbose", action=NormalOption, dtype=bool)
+    parser.add_argument("input", action=NormalOption)
+    parser.add_argument("output", action=NormalOption)
+
+    return parser

--- a/compiler/one-cmds/tests/onecc_neg_039.test
+++ b/compiler/one-cmds/tests/onecc_neg_039.test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Boolean type option has multiple options. 
+# Have invalid options in the [one-codegen]
 
 : '
 This test assumes below directories.
@@ -44,9 +44,9 @@ filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
 driver_name="dummy-compiler"
-configfile="onecc_neg_038.cfg"
-outputfile="onecc_neg_038.tvn"
-targetfile="onecc_neg_038.ini"
+configfile="onecc_neg_039.cfg"
+outputfile="onecc_neg_039.tvn"
+targetfile="onecc_neg_039.ini"
 
 clean_envir()
 {
@@ -69,7 +69,7 @@ clean_envir()
 
 trap_err_onexit()
 {
-  if grep -q "Only either of option type is allowed: positional or optional" "${filename}.log"; then
+  if grep -q "Invalid option in \[one-codegen\] section" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     clean_envir
     exit 0
@@ -105,7 +105,7 @@ fi
 # copy dummy tools to bin folder
 cp ${driver_name} ../bin/
 cp ${targetfile} ../target/
-cp onecc_neg_038.py "../backends/command/${BACKEND_NAME}/codegen.py"
+cp onecc_neg_039.py "../backends/command/${BACKEND_NAME}/codegen.py"
 
 # run test
 onecc -C ${configfile} > ${filename}.log 2>&1


### PR DESCRIPTION
This commit revises codegen and profile scripts.

As of now, the logic was too complicated for broad flexibility of interface. To tackle https://github.com/Samsung/ONE/issues/13655#issuecomment-2339912605, I've revised codes.

- Revise the overall logic to make it easy to maintain.
- Allow `__command` key for command customization.
- Add more description.
- Rename confusing variables.
- Add more tests.
- Add missing checks for input validation.

 

Related: #13655
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>