### PR TITLE
[onert] Initialize ggml context in CPU ExternalContext

### DIFF
--- a/runtime/onert/backend/cpu/CMakeLists.txt
+++ b/runtime/onert/backend/cpu/CMakeLists.txt
@@ -12,6 +12,8 @@ target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE nnfw_coverage)
 target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE ruy)
 target_link_libraries(${LIB_ONERT_BACKEND_CPU} INTERFACE ruy_instrumentation)
 target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE ndarray)
+# Set public: ExternalContext is used in train backend
+target_link_libraries(${LIB_ONERT_BACKEND_CPU} PUBLIC ggml)
 
 set_target_properties(${LIB_ONERT_BACKEND_CPU} PROPERTIES
   OUTPUT_NAME backend_cpu

--- a/runtime/onert/backend/cpu/ExternalContext.h
+++ b/runtime/onert/backend/cpu/ExternalContext.h
@@ -19,6 +19,7 @@
 
 #include <util/ConfigSource.h>
 #include <ruy/context.h>
+#include <ggml.h>
 
 #include <memory>
 
@@ -47,10 +48,18 @@ public:
     _ruy_context->set_max_num_threads(target_num_threads);
   }
 
+  void initGgmlContext()
+  {
+    if (_ggml_context == nullptr)
+      _ggml_context = std::unique_ptr<ggml_context, decltype(&ggml_free)>(
+        ggml_init({.mem_size = 0, .mem_buffer = nullptr, .no_alloc = true}), &ggml_free);
+  }
+
   ruy::Context *ruy_context() const { return _ruy_context.get(); }
 
 private:
   const std::unique_ptr<ruy::Context> _ruy_context;
+  std::unique_ptr<ggml_context, decltype(&ggml_free)> _ggml_context{nullptr, &ggml_free};
 };
 
 } // namespace cpu


### PR DESCRIPTION
This commit updates CPU backend ExternalContext to initialize GGML context to prepare GGML support.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/13909 https://github.com/Samsung/ONE/issues/13910
Draft: #13956