### PR TITLE
[dredd] Introduce new dredd rule for tensor shape

### DIFF
--- a/compiler/dredd-rule-lib/README.md
+++ b/compiler/dredd-rule-lib/README.md
@@ -21,6 +21,7 @@ Models (input of test) exist in *model repo*, where
 The following metric functions are provided:
 - `all_op_count` : the count of operations inside a compiled tflite file
 - `file_size` : the size of compiled tflite file
+- `tensor_shape` : The shape of a specific node in a compiled tflite file. The format looks like `[1,-1,7,2]`(without spaces).
 - In addition, `op_count`, `conv2d_weight_not_constant`, etc.
 - Please , refer to [`rule-lib.sh`](rule-lib.sh) for metric functions
 

--- a/compiler/dredd-rule-lib/rule-lib.sh
+++ b/compiler/dredd-rule-lib/rule-lib.sh
@@ -252,4 +252,21 @@ const_count()
   echo ${ACTUAL}
 }
 
+tensor_shape()
+{
+  argc_check $# 1
+  file_path_check ${COMPILED_FILE}
+  file_path_check ${INSPECT_PROG_PATH}
+
+  set -o pipefail
+
+  ACTUAL=`init_error_log ; \
+          ${INSPECT_PROG_PATH} --tensor_shape ${COMPILED_FILE} | \
+          awk -v tensor_name="$1" '{ if ($1 == tensor_name) print $2}'`
+
+  check_success_exit_code $? 0
+  
+  echo ${ACTUAL}
+}
+
 # TODO define more qullity test function


### PR DESCRIPTION
This commit introduces new dredd-test rule for tensor shape.

ONE-DCO-1.0-Signed-off-by: JuYoung Lee rsb98759@gmail.com