### PR TITLE
[common-artifacts] Exclude Reshape_003 optimization test

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -7,6 +7,7 @@
 ## TensorFlowLiteRecipes
 optimize(Add_STR_000) # STRING is not supported
 optimize(Add_STR_001) # STRING is not supported
+optimize(Reshape_003) # no input, no option is not supported
 
 ## CircleRecipes
 optimize(RoPE_000)


### PR DESCRIPTION
This commit is to exclude Reshape_003 optimization test.
This recipe does not reflect the original intention.

Related: https://github.com/Samsung/ONE/issues/13927

ONE-DCO-Signed-off-by: Jongwon Yang <yjw963@gmail.com>