### PR TITLE
[onert/backend] Add tests for LayerScopeTensorIndex planner

### DIFF
--- a/runtime/onert/backend/train/MemoryPlanner.test.cc
+++ b/runtime/onert/backend/train/MemoryPlanner.test.cc
@@ -25,7 +25,6 @@ using namespace onert::backend::train;
 using onert::ir::OperandIndex;
 using onert::ir::OperationIndex;
 
-// TODO: Add test testcase for {Bump, FirstFit, WIC}Planner<LayerScopeTensor>
 namespace
 {
 
@@ -276,4 +275,189 @@ TEST(WICPlanner, disposable_claim_release_test)
   });
 }
 
-// Add Testcase for LayerScopeTensorIndex, using PlannerVerifier
+TEST(BumpPlanner, layerscope_claim_test)
+{
+  PlannerVerifier<BumpPlanner, LayerScopeTensorIndex> p;
+
+  ASSERT_NO_FATAL_FAILURE({
+    p.claim(0, 0, 10, 0);
+    p.claim(1, 0, 20, 10);
+    p.claim(2, 2, 30, 30);
+    p.release(0, 0);
+    p.capacity(60);
+  });
+}
+
+TEST(FirstFitPlanner, layerscope_claim_release_test)
+{
+  PlannerVerifier<FirstFitPlanner, LayerScopeTensorIndex> p;
+
+  ASSERT_NO_FATAL_FAILURE({
+    // 0 CLAIM - 10
+    p.claim(0, 0, 10, 0);
+
+    // 1 CLAIM - 20
+    p.claim(1, 0, 20, 10);
+
+    // 2 CLAIM - 30
+    p.claim(2, 2, 30, 30);
+
+    // 0 RELEASE - 10
+    p.release(0, 0);
+
+    // 3 CLAIM - 20
+    p.claim(3, 1, 20, 60);
+
+    // 4 CLAIM - 5
+    p.claim(4, 1, 5, 0);
+
+    // 5 CLAIM - 10
+    p.claim(5, 1, 10, 80);
+
+    // 6 CLAIM - 5
+    p.claim(6, 1, 5, 5);
+
+    // 2 RELEASE - 30
+    p.release(2, 2);
+
+    // 7 CLAIM - 35
+    p.claim(7, 1, 35, 90);
+
+    // 8 CLAIM - 10
+    p.claim(8, 1, 10, 30);
+
+    // 4 RELEASE - 5
+    p.release(4, 1);
+
+    // 9 CLAIM - 10
+    p.claim(9, 0, 10, 40);
+
+    // 10 CLAIM - 10
+    p.claim(10, 0, 10, 50);
+
+    // 6 RELEASE
+    p.release(6, 1);
+
+    // 1 RELEASE
+    p.release(1, 0);
+
+    // 8 RELEASE
+    p.release(8, 1);
+
+    // 9 RELEASE
+    p.release(9, 0);
+
+    // 10 RELEASE
+    p.release(10, 0);
+
+    // 3 RELEASE
+    p.release(3, 1);
+
+    // 5 RELEASE
+    p.release(5, 1);
+
+    // 7 RELEASE
+    p.release(7, 1);
+
+    // CAPACITY - 125
+    p.capacity(125);
+  });
+}
+
+TEST(FirstFitPlanner, layerscope_neg_release_non_existing_index)
+{
+  PlannerVerifier<FirstFitPlanner, LayerScopeTensorIndex> p;
+
+  auto on_only_debug_mode = [&p]() {
+    EXPECT_DEATH({ p.release(0, 1); },
+                 "Cannot release for given index. It has been not claimed or released already.");
+    return true;
+  };
+
+  ASSERT_NO_FATAL_FAILURE({
+    // 0 CLAIM - 10
+    p.claim(0, 0, 10, 0);
+
+    // 1 CLAIM - 20
+    p.claim(1, 0, 20, 10);
+
+    // 2 CLAIM - 30
+    p.claim(2, 2, 30, 30);
+
+    // RELEASE non-existing index
+    assert(on_only_debug_mode());
+  });
+}
+
+TEST(FirstFitPlanner, layerscope_neg_release_twice)
+{
+  PlannerVerifier<FirstFitPlanner, LayerScopeTensorIndex> p;
+
+  auto on_only_debug_mode = [&p]() {
+    EXPECT_EXIT({ p.release(0, 0); }, ::testing::KilledBySignal(SIGABRT),
+                "Cannot release for given index. It has been not claimed or released already.");
+    return true;
+  };
+
+  ASSERT_NO_FATAL_FAILURE({
+    // 0 CLAIM - 10
+    p.claim(0, 0, 10, 0);
+
+    // 1 CLAIM - 20
+    p.claim(1, 0, 20, 10);
+
+    // 2 CLAIM - 30
+    p.claim(2, 2, 30, 30);
+
+    // 0 RELEASE - 10
+    p.release(0, 0);
+
+    // 0 RELEASE again
+    assert(on_only_debug_mode());
+  });
+}
+
+TEST(WICPlanner, claim_release_test)
+{
+  PlannerVerifier<WICPlanner, LayerScopeTensorIndex> p;
+
+  ASSERT_NO_FATAL_FAILURE({
+    p.claim(0, 0, 20);
+    p.claim(1, 0, 5);
+    p.release(0, 0);
+    p.claim(2, 2, 10);
+    p.release(1, 0);
+    p.claim(3, 1, 10);
+    p.release(2, 2);
+    p.claim(4, 1, 10);
+    p.release(3, 1);
+    p.claim(5, 1, 20);
+    p.release(4, 1);
+    p.claim(6, 1, 20);
+    p.release(5, 1);
+
+    // VERIFY 0 - 0
+    p.verify(0, 0, 20, 0);
+
+    // VERIFY 1 - 20
+    p.verify(1, 0, 5, 20);
+
+    // VERIFY 2 - 0
+    p.verify(2, 2, 10, 0);
+
+    // VERIFY 3 - 10
+    p.verify(3, 1, 10, 10);
+
+    // VERIFY 4 - 20
+    p.verify(4, 1, 10, 20);
+
+    // VERIFY 5 - 0
+    p.verify(5, 1, 20, 0);
+
+    // VERIFY 6 - 20
+    p.verify(6, 1, 20, 20);
+
+    // CAPACITY - 40
+    p.capacity(40);
+  });
+}

--- a/runtime/onert/backend/train/MemoryPlanner.test.cc
+++ b/runtime/onert/backend/train/MemoryPlanner.test.cc
@@ -364,7 +364,7 @@ TEST(FirstFitPlanner, layerscope_claim_release_test)
   });
 }
 
-TEST(FirstFitPlanner, layerscope_neg_release_non_existing_index)
+TEST(FirstFitPlanner, neg_layerscope_release_non_existing_index)
 {
   PlannerVerifier<FirstFitPlanner, LayerScopeTensorIndex> p;
 
@@ -389,7 +389,7 @@ TEST(FirstFitPlanner, layerscope_neg_release_non_existing_index)
   });
 }
 
-TEST(FirstFitPlanner, layerscope_neg_release_twice)
+TEST(FirstFitPlanner, neg_layerscope_release_twice)
 {
   PlannerVerifier<FirstFitPlanner, LayerScopeTensorIndex> p;
 
@@ -417,7 +417,7 @@ TEST(FirstFitPlanner, layerscope_neg_release_twice)
   });
 }
 
-TEST(WICPlanner, claim_release_test)
+TEST(WICPlanner, layerscope_claim_release_test)
 {
   PlannerVerifier<WICPlanner, LayerScopeTensorIndex> p;
 


### PR DESCRIPTION
This PR adds test ceases for LayerScopeTensorIndex based MemoryPlanner.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>

related : https://github.com/Samsung/ONE/pull/13892#pullrequestreview-2278797746