### PR TITLE
[common-artifacts] Exclude RmsNorm optimization test

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -9,6 +9,7 @@ optimize(Add_STR_000) # STRING is not supported
 optimize(Add_STR_001) # STRING is not supported
 
 ## CircleRecipes
+optimize(RmsNorm_000)
 
 #[[ tcgenerate : Exclude from test data generation(TestDataGenerator) ]]
 ## TensorFlowLiteRecipes


### PR DESCRIPTION
This commit is to exclude RmsNorm optimization test until it's fully applied. 
It will be reverted once RmsNorm is fully applied.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967