### PR TITLE
[compute/cker] Add RmsNorm operation

### DIFF
--- a/compute/cker/include/cker/Types.h
+++ b/compute/cker/include/cker/Types.h
@@ -316,6 +316,11 @@ struct ResizeBilinearParams
   bool half_pixel_centers;
 };
 
+struct RmsNormParams
+{
+  float epsilon;
+};
+
 struct TransposeConvParams
 {
   PaddingType padding_type;

--- a/compute/cker/include/cker/operation/RmsNorm.h
+++ b/compute/cker/include/cker/operation/RmsNorm.h
@@ -59,8 +59,8 @@ inline void RmsNorm(const RmsNormParams &params, const Shape &input_shape, const
         double rms = std::sqrt((square_sum / channels) + params.epsilon);
         for (int32_t channel = 0; channel < channels; channel++)
         {
-          double gamma = gamma_data[channel];
-          double beta = beta_data[channel];
+          double gamma = (gamma_data ? gamma_data[channel] : 1.0);
+          double beta = (beta_data ? beta_data[channel] : 0.0);
           output_data[Offset(output_shape, batch, height, width, channel)] =
             (gamma * (input_data[Offset(input_shape, batch, height, width, channel)] / rms) + beta);
         }

--- a/compute/cker/include/cker/operation/RmsNorm.h
+++ b/compute/cker/include/cker/operation/RmsNorm.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_CKER_RMS_NORM_H__
+#define __NNFW_CKER_RMS_NORM_H__
+
+#include "cker/Shape.h"
+#include "cker/Types.h"
+#include "cker/Utils.h"
+
+#include <cmath>
+
+namespace nnfw
+{
+namespace cker
+{
+
+inline void RmsNorm(const RmsNormParams &params, const Shape &input_shape, const float *input_data,
+                    const Shape &gamma_shape, const float *gamma_data, const Shape &beta_shape,
+                    const float *beta_data, const Shape &output_shape, float *output_data)
+{
+  const int32_t batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int32_t heights = MatchingDim(input_shape, 1, output_shape, 1);
+  const int32_t widths = MatchingDim(input_shape, 2, output_shape, 2);
+  const int32_t channels = MatchingDim(input_shape, 3, output_shape, 3);
+
+  UNUSED_RELEASE(gamma_shape);
+  UNUSED_RELEASE(beta_shape);
+
+  for (int32_t batch = 0; batch < batches; batch++)
+  {
+    for (int32_t height = 0; height < heights; height++)
+    {
+      for (int32_t width = 0; width < widths; width++)
+      {
+        double square_sum = 0.0f;
+        for (int32_t channel = 0; channel < channels; channel++)
+        {
+          double input_val = input_data[Offset(input_shape, batch, height, width, channel)];
+          square_sum += (input_val * input_val);
+        }
+        double rms = std::sqrt((square_sum / channels) + params.epsilon);
+        for (int32_t channel = 0; channel < channels; channel++)
+        {
+          double gamma = gamma_data[channel];
+          double beta = beta_data[channel];
+          output_data[Offset(output_shape, batch, height, width, channel)] =
+            (gamma * (input_data[Offset(input_shape, batch, height, width, channel)] / rms) + beta);
+        }
+      }
+    }
+  }
+}
+
+} // namespace cker
+} // namespace nnfw
+
+#endif // __NNFW_CKER_RMS_NORM_H__

--- a/compute/cker/include/cker/operation/RmsNorm.h
+++ b/compute/cker/include/cker/operation/RmsNorm.h
@@ -37,8 +37,12 @@ inline void RmsNorm(const RmsNormParams &params, const Shape &input_shape, const
   const int32_t widths = MatchingDim(input_shape, 2, output_shape, 2);
   const int32_t channels = MatchingDim(input_shape, 3, output_shape, 3);
 
-  UNUSED_RELEASE(gamma_shape);
-  UNUSED_RELEASE(beta_shape);
+  if (gamma_shape.DimensionsCount() != 1 ||
+      gamma_shape.Dims(0) != input_shape.Dims(input_shape.DimensionsCount() - 1))
+    throw std::runtime_error("cker::RmsNorm: Unmatched gamma shape");
+  if (beta_shape.DimensionsCount() != 1 ||
+      beta_shape.Dims(0) != input_shape.Dims(input_shape.DimensionsCount() - 1))
+    throw std::runtime_error("cker::RmsNorm: Unmatched beta shape");
 
   for (int32_t batch = 0; batch < batches; batch++)
   {

--- a/compute/cker/include/cker/operation/RmsNorm.h
+++ b/compute/cker/include/cker/operation/RmsNorm.h
@@ -29,8 +29,8 @@ namespace cker
 {
 
 inline void RmsNorm(const RmsNormParams &params, const Shape &input_shape, const float *input_data,
-                    const Shape &gamma_shape, const float *gamma_data, const Shape &beta_shape,
-                    const float *beta_data, const Shape &output_shape, float *output_data)
+                    const Shape &gamma_shape, const float *gamma_data, const Shape &output_shape,
+                    float *output_data)
 {
   const int32_t batches = MatchingDim(input_shape, 0, output_shape, 0);
   const int32_t heights = MatchingDim(input_shape, 1, output_shape, 1);
@@ -40,9 +40,6 @@ inline void RmsNorm(const RmsNormParams &params, const Shape &input_shape, const
   if (gamma_shape.DimensionsCount() != 1 ||
       gamma_shape.Dims(0) != input_shape.Dims(input_shape.DimensionsCount() - 1))
     throw std::runtime_error("cker::RmsNorm: Unmatched gamma shape");
-  if (beta_shape.DimensionsCount() != 1 ||
-      beta_shape.Dims(0) != input_shape.Dims(input_shape.DimensionsCount() - 1))
-    throw std::runtime_error("cker::RmsNorm: Unmatched beta shape");
 
   for (int32_t batch = 0; batch < batches; batch++)
   {
@@ -60,9 +57,8 @@ inline void RmsNorm(const RmsNormParams &params, const Shape &input_shape, const
         for (int32_t channel = 0; channel < channels; channel++)
         {
           double gamma = (gamma_data ? gamma_data[channel] : 1.0);
-          double beta = (beta_data ? beta_data[channel] : 0.0);
           output_data[Offset(output_shape, batch, height, width, channel)] =
-            (gamma * (input_data[Offset(input_shape, batch, height, width, channel)] / rms) + beta);
+            gamma * (input_data[Offset(input_shape, batch, height, width, channel)] / rms);
         }
       }
     }

--- a/compute/cker/src/RmsNorm.test.cc
+++ b/compute/cker/src/RmsNorm.test.cc
@@ -33,20 +33,17 @@ TEST(CKer_Operation, RmsNorm)
     std::vector<float> gamma = {1};
     nnfw::cker::Shape gamma_shape{1};
 
-    std::vector<float> beta = {0};
-    nnfw::cker::Shape beta_shape{1};
-
     nnfw::cker::RmsNormParams param;
     param.epsilon = 0.00001f;
 
-    nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape, gamma.data(), beta_shape,
-                        beta.data(), output_shape, output.data());
+    nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape, gamma.data(), output_shape,
+                        output.data());
 
     for (size_t i = 0; i < expected_output.size(); ++i)
       EXPECT_NEAR(output[i], expected_output[i], 1e-5f);
   }
 
-  // Default gamma and beta
+  // Default gamma
   {
     std::vector<float> input = {0, 1, 2, 3, 4, 5, 6, 7};
     nnfw::cker::Shape input_shape{1, 2, 2, 2};
@@ -59,14 +56,11 @@ TEST(CKer_Operation, RmsNorm)
     std::vector<float> gamma = {1, 1};
     nnfw::cker::Shape gamma_shape{2};
 
-    std::vector<float> beta = {0, 0};
-    nnfw::cker::Shape beta_shape{2};
-
     nnfw::cker::RmsNormParams param;
     param.epsilon = 0.001f;
 
-    nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape, gamma.data(), beta_shape,
-                        beta.data(), output_shape, output.data());
+    nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape, gamma.data(), output_shape,
+                        output.data());
 
     for (size_t i = 0; i < expected_output.size(); ++i)
       EXPECT_NEAR(output[i], expected_output[i], 1e-5f);
@@ -87,14 +81,10 @@ TEST(CKer_Operation, neg_RmsNormWrongGammaDims)
     std::vector<float> gamma = {1};
     nnfw::cker::Shape gamma_shape{1};
 
-    std::vector<float> beta = {0, 0};
-    nnfw::cker::Shape beta_shape{2};
-
     nnfw::cker::RmsNormParams param;
     param.epsilon = 0.001f;
 
     EXPECT_ANY_THROW(nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape,
-                                         gamma.data(), beta_shape, beta.data(), output_shape,
-                                         output.data()));
+                                         gamma.data(), output_shape, output.data()));
   }
 }

--- a/compute/cker/src/RmsNorm.test.cc
+++ b/compute/cker/src/RmsNorm.test.cc
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cker/operation/RmsNorm.h>
+
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(CKer_Operation, RmsNorm)
+{
+  // Simple
+  {
+    std::vector<float> input = {0, 1, 2, 3};
+    nnfw::cker::Shape input_shape{1, 2, 2, 1};
+
+    std::vector<float> expected_output = {0, 1, 1, 1};
+    std::vector<float> output(expected_output.size());
+    nnfw::cker::Shape output_shape{1, 2, 2, 1};
+
+    std::vector<float> gamma = {1};
+    nnfw::cker::Shape gamma_shape{1};
+
+    std::vector<float> beta = {0};
+    nnfw::cker::Shape beta_shape{1};
+
+    nnfw::cker::RmsNormParams param;
+    param.epsilon = 0.00001f;
+
+    nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape, gamma.data(), beta_shape,
+                        beta.data(), output_shape, output.data());
+
+    for (size_t i = 0; i < expected_output.size(); ++i)
+      EXPECT_NEAR(output[i], expected_output[i], 1e-5f);
+  }
+
+  // Default gamma and beta
+  {
+    std::vector<float> input = {0, 1, 2, 3, 4, 5, 6, 7};
+    nnfw::cker::Shape input_shape{1, 2, 2, 2};
+
+    std::vector<float> expected_output = {0,        1.412802, 0.784404, 1.176606,
+                                          0.883431, 1.104288, 0.920347, 1.073738};
+    std::vector<float> output(expected_output.size());
+    nnfw::cker::Shape output_shape{1, 2, 2, 2};
+
+    std::vector<float> gamma = {1, 1};
+    nnfw::cker::Shape gamma_shape{2};
+
+    std::vector<float> beta = {0, 0};
+    nnfw::cker::Shape beta_shape{2};
+
+    nnfw::cker::RmsNormParams param;
+    param.epsilon = 0.001f;
+
+    nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape, gamma.data(), beta_shape,
+                        beta.data(), output_shape, output.data());
+
+    for (size_t i = 0; i < expected_output.size(); ++i)
+      EXPECT_NEAR(output[i], expected_output[i], 1e-5f);
+  }
+}
+
+TEST(CKer_Operation, neg_RmsNormWrongGammaDims)
+{
+  {
+    std::vector<float> input = {0, 1, 2, 3, 4, 5, 6, 7};
+    nnfw::cker::Shape input_shape{1, 2, 2, 2};
+
+    std::vector<float> expected_output = {0,        1.412802, 0.784404, 1.176606,
+                                          0.883431, 1.104288, 0.920347, 1.073738};
+    std::vector<float> output(expected_output.size());
+    nnfw::cker::Shape output_shape{1, 2, 2, 2};
+
+    std::vector<float> gamma = {1};
+    nnfw::cker::Shape gamma_shape{1};
+
+    std::vector<float> beta = {0, 0};
+    nnfw::cker::Shape beta_shape{2};
+
+    nnfw::cker::RmsNormParams param;
+    param.epsilon = 0.001f;
+
+    EXPECT_ANY_THROW(nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape,
+                                         gamma.data(), beta_shape, beta.data(), output_shape,
+                                         output.data()));
+  }
+}


### PR DESCRIPTION
This commit adds RmsNorm operation to cker

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14089
draft: https://github.com/Samsung/ONE/pull/14088
