### PR TITLE
[luci/pass] Add RmsNorm to VerifyQuantizedNodeType

### DIFF
--- a/compiler/luci/pass/src/VerifyQuantizedNodeType.cpp
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeType.cpp
@@ -365,6 +365,12 @@ bool VerifyQuantizedNodeTypeBase<Qtype, Btype>::visit(const luci::CircleResizeNe
 }
 
 template <loco::DataType Qtype, loco::DataType Btype>
+bool VerifyQuantizedNodeTypeBase<Qtype, Btype>::visit(const luci::CircleRmsNorm *node)
+{
+  return group_has_type(node, Qtype);
+}
+
+template <loco::DataType Qtype, loco::DataType Btype>
 bool VerifyQuantizedNodeTypeBase<Qtype, Btype>::visit(const luci::CircleRsqrt *node)
 {
   return group_has_type(node, Qtype);

--- a/compiler/luci/pass/src/VerifyQuantizedNodeType.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeType.h
@@ -110,6 +110,7 @@ private:
   bool visit(const luci::CircleReshape *node);
   bool visit(const luci::CircleResizeBilinear *node);
   bool visit(const luci::CircleResizeNearestNeighbor *node);
+  bool visit(const luci::CircleRmsNorm *node);
   bool visit(const luci::CircleRsqrt *node);
   bool visit(const luci::CircleSlice *node);
   bool visit(const luci::CircleSpaceToBatchND *node);


### PR DESCRIPTION
This commit adds CircleRmsNorm to VerifyQuantizedNodeType.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967