### PR TITLE
[luci/pass] Add to skip RmsNorm in QuantizeActivation

### DIFF
--- a/compiler/luci/pass/src/QuantizeActivation.h
+++ b/compiler/luci/pass/src/QuantizeActivation.h
@@ -75,6 +75,7 @@ private:
   SKIP(luci::CircleFullyConnected)
   SKIP(luci::CircleInstanceNorm)
   SKIP(luci::CirclePRelu)
+  SKIP(luci::CircleRmsNorm)
   SKIP(luci::CircleTransposeConv)
 
   // Handled in PropagateQParamBackwardPass


### PR DESCRIPTION
This commit adds to skip RmsNorm in QuantizeActivation.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967