### PR TITLE
[luci-interpreter] Add RmsNorm kernel

### DIFF
--- a/compiler/luci-interpreter/src/core/KernelParams.h
+++ b/compiler/luci-interpreter/src/core/KernelParams.h
@@ -181,6 +181,11 @@ struct ResizeNearestNeighborParams
   bool half_pixel_centers;
 };
 
+struct RmsNormParams
+{
+  float epsilon;
+};
+
 struct ShapeParams
 {
   loco::DataType out_type;

--- a/compiler/luci-interpreter/src/kernels/RmsNorm.cpp
+++ b/compiler/luci-interpreter/src/kernels/RmsNorm.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/RmsNorm.h"
+
+#include "kernels/Utils.h"
+
+#include <tensorflow/lite/kernels/internal/common.h>
+#include <cmath>
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+RmsNorm::RmsNorm(const Tensor *input, const Tensor *gamma, const Tensor *beta, Tensor *output,
+                 const RmsNormParams &params)
+  : KernelWithParams<RmsNormParams>({input, gamma, beta}, {output}, params)
+{
+}
+
+void RmsNorm::configure()
+{
+  auto num_dims = input()->shape().num_dims();
+  LUCI_INTERPRETER_CHECK(num_dims == 3 || num_dims == 4);
+  LUCI_INTERPRETER_CHECK(input()->element_type() == output()->element_type());
+  LUCI_INTERPRETER_CHECK(gamma()->element_type() == input()->element_type());
+  LUCI_INTERPRETER_CHECK(beta()->element_type() == input()->element_type());
+  LUCI_INTERPRETER_CHECK(gamma()->shape().num_dims() == 1);
+  LUCI_INTERPRETER_CHECK(beta()->shape().num_dims() == 1);
+  LUCI_INTERPRETER_CHECK((gamma()->shape().dim(0) == input()->shape().dim(num_dims - 1)) ||
+                         (gamma()->shape().dim(0) == 1));
+  LUCI_INTERPRETER_CHECK((beta()->shape().dim(0) == input()->shape().dim(num_dims - 1)) ||
+                         (beta()->shape().dim(0) == 1));
+
+  output()->resize(input()->shape());
+}
+
+void RmsNorm::execute() const
+{
+  switch (input()->element_type())
+  {
+    case DataType::FLOAT32:
+      evalFloat();
+      break;
+    default:
+      throw std::runtime_error("luci-intp RmsNorm Unsupported type.");
+  }
+}
+
+void RmsNorm::evalFloat() const
+{
+  tflite::RuntimeShape input_shape = getTensorShape(input());
+  auto output_shape = getTensorShape(output());
+
+  const float *input_data = getTensorData<float>(input());
+  const float *gamma_data = getTensorData<float>(gamma());
+  auto gamma_shape = getTensorShape(gamma());
+  bool single_gamma = gamma_shape.DimensionsCount() == 1 && gamma_shape.Dims(0) == 1;
+  const float *beta_data = getTensorData<float>(beta());
+  auto beta_shape = getTensorShape(beta());
+  bool single_beta = beta_shape.DimensionsCount() == 1 && beta_shape.Dims(0) == 1;
+  float *output_data = getTensorData<float>(output());
+
+  if (input_shape.DimensionsCount() == 4)
+  {
+    // Dimensions for image case are (N x H x W x C)
+    const int32_t batches = tflite::MatchingDim(input_shape, 0, output_shape, 0);
+    const int32_t heights = tflite::MatchingDim(input_shape, 1, output_shape, 1);
+    const int32_t widths = tflite::MatchingDim(input_shape, 2, output_shape, 2);
+    const int32_t channels = tflite::MatchingDim(input_shape, 3, output_shape, 3);
+    for (int32_t batch = 0; batch < batches; batch++)
+    {
+      for (int32_t height = 0; height < heights; height++)
+      {
+        for (int32_t width = 0; width < widths; width++)
+        {
+          double square_sum = 0.0f;
+          for (int32_t channel = 0; channel < channels; channel++)
+          {
+            double input_val =
+              input_data[tflite::Offset(input_shape, batch, height, width, channel)];
+            square_sum += (input_val * input_val);
+          }
+          double rms = std::sqrt((square_sum / channels) + params().epsilon);
+          for (int32_t channel = 0; channel < channels; channel++)
+          {
+            double gamma = single_gamma ? gamma_data[0] : gamma_data[channel];
+            double beta = single_beta ? beta_data[0] : beta_data[channel];
+            output_data[tflite::Offset(output_shape, batch, height, width, channel)] =
+              (gamma *
+                 (input_data[tflite::Offset(input_shape, batch, height, width, channel)] / rms) +
+               beta);
+          }
+        }
+      }
+    }
+  }
+  else if (input_shape.DimensionsCount() == 3)
+  {
+    // Dimensions for non image case are (N x C x D1 x D2 … Dn)
+    const int32_t batches = tflite::MatchingDim(input_shape, 0, output_shape, 0);
+    const int32_t channels = tflite::MatchingDim(input_shape, 1, output_shape, 1);
+    const int32_t size = tflite::MatchingDim(input_shape, 2, output_shape, 2);
+    for (int32_t batch = 0; batch < batches; batch++)
+    {
+      for (int32_t channel = 0; channel < channels; channel++)
+      {
+        double square_sum = 0.0f;
+        size_t offset =
+          static_cast<size_t>(batch * channels * size) + static_cast<size_t>(channel * size);
+        for (int32_t i = 0; i < size; i++)
+        {
+          double input_val = input_data[offset + i];
+          square_sum += (input_val * input_val);
+        }
+        double rms = std::sqrt((square_sum / size) + params().epsilon);
+        for (int32_t i = 0; i < size; i++)
+        {
+          double gamma = single_gamma ? gamma_data[0] : gamma_data[i];
+          double beta = single_beta ? beta_data[0] : beta_data[i];
+          output_data[offset + i] = (gamma * (input_data[offset + i] / rms) + beta);
+        }
+      }
+    }
+  }
+  else
+    throw std::runtime_error("luci-intp RmsNorm unsupported rank.");
+}
+
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/RmsNorm.h
+++ b/compiler/luci-interpreter/src/kernels/RmsNorm.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_RMSNORM_H
+#define LUCI_INTERPRETER_KERNELS_RMSNORM_H
+
+#include "core/Kernel.h"
+#include "core/KernelParams.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+class RmsNorm : public KernelWithParams<RmsNormParams>
+{
+public:
+  RmsNorm(const Tensor *input, const Tensor *gamma, const Tensor *beta, Tensor *output,
+          const RmsNormParams &params);
+
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *gamma() const { return _inputs[1]; }
+  const Tensor *beta() const { return _inputs[2]; }
+  Tensor *output() const { return _outputs[0]; }
+
+  void configure() override;
+  void execute() const override;
+
+private:
+  void evalFloat() const;
+};
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_RMSNORM_H

--- a/compiler/luci-interpreter/src/kernels/RmsNorm.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/RmsNorm.test.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kernels/RmsNorm.h"
+#include "kernels/TestUtils.h"
+#include "luci_interpreter/TestMemoryManager.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+namespace
+{
+
+using namespace testing;
+
+class RmsNormTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { _memory_manager = std::make_unique<TestMemoryManager>(); }
+
+  std::unique_ptr<IMemoryManager> _memory_manager;
+};
+
+TEST_F(RmsNormTest, Simple)
+{
+  Tensor input_tensor =
+    makeInputTensor<DataType::FLOAT32>({1, 2, 2, 1}, {0, 1, 2, 3}, _memory_manager.get());
+  Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
+  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  RmsNormParams params{};
+  params.epsilon = 0.00001f;
+
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  kernel.configure();
+  _memory_manager->allocate_memory(output_tensor);
+  kernel.execute();
+
+  EXPECT_THAT(extractTensorData<float>(output_tensor), FloatArrayNear({0, 1, 1, 1}));
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 2, 1}));
+}
+
+TEST_F(RmsNormTest, Default_gamma_beta)
+{
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
+                                                           _memory_manager.get());
+  Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
+  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  RmsNormParams params{};
+  params.epsilon = 0.001f;
+
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  kernel.configure();
+  _memory_manager->allocate_memory(output_tensor);
+  kernel.execute();
+
+  EXPECT_THAT(
+    extractTensorData<float>(output_tensor),
+    FloatArrayNear({0, 1.412802, 0.784404, 1.176606, 0.883431, 1.104288, 0.920347, 1.073738}));
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 2, 2}));
+}
+
+TEST_F(RmsNormTest, Have_gamma)
+{
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
+                                                           _memory_manager.get());
+  Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {2}, _memory_manager.get());
+  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  RmsNormParams params{};
+  params.epsilon = 0.001f;
+
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  kernel.configure();
+  _memory_manager->allocate_memory(output_tensor);
+  kernel.execute();
+
+  EXPECT_THAT(
+    extractTensorData<float>(output_tensor),
+    FloatArrayNear({0, 2.825603, 1.568808, 2.353213, 1.766861, 2.208577, 1.840694, 2.147477}));
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 2, 2}));
+}
+
+TEST_F(RmsNormTest, Wrong_gamma_beta_dim_NEG)
+{
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
+                                                           _memory_manager.get());
+  Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({3}, {1, 1, 1}, _memory_manager.get());
+  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({3}, {0, 0, 0}, _memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  RmsNormParams params{};
+  params.epsilon = 0.001f;
+
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST_F(RmsNormTest, Unsupported_dims_NEG)
+{
+  Tensor input_tensor =
+    makeInputTensor<DataType::FLOAT32>({2, 2}, {0, 1, 2, 3}, _memory_manager.get());
+  Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
+  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  RmsNormParams params{};
+  params.epsilon = 0.001f;
+
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+} // namespace
+} // namespace kernels
+} // namespace luci_interpreter


### PR DESCRIPTION
This commit support RmsNorm operation kernel in luci-interpreter.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967