### PR TITLE
[one-cmds] Add missing clean envir in tests

### DIFF
--- a/compiler/one-cmds/tests/one-codegen_006.test
+++ b/compiler/one-cmds/tests/one-codegen_006.test
@@ -52,7 +52,7 @@ clean_envir()
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"
-  rm -rf ../bin/dummy-compile
+  clean_envir
   exit 255
 }
 

--- a/compiler/one-cmds/tests/one-codegen_010.test
+++ b/compiler/one-cmds/tests/one-codegen_010.test
@@ -52,7 +52,7 @@ clean_envir()
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"
-  rm -rf ../bin/dummy-compile
+  clean_envir
   exit 255
 }
 

--- a/compiler/one-cmds/tests/one-codegen_011.test
+++ b/compiler/one-cmds/tests/one-codegen_011.test
@@ -53,7 +53,7 @@ clean_envir()
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"
-  rm -rf ../bin/dummy-compile
+  clean_envir
   exit 255
 }
 

--- a/compiler/one-cmds/tests/one-profile_006.test
+++ b/compiler/one-cmds/tests/one-profile_006.test
@@ -52,7 +52,7 @@ clean_envir()
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"
-  rm -rf ../bin/dummy-profile
+  clean_envir
   exit 255
 }
 

--- a/compiler/one-cmds/tests/one-profile_010.test
+++ b/compiler/one-cmds/tests/one-profile_010.test
@@ -52,7 +52,7 @@ clean_envir()
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"
-  rm -rf ../bin/dummy-profile
+  clean_envir
   exit 255
 }
 

--- a/compiler/one-cmds/tests/one-profile_011.test
+++ b/compiler/one-cmds/tests/one-profile_011.test
@@ -52,7 +52,7 @@ clean_envir()
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"
-  rm -rf ../bin/dummy-profile
+  clean_envir
   exit 255
 }
 

--- a/compiler/one-cmds/tests/onecc_057.test
+++ b/compiler/one-cmds/tests/onecc_057.test
@@ -19,11 +19,16 @@
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
+clean_envir()
+{
+  rm -rf ../bin/dummyV2-profile
+  rm -rf ../bin/dummyV3-profile
+}
+
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"
-  rm -rf ../bin/dummyV2-profile
-  rm -rf ../bin/dummyV3-profile
+  clean_envir
   exit 255
 }
 
@@ -45,7 +50,6 @@ if ! grep -q "dummyV3-profile with onecc_057_overwrite" "${filename}.log"; then
   trap_err_onexit
 fi
 
-rm -rf ../bin/dummyV2-profile
-rm -rf ../bin/dummyV3-profile
+clean_envir
 
 echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_neg_038.test
+++ b/compiler/one-cmds/tests/onecc_neg_038.test
@@ -69,6 +69,8 @@ clean_envir()
 
 trap_err_onexit()
 {
+  clean_envir
+
   if grep -q "Only either of option type is allowed: positional or optional" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
@@ -107,6 +109,8 @@ cp onecc_neg_038.py "../backends/command/${BACKEND_NAME}/codegen.py"
 
 # run test
 onecc -C ${configfile} > ${filename}.log 2>&1
+
+clean_envir
 
 echo "${filename_ext} FAILED"
 exit 255


### PR DESCRIPTION
This commit adds missing clean envir in test.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>