### PR TITLE
[common-artifacts] Exclude RmsNorm test

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -178,3 +178,4 @@ tcgenerate(CircleFullyConnected_U4_002)
 tcgenerate(GRU_000) # luci-interpreter does not support custom GRU
 tcgenerate(InstanceNorm_000)
 tcgenerate(InstanceNorm_001)
+tcgenerate(RmsNorm_000)


### PR DESCRIPTION
This commit is to exclude RmsNorm test until it's fully applied. 
It will be reverted once RmsNorm is fully applied.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967