### PR TITLE
[luci/export] Add RmsNorm to luci export

### DIFF
--- a/compiler/luci/export/src/CircleBuiltinTypesExtractor.h
+++ b/compiler/luci/export/src/CircleBuiltinTypesExtractor.h
@@ -548,6 +548,10 @@ public:
                                              to_circle_actfunc(node->fusedActivationFunction()))
       .Union();
   }
+  flatbuffers::Offset<void> visit(luci::CircleRmsNorm *node)
+  {
+    return circle::CreateRmsNormOptions(_builder, node->epsilon()).Union();
+  }
 
 protected:
   flatbuffers::FlatBufferBuilder &_builder;

--- a/compiler/luci/export/src/CircleOps.lst
+++ b/compiler/luci/export/src/CircleOps.lst
@@ -141,6 +141,7 @@ CIRCLE_NODE(CircleBCQFullyConnected, BuiltinOperator_BCQ_FULLY_CONNECTED, Builti
 CIRCLE_NODE(CircleBCQGather, BuiltinOperator_BCQ_GATHER, BuiltinOptions_BCQGatherOptions)
 CIRCLE_NODE(CircleGRU, BuiltinOperator_GRU, BuiltinOptions_GRUOptions)
 CIRCLE_NODE(CircleInstanceNorm, BuiltinOperator_INSTANCE_NORM, BuiltinOptions_InstanceNormOptions)
+CIRCLE_NODE(CircleRmsNorm, BuiltinOperator_RMS_NORM, BuiltinOptions_RmsNormOptions)
 // Virtual node(s)
 CIRCLE_VNODE(CircleBidirectionalSequenceLSTMOut)
 CIRCLE_VNODE(CircleConst)


### PR DESCRIPTION
This commit supports RmsNorm operation in luci export

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967