### PR TITLE
[onert/backend] Fix test names in MemoryPlanner.test.cc

### DIFF
--- a/runtime/onert/backend/train/MemoryPlanner.test.cc
+++ b/runtime/onert/backend/train/MemoryPlanner.test.cc
@@ -178,7 +178,7 @@ TEST(FirstFitPlanner, disposable_claim_release_test)
   });
 }
 
-TEST(FirstFitPlanner, disposable_neg_release_non_existing_index)
+TEST(FirstFitPlanner, neg_disposable_release_non_existing_index)
 {
   PlannerVerifier<FirstFitPlanner, DisposableTensorIndex> p;
 
@@ -203,7 +203,7 @@ TEST(FirstFitPlanner, disposable_neg_release_non_existing_index)
   });
 }
 
-TEST(FirstFitPlanner, disposable_neg_release_twice)
+TEST(FirstFitPlanner, neg_disposable_release_twice)
 {
   PlannerVerifier<FirstFitPlanner, DisposableTensorIndex> p;
 


### PR DESCRIPTION
This PR fix test names in MemoryPlanner.test.cc.
It makes 'neg' keywords resides in prefix of test names.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>