### PR TITLE
[circledump] Support RoPE Operation

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -839,6 +839,20 @@ public:
   }
 };
 
+class RoPEPrinter : public OpPrinter
+{
+public:
+  void options(const circle::Operator *op, std::ostream &os) const override
+  {
+    if (auto *params = op->builtin_options_as_RoPEOptions())
+    {
+      os << "    ";
+      os << "mode(" << EnumNameRoPEMode(params->mode()) << ") ";
+      os << std::endl;
+    }
+  }
+};
+
 OpPrinterRegistry::OpPrinterRegistry()
 {
   _op_map[circle::BuiltinOperator_ADD] = make_unique<AddPrinter>();
@@ -927,6 +941,7 @@ OpPrinterRegistry::OpPrinterRegistry()
   _op_map[circle::BuiltinOperator_GRU] = make_unique<GRUPrinter>();
   _op_map[circle::BuiltinOperator_INSTANCE_NORM] = make_unique<InstanceNormPrinter>();
   _op_map[circle::BuiltinOperator_RMS_NORM] = make_unique<RmsNormPrinter>();
+  _op_map[circle::BuiltinOperator_ROPE] = make_unique<RoPEPrinter>();
 }
 
 } // namespace circledump


### PR DESCRIPTION
This commit adds RoPE Printer in circle dump

ONE-DCO-1.0-Signed-off-by: youngsik kim <ys44.kim@samsung.com>

draft : https://github.com/Samsung/ONE/pull/13978
issue : https://github.com/Samsung/ONE/issues/13972