### PR TITLE
[luci/pass] Add RmsNorm to QuantizeWeights

### DIFF
--- a/compiler/luci/pass/src/QuantizeWeights.h
+++ b/compiler/luci/pass/src/QuantizeWeights.h
@@ -44,6 +44,7 @@ private:
   void visit(luci::CircleConv2D *node);
   void visit(luci::CircleDepthwiseConv2D *node);
   void visit(luci::CircleInstanceNorm *node);
+  void visit(luci::CircleRmsNorm *node);
   void visit(luci::CirclePRelu *node);
   void visit(luci::CircleTransposeConv *node);
   void visit(luci::CircleFullyConnected *node);


### PR DESCRIPTION
This commit adds RmsNorm to QuantizeWeights.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967