### PR TITLE
[luci/import] Fix invalid comment of RmsNorm

### DIFF
--- a/compiler/luci/import/src/GraphBuilderRegistry.cpp
+++ b/compiler/luci/import/src/GraphBuilderRegistry.cpp
@@ -116,7 +116,7 @@ GraphBuilderRegistry::GraphBuilderRegistry()
   CIRCLE_NODE(RESIZE_NEAREST_NEIGHBOR, CircleResizeNearestNeighborGraphBuilder);           // 97
   CIRCLE_NODE(REVERSE_SEQUENCE, CircleReverseSequenceGraphBuilder);                        // 112
   CIRCLE_NODE(REVERSE_V2, CircleReverseV2GraphBuilder);                                    // 105
-  CIRCLE_NODE(RMS_NORM, CircleRmsNormGraphBuilder);                                        // 255
+  CIRCLE_NODE(RMS_NORM, CircleRmsNormGraphBuilder);                                        // 250
   CIRCLE_NODE(ROUND, CircleRoundGraphBuilder);                                             // 116
   CIRCLE_NODE(RSQRT, CircleRsqrtGraphBuilder);                                             // 76
   CIRCLE_NODE(SCATTER_ND, CircleScatterNdGraphBuilder);                                    // 122


### PR DESCRIPTION
This commit modifies RmsNorm comment to align to the schema

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967