### PR TITLE
[circlechef] Add RmsNorm to test recipe

### DIFF
--- a/compiler/circlechef/tests/shape_signature/test.recipe
+++ b/compiler/circlechef/tests/shape_signature/test.recipe
@@ -41,5 +41,15 @@ operation {
     activation: NONE
   }
 }
+operation {
+  type: "RmsNorm"
+  input: "ifm"
+  input: "gamma"
+  input: "beta"
+  output: "ofm"
+  rms_norm_options {
+    epsilon: 0.000001
+  }
+}
 input: "ifm"
 output: "ofm"


### PR DESCRIPTION
This commit adds RmsNorm operation to circlechef test recipe

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967