### PR TITLE
[common-artifacts] Exclude rope test

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -10,6 +10,7 @@ optimize(Add_STR_001) # STRING is not supported
 
 ## CircleRecipes
 optimize(RmsNorm_000)
+optimize(RoPE_000)
 
 #[[ tcgenerate : Exclude from test data generation(TestDataGenerator) ]]
 ## TensorFlowLiteRecipes
@@ -180,3 +181,4 @@ tcgenerate(GRU_000) # luci-interpreter does not support custom GRU
 tcgenerate(InstanceNorm_000)
 tcgenerate(InstanceNorm_001)
 tcgenerate(RmsNorm_000)
+tcgenerate(RoPE_000)


### PR DESCRIPTION
This commit is to exclude rope test until it's fully supported

ONE-DCO-1.0-Signed-off-by: youngsik kim <ys44.kim@samsung.com>

draft : https://github.com/Samsung/ONE/pull/13978
issue : https://github.com/Samsung/ONE/issues/13972