### PR TITLE
[luci/pass] Add RmsNorm to QuantizeWithMinMax pass

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -301,6 +301,7 @@ private:
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleResizeBilinear, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleResizeNearestNeighbor, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleReverseSequence, input)
+  INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleRmsNorm, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleRsqrt, x)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleSlice, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleSoftmax, logits)


### PR DESCRIPTION
This commit adds RmsNorm to QuantizeWithMinMax pass.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967