### PR TITLE
[onert/train] Add LayerScopeManager into TensorManager

### DIFF
--- a/runtime/onert/backend/train/TensorManager.h
+++ b/runtime/onert/backend/train/TensorManager.h
@@ -49,6 +49,7 @@ public:
   void allocateBackPropTensors();
   void allocateGradientTensors();
   void allocateDisposableBackPropTensors();
+  void allocateLayerScopeTensors();
   // TODO Add member functions to deallocate tensors
 
   void claimNonConstPlan(const ir::OperandIndex &ind);
@@ -61,7 +62,8 @@ public:
   void releaseGradientPlan(const ir::OperandIndex &ind);
   void claimDisposableBackPropPlan(const DisposableTensorIndex &ind);
   void releaseDisposableBackPropPlan(const DisposableTensorIndex &ind);
-  // TODO Add member functions related to LayerScopeMemoryManager
+  void claimLayerScopePlan(const LayerScopeTensorIndex &ind);
+  void releaseLayerScopePlan(const LayerScopeTensorIndex &ind);
 
 private:
   std::unique_ptr<MemoryManager> _nonconst_mgr;
@@ -69,8 +71,7 @@ private:
   std::unique_ptr<MemoryManager> _back_prop_mgr;
   std::unique_ptr<MemoryManager> _gradient_mgr;
   std::unique_ptr<DisposableMemoryManager> _disposable_back_prop_mgr;
-  // TODO: enable _layer_scope_mgr
-  // std::unique_ptr<LayerScopeMemoryManager> _layer_scope_mgr;
+  std::unique_ptr<LayerScopeMemoryManager> _layer_scope_mgr;
   const std::shared_ptr<TensorRegistry> _tensors;
 };
 


### PR DESCRIPTION
This PR adds LayerScopeManager into TensorManager.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>

draft : https://github.com/Samsung/ONE/pull/13486
for : https://github.com/Samsung/ONE/issues/13282