### PR TITLE
[res] CircleRecipes and TFLiteRecipes added for RmsNorm

### DIFF
--- a/res/CircleRecipes/RmsNorm_000/test.recipe
+++ b/res/CircleRecipes/RmsNorm_000/test.recipe
@@ -1,0 +1,46 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 4 }
+}
+operand {
+  name: "gamma"
+  type: FLOAT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "1.0"
+    arg: "1.0"
+    arg: "1.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "beta"
+  type: FLOAT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "0.0"
+    arg: "0.0"
+    arg: "0.0"
+    arg: "0.0"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 4 }
+}
+operation {
+  type: "RmsNorm"
+  input: "ifm"
+  input: "gamma"
+  input: "beta"
+  output: "ofm"
+  rms_norm_options {
+    epsilon: 0.0001
+  }
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.recipe
@@ -4,7 +4,7 @@ operand {
   shape {
     dim: 1
     dim: 1
-    dim: 1440
+    dim: 4
   }
 }
 operand {
@@ -13,7 +13,7 @@ operand {
   shape {
     dim: 1
     dim: 1
-    dim: 1440
+    dim: 4
   }
 }
 operand {
@@ -69,7 +69,7 @@ operand {
   shape {
     dim: 1
     dim: 1
-    dim: 1440
+    dim: 4
   }
 }
 operation {

--- a/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.recipe
@@ -1,0 +1,125 @@
+operand {
+  name: "Input"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1440
+  }
+  is_variable: false
+}
+operand {
+  name: "RmsNorm/Mul/Square"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1440
+  }
+  is_variable: false
+}
+operand {
+  name: "RmsNorm/Mean/Axis"
+  type: INT32
+  shape {
+  }
+  filler {
+    tag: "explicit"
+    arg: "-1"
+  }
+  is_variable: false
+}
+operand {
+  name: "RmsNorm/Mean/MeanSquare"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1
+  }
+  is_variable: false
+}
+operand {
+  name: "RmsNorm/Add/Epsilon"
+  type: FLOAT32
+  shape {
+  }
+  filler {
+    tag: "explicit"
+    arg: "1e-06"
+  }
+  is_variable: false
+}
+operand {
+  name: "RmsNorm/Add/MeanSquare_plus_eps"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1
+  }
+  is_variable: false
+}
+operand {
+  name: "RmsNorm/Sqrt/RMS"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1
+  }
+  is_variable: false
+}
+operand {
+  name: "RmsNorm/Mul/RmsNorm"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1440
+  }
+  is_variable: false
+}
+operation {
+  type: "Mul"
+  input: "Input"
+  input: "Input"
+  output: "RmsNorm/Mul/Square"
+  mul_options {
+    activation: NONE
+  }
+}
+operation {
+  type: "Mean"
+  input: "RmsNorm/Mul/Square"
+  input: "RmsNorm/Mean/Axis"
+  output: "RmsNorm/Mean/MeanSquare"
+  mean_options {
+    keep_dims: true
+  }
+}
+operation {
+  type: "Add"
+  input: "RmsNorm/Mean/MeanSquare"
+  input: "RmsNorm/Add/Epsilon"
+  output: "RmsNorm/Add/MeanSquare_plus_eps"
+  add_options {
+    activation: NONE
+  }
+}
+operation {
+  type: "Rsqrt"
+  input: "RmsNorm/Add/MeanSquare_plus_eps"
+  output: "RmsNorm/Sqrt/RMS"
+}
+operation {
+  type: "Mul"
+  input: "Input"
+  input: "RmsNorm/Sqrt/RMS"
+  output: "RmsNorm/Mul/RmsNorm"
+  mul_options {
+    activation: NONE
+  }
+}
+input: "Input"
+output: "RmsNorm/Mul/RmsNorm"

--- a/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.recipe
@@ -6,7 +6,6 @@ operand {
     dim: 1
     dim: 1440
   }
-  is_variable: false
 }
 operand {
   name: "RmsNorm/Mul/Square"
@@ -16,7 +15,6 @@ operand {
     dim: 1
     dim: 1440
   }
-  is_variable: false
 }
 operand {
   name: "RmsNorm/Mean/Axis"
@@ -27,7 +25,6 @@ operand {
     tag: "explicit"
     arg: "-1"
   }
-  is_variable: false
 }
 operand {
   name: "RmsNorm/Mean/MeanSquare"
@@ -37,7 +34,6 @@ operand {
     dim: 1
     dim: 1
   }
-  is_variable: false
 }
 operand {
   name: "RmsNorm/Add/Epsilon"
@@ -48,7 +44,6 @@ operand {
     tag: "explicit"
     arg: "1e-06"
   }
-  is_variable: false
 }
 operand {
   name: "RmsNorm/Add/MeanSquare_plus_eps"
@@ -58,7 +53,6 @@ operand {
     dim: 1
     dim: 1
   }
-  is_variable: false
 }
 operand {
   name: "RmsNorm/Sqrt/RMS"
@@ -68,7 +62,6 @@ operand {
     dim: 1
     dim: 1
   }
-  is_variable: false
 }
 operand {
   name: "RmsNorm/Mul/RmsNorm"
@@ -78,7 +71,6 @@ operand {
     dim: 1
     dim: 1440
   }
-  is_variable: false
 }
 operation {
   type: "Mul"

--- a/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.rule
@@ -1,0 +1,7 @@
+# To check if this network is converted to circle RmsNorm op
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "RMS_NORM_EXIST"     $(op_count RMS_NORM) '=' 1
+RULE    "NO_ADD"                  $(op_count ADD) '=' 0
+RULE    "NO_MUL"                  $(op_count MUL) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_RmsNorm_000/test.rule
@@ -2,6 +2,6 @@
 
 RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
 
-RULE    "RMS_NORM_EXIST"     $(op_count RMS_NORM) '=' 1
+RULE    "RMS_NORM_EXIST"          $(op_count RMS_NORM) '=' 1
 RULE    "NO_ADD"                  $(op_count ADD) '=' 0
 RULE    "NO_MUL"                  $(op_count MUL) '=' 0


### PR DESCRIPTION
This commit adds RmsNorm test recipe in CircleRecipes/TFLiteRecipes.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967