### PR TITLE
[common-artifacts] Include RmsNorm optimization and test data generation

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -9,7 +9,6 @@ optimize(Add_STR_000) # STRING is not supported
 optimize(Add_STR_001) # STRING is not supported
 
 ## CircleRecipes
-optimize(RmsNorm_000)
 optimize(RoPE_000)
 
 #[[ tcgenerate : Exclude from test data generation(TestDataGenerator) ]]
@@ -180,5 +179,4 @@ tcgenerate(CircleFullyConnected_U4_002)
 tcgenerate(GRU_000) # luci-interpreter does not support custom GRU
 tcgenerate(InstanceNorm_000)
 tcgenerate(InstanceNorm_001)
-tcgenerate(RmsNorm_000)
 tcgenerate(RoPE_000)


### PR DESCRIPTION
This commit reverts exclude.lst to include RmsNorm optimization and test data generation.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/13964
draft: https://github.com/Samsung/ONE/pull/13967