### PR TITLE
[onert] Initialize loss reduction type

### DIFF
--- a/runtime/onert/backend/train/ops/LossLayer.cc
+++ b/runtime/onert/backend/train/ops/LossLayer.cc
@@ -26,7 +26,8 @@ namespace ops
 {
 
 LossLayer::LossLayer()
-  : _y_pred(nullptr), _y_true(nullptr), _output(nullptr), _back_prop_y_pred(nullptr)
+  : _y_pred(nullptr), _y_true(nullptr), _output(nullptr), _back_prop_y_pred(nullptr),
+    _reduction_type(ir::train::LossReductionType::Undefined)
 {
   // DO NOTHING
 }


### PR DESCRIPTION
This commit initializes loss reduction type on LossLayer default constructor.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>