### PR TITLE
[luci/service] Migrate logistic op to sinf::Algorithm

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -91,7 +91,7 @@ public:
   // loco::TensorShape visit(const luci::CircleLogicalAnd *node) final;
   // loco::TensorShape visit(const luci::CircleLogicalNot *node) final;
   // loco::TensorShape visit(const luci::CircleLogicalOr *node) final;
-  // loco::TensorShape visit(const luci::CircleLogistic *node) final;
+  loco::TensorShape visit(const luci::CircleLogistic *node) final;
   // loco::TensorShape visit(const luci::CircleLogSoftmax *node) final;
   // loco::TensorShape visit(const luci::CircleMatrixDiag *node) final;
   // loco::TensorShape visit(const luci::CircleMatrixSetDiag *node) final;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2095,8 +2095,6 @@ public:
 
   loco::NodeShape visit(const luci::CircleLogicalOr *node) final { return use_x(node); }
 
-  loco::NodeShape visit(const luci::CircleLogistic *node) final { return use_x(node); }
-
   loco::NodeShape visit(const luci::CircleLogSoftmax *node) final { return use_logits(node); }
 
   loco::NodeShape visit(const luci::CircleMatrixDiag *node) final

--- a/compiler/luci/service/src/Nodes/CircleLogistic.cpp
+++ b/compiler/luci/service/src/Nodes/CircleLogistic.cpp
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+#include "luci/Service/CircleShapeInference.h"
+
 #include "CircleCloneNode.h"
+#include "CircleShapeInferenceHelper.h"
 
 namespace luci
 {
@@ -23,5 +26,17 @@ luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleLogistic *)
 {
   return _graph->nodes()->create<luci::CircleLogistic>();
 }
+
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleLogistic *node)
+{
+  const auto input_x = loco::must_cast<luci::CircleNode *>(node->x());
+  const auto input_shape = circle_shape(input_x);
+  return input_shape;
+}
+
+} // namespace sinf
 
 } // namespace luci


### PR DESCRIPTION
This commit migrates logistic operation to sinf::Algorithm

Related: https://github.com/Samsung/ONE/issues/13697
Draft: https://github.com/Samsung/ONE/pull/13992

ONE-DCO-1.0-Signed-off-by: Jongwon Yang <yjw963@gmail.com>