### PR TITLE
[luci/service] Enhance handling CircleConst as reshape's shape

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -87,6 +87,10 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
       for (uint32_t axis = 0; axis < shape_by_input.rank(); ++axis)
       {
         shape_by_input.dim(axis) = const_shape_node->at<S32>(axis);
+        if (const_shape_node->at<S32>(axis) < 0)
+        {
+          shape_by_input.dim(axis).unset();
+        }
       }
     }
     else
@@ -139,7 +143,7 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
   for (uint32_t dim_index = 0; dim_index < output_shape.rank(); ++dim_index)
   {
     const uint32_t dim_value = output_shape.dim(dim_index).value();
-    if (static_cast<int>(dim_value) == -1)
+    if (output_shape.dim(dim_index).known() == false)
     {
       LUCI_ASSERT(unknown_dim_index == UINT32_MAX, "More than one unknown dimension");
       unknown_dim_index = dim_index;

--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -143,7 +143,7 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
   for (uint32_t dim_index = 0; dim_index < output_shape.rank(); ++dim_index)
   {
     const uint32_t dim_value = output_shape.dim(dim_index).value();
-    if (output_shape.dim(dim_index).known() == false)
+    if (not output_shape.dim(dim_index).known())
     {
       LUCI_ASSERT(unknown_dim_index == UINT32_MAX, "More than one unknown dimension");
       unknown_dim_index = dim_index;


### PR DESCRIPTION
This commit improves handling `CircleConst` as the `shape` for the reshape operation.

- Use `known` explicitly instead of `static_cast` which can cause overflow.

Draft: https://github.com/Samsung/ONE/pull/13999, https://github.com/Samsung/ONE/pull/14034
Related: https://github.com/Samsung/ONE/issues/13927

ONE-DCO-1.0-Signed-off-by: Jongwon Yang <yjw963@gmail.com>