### PR TITLE
[onert] Remove backend layout helper

### DIFF
--- a/runtime/onert/backend/acl_common/Convert.cc
+++ b/runtime/onert/backend/acl_common/Convert.cc
@@ -252,19 +252,6 @@ std::unique_ptr<AclFunction> asAclFunction(std::unique_ptr<::arm_compute::IFunct
   return std::make_unique<AclFunction>(std::move(layer));
 }
 
-ir::Layout asRuntimeLayout(::arm_compute::DataLayout data_layout)
-{
-  switch (data_layout)
-  {
-    case ::arm_compute::DataLayout::NHWC:
-      return ir::Layout::NHWC;
-    case ::arm_compute::DataLayout::NCHW:
-      return ir::Layout::NCHW;
-    default:
-      return ir::Layout::UNKNOWN;
-  }
-}
-
 ir::DataType asRuntimeDataType(::arm_compute::DataType data_type)
 {
   switch (data_type)

--- a/runtime/onert/backend/acl_common/Convert.h
+++ b/runtime/onert/backend/acl_common/Convert.h
@@ -73,7 +73,6 @@ std::unique_ptr<T_Function> asFunction(std::unique_ptr<::arm_compute::IFunction>
   return std::make_unique<T_Function>(std::move(fn));
 }
 
-ir::Layout asRuntimeLayout(::arm_compute::DataLayout data_layout);
 ir::DataType asRuntimeDataType(::arm_compute::DataType data_type);
 
 arm_compute::PoolingType convertPoolType(ir::operation::Pool2D::PoolType pool_type_ir);

--- a/runtime/onert/backend/trix/Convert.cc
+++ b/runtime/onert/backend/trix/Convert.cc
@@ -23,19 +23,6 @@ namespace backend
 namespace trix
 {
 
-data_layout convertDataLayout(const ir::Layout layout)
-{
-  switch (layout)
-  {
-    case ir::Layout::NCHW:
-      return DATA_LAYOUT_NCHW;
-    case ir::Layout::NHWC:
-      return DATA_LAYOUT_NHWC;
-    default:
-      throw std::runtime_error("Unknown Layout");
-  }
-}
-
 data_type convertDataType(const ir::DataType type)
 {
   switch (type)

--- a/runtime/onert/backend/trix/Convert.h
+++ b/runtime/onert/backend/trix/Convert.h
@@ -32,14 +32,6 @@ namespace trix
 {
 
 /**
- * @brief Convert type of layout from onert type to npu type
- *
- * @param layout Layout type in onert
- * @return data_layout Layout type in npu
- */
-data_layout convertDataLayout(const ir::Layout layout);
-
-/**
  * @brief Convert type of data from onert type to npu type
  *
  * @param type Data type in onert


### PR DESCRIPTION
This commit removes unused backend layout helper functions.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>