### PR TITLE
[luci/service] Support RmsNorm operation

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -259,6 +259,7 @@ public:
   luci::CircleNode *visit(const luci::CircleBCQGather *) final;
   luci::CircleNode *visit(const luci::CircleInstanceNorm *) final;
   luci::CircleNode *visit(const luci::CircleGRU *) final;
+  luci::CircleNode *visit(const luci::CircleRmsNorm *) final;
 
   // NOTE CircleInput and CircleOutput are not handled here as these need
   //      link with graph I/O

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2198,6 +2198,13 @@ public:
 
   loco::NodeShape visit(const luci::CircleGRU *node) final { return infer_circle_gru(node); }
 
+  loco::NodeShape visit(const luci::CircleRmsNorm *node) final
+  {
+    auto input_shape = luci::shape_get(node->input()).as<loco::TensorShape>();
+
+    return loco::NodeShape{input_shape};
+  }
+
   // Virtual
   loco::NodeShape visit(const luci::CircleInput *node) final { return infer_input(node); }
 

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -579,6 +579,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return luci::dtype_get(node->input());
   }
 
+  loco::DataType visit(const luci::CircleRmsNorm *node) final
+  {
+    return luci::dtype_get(node->input());
+  }
+
   // Virtual
   loco::DataType visit(const luci::CircleInput *node) final { return node->dtype(); }
 

--- a/compiler/luci/service/src/Nodes/CircleRmsNorm.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRmsNorm.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleRmsNorm *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleRmsNorm>();
+  if (cloned != nullptr)
+  {
+    cloned->epsilon(node->epsilon());
+  }
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleRmsNorm.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRmsNorm.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_RmsNorm)
+{
+  auto g = loco::make_graph();
+  auto node_fc = g->nodes()->create<luci::CircleRmsNorm>();
+  node_fc->epsilon(3);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_fc, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_fc = dynamic_cast<luci::CircleRmsNorm *>(cloned);
+  ASSERT_NE(nullptr, cloned_fc);
+  ASSERT_EQ(node_fc->epsilon(), cloned_fc->epsilon());
+}


### PR DESCRIPTION
This commit supports RmsNorm operation in luci service.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967