### PR TITLE
[luci/service] Change assert to throw exception for invalid paddings

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -168,14 +168,17 @@ loco::TensorShape pad_shape(const loco::TensorShape &input_shape, const luci::Ci
 
   // TODO support other data type
   LUCI_ASSERT(paddings->dtype() == S32 || paddings->dtype() == S64, "Support int 32/64 for now");
-  LUCI_ASSERT(paddings->rank() == 2, "paddings should be rank 2");
+  if (paddings->rank() != 2)
+    INTERNAL_EXN("paddings should be rank 2");
 
   int32_t n = paddings->dim(0).value();
   int32_t v = paddings->dim(1).value();
 
-  LUCI_ASSERT(v == 2, "paddings should be [n, 2]");
-  LUCI_ASSERT(n == int32_t(input_shape.rank()),
-              "paddings [n, 2] should have same value of input rank");
+  if (v != 2)
+    INTERNAL_EXN("paddings should be [n, 2]");
+
+  if (n != int32_t(input_shape.rank()))
+    INTERNAL_EXN("paddings [n, 2] should have same value of input rank");
 
   loco::TensorShape output_shape;
 

--- a/compiler/luci/service/src/Nodes/CirclePad.test.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePad.test.cpp
@@ -124,3 +124,87 @@ TEST(ShapeRuleTest, pad_non_const_paddings)
   ASSERT_EQ(0, shape.dim(2).value());
   ASSERT_EQ(0, shape.dim(3).value());
 }
+
+TEST(ShapeRuleTest, paddings_invalid_rank_NEG)
+{
+  auto g = loco::make_graph();
+  auto node_pad = g->nodes()->create<luci::CirclePad>();
+
+  auto node_paddings = g->nodes()->create<luci::CircleConst>();
+  auto node_input = g->nodes()->create<luci::CircleInput>();
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  node_input->shape({1, 2, 3, 4});
+  node_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_paddings->dtype(loco::DataType::S64);
+  node_paddings->shape({4, 2, 3});
+  node_paddings->shape_status(luci::ShapeStatus::VALID);
+
+  const loco::DataType S64 = loco::DataType::S64;
+  uint32_t t = 64 * 8;
+  node_paddings->size<S64>(t);
+
+  node_pad->input(node_input);
+  node_pad->paddings(node_paddings);
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(node_pad, shape));
+}
+
+TEST(ShapeRuleTest, paddings_invalid_shape_1_NEG)
+{
+  auto g = loco::make_graph();
+  auto node_pad = g->nodes()->create<luci::CirclePad>();
+
+  auto node_paddings = g->nodes()->create<luci::CircleConst>();
+  auto node_input = g->nodes()->create<luci::CircleInput>();
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  node_input->shape({1, 2, 3, 4});
+  node_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_paddings->dtype(loco::DataType::S64);
+  node_paddings->shape({4, 4});
+  node_paddings->shape_status(luci::ShapeStatus::VALID);
+
+  const loco::DataType S64 = loco::DataType::S64;
+  uint32_t t = 64 * 8;
+  node_paddings->size<S64>(t);
+
+  node_pad->input(node_input);
+  node_pad->paddings(node_paddings);
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(node_pad, shape));
+}
+
+TEST(ShapeRuleTest, paddings_invalid_shape_2_NEG)
+{
+  auto g = loco::make_graph();
+  auto node_pad = g->nodes()->create<luci::CirclePad>();
+
+  auto node_paddings = g->nodes()->create<luci::CircleConst>();
+  auto node_input = g->nodes()->create<luci::CircleInput>();
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  node_input->shape({1, 2, 3, 4});
+  node_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_paddings->dtype(loco::DataType::S64);
+  node_paddings->shape({5, 2});
+  node_paddings->shape_status(luci::ShapeStatus::VALID);
+
+  const loco::DataType S64 = loco::DataType::S64;
+  uint32_t t = 64 * 8;
+  node_paddings->size<S64>(t);
+
+  node_pad->input(node_input);
+  node_pad->paddings(node_paddings);
+
+  ASSERT_ANY_THROW(shape_inf_rule.infer(node_pad, shape));
+}


### PR DESCRIPTION
This PR modifies the pad operation to throw exceptions for invalid paddings, replacing the previous assert conditions.

ONE-DCO-1.0-Signed-off-by: JuYoung Lee rsb98759@gmail.com