### PR TITLE
[infra/github] Change format check runner

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   check-format:
     name: Check format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'Samsung'
 
     steps:
@@ -29,15 +29,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      # C format: clang-format-16
+      # C format: clang-format-16 (already installed)
       # Python format: yapf==0.40.2
       - name: Install packages
         run: |
-          sudo apt-get install -y gnupg2 software-properties-common
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
-          sudo apt-get update && sudo apt-get install -qqy clang-format-16
-          python -m pip install --upgrade pip
           pip install yapf==0.40.2
 
       - name: Check


### PR DESCRIPTION
This commit changes format check runner to ubuntu 24.04. 
It supports pre-installed clang-format-16.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>