### PR TITLE
[luci/service] Handle CircleNode as reshape's shape

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -71,6 +71,8 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
 
   const loco::DataType S32 = loco::DataType::S32;
 
+  bool is_static_shape = true;
+
   loco::TensorShape shape_by_input;
   {
     LUCI_ASSERT(node->shape(), "2nd input shape() should not be nullptr");
@@ -95,21 +97,13 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
     }
     else
     {
-      // We use shape from the node itself
-      loco::TensorShape shape;
-      shape.rank(node->rank());
-      for (uint32_t r = 0; r < node->rank(); ++r)
+      auto shape = loco::must_cast<luci::CircleNode *>(node->shape());
+      shape_by_input.rank(shape->dim(0).value());
+      for (uint32_t r = 0; r < shape_by_input.rank(); ++r)
       {
-        // TODO remove this copy from `use_own(node);`
-        // Shape inference rules in this file did not consider unknown dimension.
-        // If some node has unknown dimension, 0 is inserted and wrong shape
-        // inference was done as a result.
-        // To fix this, new shape inference algorithm is being implemented.
-        // Until new inference algorithm is fully implemented, unknown dimension
-        // would be represented as 1 along with TFLite expression.
-        shape.dim(r) = node->dim(r).known() ? node->dim(r).value() : 1;
+        shape_by_input.dim(r).unset();
       }
-      shape_by_input = shape;
+      is_static_shape = false;
     }
   }
 
@@ -138,7 +132,6 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
   uint32_t input_element_count = 1;
   uint32_t output_element_count = 1;
   uint32_t unknown_dim_index = UINT32_MAX;
-  bool is_static_shape = true;
   for (uint32_t i = 0; i < input_shape.rank(); ++i)
   {
     if (input_shape.dim(i).known())
@@ -146,22 +139,26 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
     else
       is_static_shape = false;
   }
-  for (uint32_t dim_index = 0; dim_index < output_shape.rank(); ++dim_index)
+
+  if (is_static_shape)
   {
-    const uint32_t dim_value = output_shape.dim(dim_index).value();
-    if (not output_shape.dim(dim_index).known())
+    for (uint32_t dim_index = 0; dim_index < output_shape.rank(); ++dim_index)
     {
-      LUCI_ASSERT(unknown_dim_index == UINT32_MAX, "More than one unknown dimension");
-      unknown_dim_index = dim_index;
+      const uint32_t dim_value = output_shape.dim(dim_index).value();
+      if (not output_shape.dim(dim_index).known())
+      {
+        LUCI_ASSERT(unknown_dim_index == UINT32_MAX, "More than one unknown dimension");
+        unknown_dim_index = dim_index;
+      }
+      else
+      {
+        output_element_count *= dim_value;
+      }
     }
-    else
+    if (unknown_dim_index != UINT32_MAX)
     {
-      output_element_count *= dim_value;
+      output_shape.dim(unknown_dim_index) = input_element_count / output_element_count;
     }
-  }
-  if (unknown_dim_index != UINT32_MAX && is_static_shape)
-  {
-    output_shape.dim(unknown_dim_index) = input_element_count / output_element_count;
   }
 
   return output_shape;


### PR DESCRIPTION
This commit supports handling of CircleNode as reshape's shape.
This is a part of the new shape inference policy of reshape.

Draft: https://github.com/Samsung/ONE/pull/14127
Related: https://github.com/Samsung/ONE/issues/13927

ONE-DCO-Signed-off-by: Jongwon Yang <yjw963@gmail.com>