### PR TITLE
[one-cmds] Add fuse_rmsnorm option to one command

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -187,6 +187,8 @@ Current transformation options are
 - fuse_mean_with_mean: This fuses two consecutive ReduceMean operations into one.
 - fuse_transpose_with_mean: This fuses ReduceMean with a preceding Transpose under certain conditions.
 - fuse_horizontal_fc_layers: This fuses horizontal FullyConnected layers under certain conditions.
+- fuse_rmsnorm: This will convert rms normalization related operators to
+  one RmsNormalization operator that our onert provides for faster execution.
 - make_batchnorm_gamma_positive: This makes negative gamma of batch normalization into a small positive value (1e-10).
   Note that this pass can change the execution result of the model.
   So, use it only when the impact is known to be acceptable.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -146,6 +146,7 @@ class CONSTANT:
         ('fuse_instnorm', 'fuse ops to InstanceNorm operator'),
         ('fuse_prelu', 'fuse ops to PReLU operator'),
         ('fuse_gelu', 'fuse ops to GeLU operator'),
+        ('fuse_rmsnorm', 'fuse ops to RmsNorm operator'),
         ('fuse_rsqrt', 'fuse ops to Rsqrt operator'),
         ('replace_cw_mul_add_with_depthwise_conv',
          'replace channel-wise Mul/Add with DepthwiseConv2D'),


### PR DESCRIPTION
This commit supports 'fuse_rmsnorm' option to one-cmds.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967