### PR TITLE
[luci/pass] Add RmsNorm to QuantizePreChecker pass

### DIFF
--- a/compiler/luci/pass/src/QuantizePreCheckerPass.cpp
+++ b/compiler/luci/pass/src/QuantizePreCheckerPass.cpp
@@ -84,6 +84,7 @@ struct ConstInputChecker final : public luci::CircleNodeMutableVisitor<void>
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleDepthwiseConv2D, filter, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleFullyConnected, weights, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleInstanceNorm, gamma, beta)
+  CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleRmsNorm, gamma, beta)
 
   // Ops that receive three const nodes as an inputs
   CHECK_NODE_WITH_THREE_INPUT_CONST(luci::CircleTransposeConv, inputSizes, filter, bias)

--- a/compiler/luci/pass/src/QuantizePreCheckerPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizePreCheckerPass.test.cpp
@@ -192,6 +192,49 @@ private:
   luci::CircleOutput *output = nullptr;
 };
 
+class SimpleRmsNormGraph
+{
+public:
+  SimpleRmsNormGraph(bool make_valid)
+  {
+    rms_norm_node = g.nodes()->create<luci::CircleRmsNorm>();
+    input_1 = g.nodes()->create<luci::CircleInput>();
+    gamma = g.nodes()->create<luci::CircleConst>();
+
+    rms_norm_node->input(input_1);
+    rms_norm_node->gamma(gamma);
+
+    if (make_valid)
+    {
+      beta = g.nodes()->create<luci::CircleConst>();
+      rms_norm_node->beta(beta);
+    }
+    else
+    {
+      input_2 = g.nodes()->create<luci::CircleInput>();
+      rms_norm_node->beta(input_2);
+    }
+
+    output = g.nodes()->create<luci::CircleOutput>();
+
+    auto graph_output = g.outputs()->create();
+    output->index(graph_output->index());
+
+    output->from(rms_norm_node);
+  }
+
+public:
+  loco::Graph g;
+
+private:
+  luci::CircleRmsNorm *rms_norm_node = nullptr;
+  luci::CircleInput *input_1 = nullptr;
+  luci::CircleInput *input_2 = nullptr;
+  luci::CircleConst *gamma = nullptr;
+  luci::CircleConst *beta = nullptr;
+  luci::CircleOutput *output = nullptr;
+};
+
 class SimpleTransposeConvGraph
 {
 public:
@@ -357,6 +400,25 @@ TEST(QuantizePreCheckerPassTest, instance_norm)
 TEST(QuantizePreCheckerPassTest, instance_norm_NEG)
 {
   SimpleInstanceNormGraph invalid_graph(false);
+
+  luci::QuantizePreCheckerPass checker{};
+
+  EXPECT_ANY_THROW(checker.run(&invalid_graph.g));
+}
+
+// Test RmsNorm
+TEST(QuantizePreCheckerPassTest, rms_norm)
+{
+  SimpleRmsNormGraph valid_graph(true);
+
+  luci::QuantizePreCheckerPass checker{};
+
+  EXPECT_NO_THROW(checker.run(&valid_graph.g));
+}
+
+TEST(QuantizePreCheckerPassTest, rms_norm_NEG)
+{
+  SimpleRmsNormGraph invalid_graph(false);
 
   luci::QuantizePreCheckerPass checker{};
 


### PR DESCRIPTION
This commit adds RmsNorm to QuantizePreChecker pass.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967