### PR TITLE
 [onert/backend] Introduce LayerScopeMemoryManager

### DIFF
--- a/runtime/onert/backend/train/MemoryManager.h
+++ b/runtime/onert/backend/train/MemoryManager.h
@@ -20,6 +20,7 @@
 #include <backend/basic/MemoryManager.h>
 
 #include "DisposableTensorIndex.h"
+#include "LayerScopeTensorIndex.h"
 
 namespace onert
 {
@@ -67,7 +68,25 @@ private:
   std::shared_ptr<basic::Allocator> _mem_alloc;
 };
 
-// TODO: Add LayerScopeMemoryManager using MemoryPlannerFactory<LayerScopeTensorIndex>
+class LayerScopeMemoryManager
+{
+public:
+  LayerScopeMemoryManager();
+
+  void allocate(void);
+  uint8_t *getBuffer(const LayerScopeTensorIndex &ind) const;
+  void deallocate(void);
+
+  void claimPlan(const LayerScopeTensorIndex &ind, uint32_t size);
+  void releasePlan(const LayerScopeTensorIndex &ind);
+
+private:
+  basic::IMemoryPlanner<LayerScopeTensorIndex> *createMemoryPlanner();
+
+private:
+  std::shared_ptr<basic::IMemoryPlanner<LayerScopeTensorIndex>> _mem_planner;
+  std::shared_ptr<basic::Allocator> _mem_alloc;
+};
 
 } // namespace train
 } // namespace backend

--- a/runtime/onert/backend/train/TensorManager.h
+++ b/runtime/onert/backend/train/TensorManager.h
@@ -61,6 +61,7 @@ public:
   void releaseGradientPlan(const ir::OperandIndex &ind);
   void claimDisposableBackPropPlan(const DisposableTensorIndex &ind);
   void releaseDisposableBackPropPlan(const DisposableTensorIndex &ind);
+  // TODO Add member functions related to LayerScopeMemoryManager
 
 private:
   std::unique_ptr<MemoryManager> _nonconst_mgr;
@@ -68,6 +69,8 @@ private:
   std::unique_ptr<MemoryManager> _back_prop_mgr;
   std::unique_ptr<MemoryManager> _gradient_mgr;
   std::unique_ptr<DisposableMemoryManager> _disposable_back_prop_mgr;
+  // TODO: enable _layer_scope_mgr
+  // std::unique_ptr<LayerScopeMemoryManager> _layer_scope_mgr;
   const std::shared_ptr<TensorRegistry> _tensors;
 };
 


### PR DESCRIPTION
This PR introduces LayerScopeMemoryManager.
This Manager will be added to TensorManager and used to allocate LayerScopeTensors.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>

draft : https://github.com/Samsung/ONE/pull/13486
for : https://github.com/Samsung/ONE/issues/13282 