### PR TITLE
[luci/pass] Add RmsNorm to ConvertToFakeQuantizedModel pass

### DIFF
--- a/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
+++ b/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
@@ -219,6 +219,7 @@ struct FakeQuantize final : public luci::CircleNodeMutableVisitor<void>
   void visit(luci::CircleRelu6 *node) { fq_activation(node); }
   void visit(luci::CircleResizeBilinear *node) { fq_activation(node); }
   void visit(luci::CircleResizeNearestNeighbor *node) { fq_activation(node); }
+  void visit(luci::CircleRmsNorm *node) { fq_activation(node); }
   void visit(luci::CircleRsqrt *node) { fq_activation(node); }
   void visit(luci::CircleSoftmax *node) { fq_activation(node); }
   void visit(luci::CircleSqrt *node) { fq_activation(node); }


### PR DESCRIPTION
This commit adds CircleRmsNorm to ConvertToFakeQuantizedModel pass.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967