### PR TITLE
[DRAFT][luci/service] Enhance handling CircleConst as reshape's shape

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
@@ -39,7 +39,7 @@ TEST(CloneNodeTest, clone_Reshape)
   ASSERT_EQ(node_reshape->newShape()->dim(1), cloned_reshape->newShape()->dim(1));
 }
 
-TEST(ShapeRuleTest, reshape_by_input_const_static)
+TEST(ShapeRuleTest, reshape_by_const_static)
 {
   auto g = loco::make_graph();
   auto node_reshape = g->nodes()->create<luci::CircleReshape>();
@@ -71,7 +71,7 @@ TEST(ShapeRuleTest, reshape_by_input_const_static)
   ASSERT_EQ(4, output_shape.dim(1).value());
 }
 
-TEST(ShapeRuleTest, reshape_by_input_const_dynamic)
+TEST(ShapeRuleTest, reshape_by_const_dynamic)
 {
   auto g = loco::make_graph();
   auto node_reshape = g->nodes()->create<luci::CircleReshape>();


### PR DESCRIPTION
This commit improves the robustness of handling `CircleConst` as the `shape` for the reshape operation.

- This is the 2nd step in supporting dynamic shape inference for the reshape operation.
- The existing shape inference logic already supports using `CircleConst` as the `shape` for reshape.
  - However, it relies on `static_cast` to check whether a dimension is known or not.
  - This approach worked because unknown dimensions were stored with the value 4294967295 (`UINT32_MAX`) and then cast to -1.
  - This commit refines this behavior by explicitly handling unknown dimensions.

Draft: https://github.com/Samsung/ONE/pull/13999
Related: https://github.com/Samsung/ONE/issues/13927

ONE-DCO-1.0-Signed-off-by: Jongwon Yang <yjw963@gmail.com>