### PR TITLE
[one-cmds] Add a function that gets registered option names

### DIFF
--- a/compiler/one-cmds/onelib/argumentparse.py
+++ b/compiler/one-cmds/onelib/argumentparse.py
@@ -139,7 +139,46 @@ class ArgumentParser():
 
         oneutils.run([driver_path, '-h'], err_prefix=self.driver)
 
+    def get_option_names(self, *, flatten=False, without_dash=False):
+        """
+        Get registered option names.
+
+        :param flatten: single option can have multiple names. 
+          If it is True, such options are returned after flattened.
+        :param without_dash: optional argument has leading dash on its names. 
+          If it is True, option names are returned without such dashes.
+
+        For example, say there are options like these.
+
+          parser.add_argument("--verbose", action=NormalOption, dtype=bool)
+          parser.add_argument("--output", "--output_path", action=NormalOption)
+        
+        [EXAMPLES]
+          get_option_names()
+            [[--verbose], [--output, --output_path]]
+          get_option_names(without_dash=True)
+            [[verbose], [output, output_path]]
+          get_option_names(flatten=True)
+            [--verbose, --output, --output_path]
+          get_option_names(flatten=True, without_dash=True)
+            [verbose, output, output_path]
+        """
+        names = []
+        for action in self._actions:
+            names.append(action[0])
+
+        if flatten:
+            names = [name for name_l in names for name in name_l]
+        if without_dash:
+            names = [name.lstrip('-') for name in names]
+
+        return names
+
     def check_if_valid_option_name(self, *args, **kwargs):
+        existing_options = self.get_option_names(flatten=True, without_dash=True)
+        args_without_dash = [arg.lstrip('-') for arg in args]
+        if any(arg in existing_options for arg in args_without_dash):
+            raise RuntimeError('Duplicate option names')
         if not 'action' in kwargs:
             raise RuntimeError('"action" keyword argument is required')
 

--- a/compiler/one-cmds/tests/one-codegen_neg_006.cfg
+++ b/compiler/one-cmds/tests/one-codegen_neg_006.cfg
@@ -1,0 +1,9 @@
+[onecc]
+one-codegen=True
+
+[backend]
+target=one-codegen_neg_006
+
+[one-codegen]
+o=one-codegen_neg_006.tvn
+input=one-codegen_neg_006.circle

--- a/compiler/one-cmds/tests/one-codegen_neg_006.ini
+++ b/compiler/one-cmds/tests/one-codegen_neg_006.ini
@@ -1,0 +1,2 @@
+TARGET=one-codegen_neg_006
+BACKEND=dummy

--- a/compiler/one-cmds/tests/one-codegen_neg_006.py
+++ b/compiler/one-cmds/tests/one-codegen_neg_006.py
@@ -1,0 +1,14 @@
+from onelib import argumentparse
+from onelib.argumentparse import DriverName, NormalOption, TargetOption
+
+
+def command_schema():
+    parser = argumentparse.ArgumentParser()
+    parser.add_argument("dummy-compile", action=DriverName)
+    parser.add_argument("--target", action=TargetOption)
+    parser.add_argument("--DSP-quota", action=NormalOption)
+    parser.add_argument("-o", action=NormalOption)
+    parser.add_argument("--op", "-o", action=NormalOption)  # duplicate names
+    parser.add_argument("input", action=NormalOption)
+
+    return parser

--- a/compiler/one-cmds/tests/one-codegen_neg_006.test
+++ b/compiler/one-cmds/tests/one-codegen_neg_006.test
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# command schema has duplicate names.
+
+: '
+This test assumes below directories.
+
+[one hierarchy]
+    one
+    ├── backends
+    │   └── command
+    │       └── dummy
+    │           └── codegen.py
+    ├── bin
+    ├── doc
+    ├── include
+    ├── lib
+    ├── optimization
+    ├── target
+    └── test # pwd
+'
+
+BACKENDS_ALREADY_EXIST=true
+CMD_ALREADY_EXIST=true
+DUMMY_ALREADY_EXIST=true
+TARGET_ALREADY_EXIST=true
+
+BACKEND_NAME="dummy"
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+configfile="one-codegen_neg_006.cfg"
+outputfile="one-codegen_neg_006.tvn"
+targetfile="one-codegen_neg_006.ini"
+commandschema="one-codegen_neg_006.py"
+
+clean_envir()
+{
+  rm -rf ../bin/dummy-compile
+  rm -rf ../target/${targetfile}
+  rm -rf "../backends/command/${BACKEND_NAME}/codegen.py"
+  if [ "$TARGET_ALREADY_EXIST" = false ]; then
+    rm -rf ../target/
+  fi
+  if [ "$DUMMY_ALREADY_EXIST" = false ]; then
+    rm -rf "../backends/command/${BACKEND_NAME}/"
+  fi
+  if [ "$CMD_ALREADY_EXIST" = false ]; then
+    rm -rf ../backends/command/
+  fi
+  if [ "$BACKENDS_ALREADY_EXIST" = false ]; then
+    rm -rf ../backends/
+  fi
+}
+
+trap_err_onexit()
+{
+  if grep -q "Duplicate option names" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    clean_envir
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  clean_envir
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
+if [ ! -d "../target/" ]; then
+  mkdir -p ../target/
+  TARGET_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/" ]; then
+  mkdir -p ../backends/
+  BACKENDS_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/command/" ]; then
+  mkdir -p ../backends/command/
+  CMD_ALREADY_EXIST=false
+fi
+if [ ! -d "../backends/command/${BACKEND_NAME}/" ]; then
+  mkdir -p ../backends/command/${BACKEND_NAME}/
+  DUMMY_ALREADY_EXIST=false
+fi
+
+# copy dummy tools to bin folder
+cp dummy-compile ../bin/dummy-compile
+cp ${targetfile} ../target/
+cp ${commandschema} "../backends/command/${BACKEND_NAME}/codegen.py"
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+clean_envir
+echo "${filename_ext} FAILED"
+exit 255


### PR DESCRIPTION
This commit adds a function that gets option names.

Draft: #14005

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>