### PR TITLE
[luci/pass] Support RmsNorm operation

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -78,6 +78,7 @@ public:
       FusePRelu,
       FuseGelu,
       FuseRsqrt,
+      FuseRmsNorm,
       ShuffleWeightTo16x1Float32,
       RemoveRedundantTranspose,
       ReplaceMulAddWithDepthwiseConv,

--- a/compiler/luci/pass/include/luci/Pass/FuseRmsNormPass.h
+++ b/compiler/luci/pass/include/luci/Pass/FuseRmsNormPass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_FUSE_RMSNORM_PASS_H__
+#define __LUCI_FUSE_RMSNORM_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to fuse certain pattern of subgraph into CircleRmsNorm
+ */
+struct FuseRmsNormPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::FuseRmsNormPass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_FUSE_RMSNORM_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -56,6 +56,7 @@
 #include "luci/Pass/FuseSliceWithTConvPass.h"
 #include "luci/Pass/FuseHorizontalFullyConnectedPass.h"
 #include "luci/Pass/FuseTransposeWithMeanPass.h"
+#include "luci/Pass/FuseRmsNormPass.h"
 #include "luci/Pass/MakeBatchNormGammaPositivePass.h"
 #include "luci/Pass/RemoveDuplicateConstPass.h"
 #include "luci/Pass/RemoveFakeQuantPass.h"
@@ -344,6 +345,7 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   option_to_pass[Options::Algorithm::FuseRsqrt] = &createPassInstance<luci::FuseRsqrtPass>;
   option_to_pass[Options::Algorithm::FuseHorizontalFullyConnected] = &createPassInstance<luci::FuseHorizontalFullyConnectedPass>;
   option_to_pass[Options::Algorithm::FuseTransposeWithMean] = &createPassInstance<luci::FuseTransposeWithMeanPass>;
+  option_to_pass[Options::Algorithm::FuseRmsNorm] = &createPassInstance<luci::FuseRmsNormPass>;
   option_to_pass[Options::Algorithm::FoldAddV2] = &createPassInstance<luci::FoldAddV2Pass>;
   option_to_pass[Options::Algorithm::FoldCast] = &createPassInstance<luci::FoldCastPass>;
   option_to_pass[Options::Algorithm::FoldDensify] = &createPassInstance<luci::FoldDensifyPass>;

--- a/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
+++ b/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
@@ -219,6 +219,7 @@ struct FakeQuantize final : public luci::CircleNodeMutableVisitor<void>
   void visit(luci::CircleRelu6 *node) { fq_activation(node); }
   void visit(luci::CircleResizeBilinear *node) { fq_activation(node); }
   void visit(luci::CircleResizeNearestNeighbor *node) { fq_activation(node); }
+  void visit(luci::CircleRmsNorm *node) { fq_activation(node); }
   void visit(luci::CircleRsqrt *node) { fq_activation(node); }
   void visit(luci::CircleSoftmax *node) { fq_activation(node); }
   void visit(luci::CircleSqrt *node) { fq_activation(node); }

--- a/compiler/luci/pass/src/FuseRmsNormPass.cpp
+++ b/compiler/luci/pass/src/FuseRmsNormPass.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/FuseRmsNormPass.h"
+#include "helpers/NodeFiller.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Profile/CircleNodeOrigin.h>
+#include <luci/Service/CircleNodeClone.h>
+
+#include <cmath>
+#include <cassert>
+
+namespace
+{
+
+/**
+ * Below diagram shows RMS normalization pattern to fuse.
+ * - this pattern will be replaced with one RmsNorm
+ *
+ *           [In]
+ *            |
+ *            V
+ *     +---- ifm ----+
+ *     |      |      |
+ *     |      V      |
+ *     |     mul <---+
+ *     |      |
+ *     |      V
+ *     |     mean
+ *     |      |
+ *     |      V
+ *     |     add_epsilon
+ *     |      |
+ *     |      V
+ *     |     rsqrt
+ *     |      |
+ *     |      V
+ *     +---> mul_input
+ *            |
+ *            V
+ *          [Out]
+ */
+
+class RmsNormPattern final
+{
+public:
+  RmsNormPattern(luci::CircleMul *candidate)
+  {
+    assert(candidate); // FIX_CALLER_UNLESS
+    _mul_input = candidate;
+  }
+
+public:
+  bool matched();
+
+public:
+  luci::CircleNode *_ifm = nullptr;
+  luci::CircleMul *_mul_pow = nullptr;
+  luci::CircleMean *_mean = nullptr;
+  luci::CircleAdd *_add_epsilon = nullptr;
+  luci::CircleRsqrt *_rsqrt = nullptr;
+  luci::CircleMul *_mul_input = nullptr;
+  luci::CircleMul *_mul_gamma = nullptr; // not used
+  luci::CircleAdd *_add_beta = nullptr;  // not used
+  luci::CircleConst *_const_epsilon = nullptr;
+  luci::CircleConst *_const_gamma = nullptr; // use default gamma(scale) 1.0
+  luci::CircleConst *_const_beta = nullptr;  // use default beta(offset) 0.0
+};
+
+#define CHECK_OR_FALSE(condition) \
+  if (not(condition))             \
+    return false;
+
+luci::CircleConst *make_const_one(loco::Graph *graph, float value)
+{
+  auto const_one = graph->nodes()->create<luci::CircleConst>();
+  const_one->dtype(loco::DataType::FLOAT32);
+  const_one->rank(1);
+  const_one->size<loco::DataType::FLOAT32>(1);
+  const_one->at<loco::DataType::FLOAT32>(0) = value;
+  return const_one;
+}
+
+bool RmsNormPattern::matched()
+{
+  // Check pattern
+  CHECK_OR_FALSE(luci::fill(&_ifm, &_rsqrt).with_commutative_args_of(_mul_input));
+  _add_epsilon = dynamic_cast<luci::CircleAdd *>(_rsqrt->x());
+  CHECK_OR_FALSE(_add_epsilon);
+  CHECK_OR_FALSE(luci::fill(&_mean, &_const_epsilon).with_commutative_args_of(_add_epsilon));
+  CHECK_OR_FALSE(_const_epsilon->dtype() == loco::DataType::FLOAT32);
+  _mul_pow = dynamic_cast<luci::CircleMul *>(_mean->input());
+  CHECK_OR_FALSE(_mul_pow);
+  CHECK_OR_FALSE(_mul_pow->x() == _ifm);
+  CHECK_OR_FALSE(_mul_pow->y() == _ifm);
+
+  assert(_mul_gamma == nullptr);
+  assert(_add_beta == nullptr);
+  assert(_const_gamma == nullptr);
+  assert(_const_beta == nullptr);
+
+  // create gamma(1.0) and beta(0.0)
+  auto graph = _mul_input->graph();
+  _const_gamma = make_const_one(graph, 1.0f);
+  _const_beta = make_const_one(graph, 0.0f);
+  _const_gamma->name(_mul_input->name() + "/gamma");
+  _const_beta->name(_mul_input->name() + "/beta");
+
+  return true;
+}
+#undef CHECK_OR_FALSE
+
+class FuseRmsNorm final
+{
+public:
+  FuseRmsNorm(const RmsNormPattern *p) : _p(p) {}
+
+public:
+  void apply(void);
+
+private:
+  luci::CircleRmsNorm *create_rms_norm(loco::Graph *graph);
+
+private:
+  const RmsNormPattern *_p = nullptr;
+};
+
+luci::CircleRmsNorm *FuseRmsNorm::create_rms_norm(loco::Graph *graph)
+{
+  assert(graph);
+
+  auto rms_norm = graph->nodes()->create<luci::CircleRmsNorm>();
+  rms_norm->input(_p->_ifm);
+  rms_norm->gamma(_p->_const_gamma);
+  rms_norm->beta(_p->_const_beta);
+  float epsilon = _p->_const_epsilon->at<loco::DataType::FLOAT32>(0);
+  rms_norm->epsilon(epsilon);
+
+  rms_norm->name("FusedRmsNorm/" + _p->_mul_input->name());
+
+  return rms_norm;
+}
+
+void FuseRmsNorm::apply()
+{
+  auto graph = _p->_mul_input->graph();
+
+  auto rms_norm = create_rms_norm(graph);
+
+  // set origin
+  std::vector<std::shared_ptr<luci::CircleNodeOrigin>> origin_vec{
+    luci::get_origin(_p->_mul_pow),     luci::get_origin(_p->_mean),
+    luci::get_origin(_p->_add_epsilon), luci::get_origin(_p->_rsqrt),
+    luci::get_origin(_p->_mul_input),
+  };
+
+  luci::add_origin(rms_norm, luci::composite_origin(origin_vec));
+
+  replace(_p->_mul_input).with(rms_norm);
+}
+
+} // namespace
+
+namespace
+{
+
+bool fuse_rms_norm(luci::CircleMul *mul)
+{
+  assert(mul);
+
+  RmsNormPattern pattern(mul);
+  if (pattern.matched())
+  {
+    FuseRmsNorm fuse(&pattern);
+    fuse.apply();
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool FuseRmsNormPass::run(loco::Graph *g)
+{
+  bool changed = false;
+
+  // default gamma(scale) 1.0 and beta(offset) 0.0
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto mul = dynamic_cast<luci::CircleMul *>(node);
+    if (not mul)
+      continue;
+
+    if (fuse_rms_norm(mul))
+      changed = true;
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/FuseRmsNormPass.test.cpp
+++ b/compiler/luci/pass/src/FuseRmsNormPass.test.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/FuseRmsNormPass.h"
+
+#include <gtest/gtest.h>
+
+TEST(FuseRmsNormPassTest, name)
+{
+  luci::FuseRmsNormPass pass;
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+}

--- a/compiler/luci/pass/src/QuantizeActivation.h
+++ b/compiler/luci/pass/src/QuantizeActivation.h
@@ -75,6 +75,7 @@ private:
   SKIP(luci::CircleFullyConnected)
   SKIP(luci::CircleInstanceNorm)
   SKIP(luci::CirclePRelu)
+  SKIP(luci::CircleRmsNorm)
   SKIP(luci::CircleTransposeConv)
 
   // Handled in PropagateQParamBackwardPass

--- a/compiler/luci/pass/src/QuantizePreCheckerPass.cpp
+++ b/compiler/luci/pass/src/QuantizePreCheckerPass.cpp
@@ -84,6 +84,7 @@ struct ConstInputChecker final : public luci::CircleNodeMutableVisitor<void>
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleDepthwiseConv2D, filter, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleFullyConnected, weights, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleInstanceNorm, gamma, beta)
+  CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleRmsNorm, gamma, beta)
 
   // Ops that receive three const nodes as an inputs
   CHECK_NODE_WITH_THREE_INPUT_CONST(luci::CircleTransposeConv, inputSizes, filter, bias)

--- a/compiler/luci/pass/src/QuantizePreCheckerPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizePreCheckerPass.test.cpp
@@ -192,6 +192,49 @@ private:
   luci::CircleOutput *output = nullptr;
 };
 
+class SimpleRmsNormGraph
+{
+public:
+  SimpleRmsNormGraph(bool make_valid)
+  {
+    rms_norm_node = g.nodes()->create<luci::CircleRmsNorm>();
+    input_1 = g.nodes()->create<luci::CircleInput>();
+    gamma = g.nodes()->create<luci::CircleConst>();
+
+    rms_norm_node->input(input_1);
+    rms_norm_node->gamma(gamma);
+
+    if (make_valid)
+    {
+      beta = g.nodes()->create<luci::CircleConst>();
+      rms_norm_node->beta(beta);
+    }
+    else
+    {
+      input_2 = g.nodes()->create<luci::CircleInput>();
+      rms_norm_node->beta(input_2);
+    }
+
+    output = g.nodes()->create<luci::CircleOutput>();
+
+    auto graph_output = g.outputs()->create();
+    output->index(graph_output->index());
+
+    output->from(rms_norm_node);
+  }
+
+public:
+  loco::Graph g;
+
+private:
+  luci::CircleRmsNorm *rms_norm_node = nullptr;
+  luci::CircleInput *input_1 = nullptr;
+  luci::CircleInput *input_2 = nullptr;
+  luci::CircleConst *gamma = nullptr;
+  luci::CircleConst *beta = nullptr;
+  luci::CircleOutput *output = nullptr;
+};
+
 class SimpleTransposeConvGraph
 {
 public:
@@ -357,6 +400,25 @@ TEST(QuantizePreCheckerPassTest, instance_norm)
 TEST(QuantizePreCheckerPassTest, instance_norm_NEG)
 {
   SimpleInstanceNormGraph invalid_graph(false);
+
+  luci::QuantizePreCheckerPass checker{};
+
+  EXPECT_ANY_THROW(checker.run(&invalid_graph.g));
+}
+
+// Test RmsNorm
+TEST(QuantizePreCheckerPassTest, rms_norm)
+{
+  SimpleRmsNormGraph valid_graph(true);
+
+  luci::QuantizePreCheckerPass checker{};
+
+  EXPECT_NO_THROW(checker.run(&valid_graph.g));
+}
+
+TEST(QuantizePreCheckerPassTest, rms_norm_NEG)
+{
+  SimpleRmsNormGraph invalid_graph(false);
 
   luci::QuantizePreCheckerPass checker{};
 

--- a/compiler/luci/pass/src/QuantizeWeights.h
+++ b/compiler/luci/pass/src/QuantizeWeights.h
@@ -44,6 +44,7 @@ private:
   void visit(luci::CircleConv2D *node);
   void visit(luci::CircleDepthwiseConv2D *node);
   void visit(luci::CircleInstanceNorm *node);
+  void visit(luci::CircleRmsNorm *node);
   void visit(luci::CirclePRelu *node);
   void visit(luci::CircleTransposeConv *node);
   void visit(luci::CircleFullyConnected *node);

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -301,6 +301,7 @@ private:
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleResizeBilinear, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleResizeNearestNeighbor, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleReverseSequence, input)
+  INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleRmsNorm, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleRsqrt, x)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleSlice, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleSoftmax, logits)

--- a/compiler/luci/pass/src/VerifyQuantizedNodeGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeGranularity.h
@@ -93,6 +93,8 @@ private:
 
   virtual bool visit(const luci::CircleInstanceNorm *node) = 0;
 
+  virtual bool visit(const luci::CircleRmsNorm *node) = 0;
+
   bool visit(const luci::CirclePack *node)
   {
     RETURN_FALSE_UNLESS(is_lwq(node))
@@ -511,6 +513,15 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleRmsNorm *node)
+  {
+    RETURN_FALSE_UNLESS(is_lwq(node))
+    RETURN_FALSE_UNLESS(is_lwq(node->input()))
+    RETURN_FALSE_UNLESS(is_cwq_const(node->gamma(), rank(node->gamma()) - 1))
+    RETURN_FALSE_UNLESS(is_cwq_const(node->beta(), rank(node->beta()) - 1))
+    return true;
+  }
+
   bool visit(const luci::CirclePRelu *node)
   {
     RETURN_FALSE_UNLESS(is_lwq(node))
@@ -587,6 +598,15 @@ private:
   }
 
   bool visit(const luci::CircleInstanceNorm *node)
+  {
+    RETURN_FALSE_UNLESS(is_lwq(node))
+    RETURN_FALSE_UNLESS(is_lwq(node->input()))
+    RETURN_FALSE_UNLESS(is_lwq_const(node->gamma()))
+    RETURN_FALSE_UNLESS(is_lwq_const(node->beta()))
+    return true;
+  }
+
+  bool visit(const luci::CircleRmsNorm *node)
   {
     RETURN_FALSE_UNLESS(is_lwq(node))
     RETURN_FALSE_UNLESS(is_lwq(node->input()))

--- a/compiler/luci/pass/src/VerifyQuantizedNodeType.cpp
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeType.cpp
@@ -365,6 +365,12 @@ bool VerifyQuantizedNodeTypeBase<Qtype, Btype>::visit(const luci::CircleResizeNe
 }
 
 template <loco::DataType Qtype, loco::DataType Btype>
+bool VerifyQuantizedNodeTypeBase<Qtype, Btype>::visit(const luci::CircleRmsNorm *node)
+{
+  return group_has_type(node, Qtype);
+}
+
+template <loco::DataType Qtype, loco::DataType Btype>
 bool VerifyQuantizedNodeTypeBase<Qtype, Btype>::visit(const luci::CircleRsqrt *node)
 {
   return group_has_type(node, Qtype);

--- a/compiler/luci/pass/src/VerifyQuantizedNodeType.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeType.h
@@ -110,6 +110,7 @@ private:
   bool visit(const luci::CircleReshape *node);
   bool visit(const luci::CircleResizeBilinear *node);
   bool visit(const luci::CircleResizeNearestNeighbor *node);
+  bool visit(const luci::CircleRmsNorm *node);
   bool visit(const luci::CircleRsqrt *node);
   bool visit(const luci::CircleSlice *node);
   bool visit(const luci::CircleSpaceToBatchND *node);


### PR DESCRIPTION
This commit supports RmsNorm operation in luci pass.

 ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967