### PR TITLE
[circle2circle-dredd-recipe-test] Add Inf_Quantize Test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -147,3 +147,4 @@ Add(REGRESS_Issue_13863 PASS substitute_pack_to_reshape)
 
 # SHAPE INFERENCE test
 Add(Inf_Pad_000 PASS)
+Add(Inf_Quantize_000 PASS)


### PR DESCRIPTION
This commit add Inf_Quantize_000 test for dynamic shape Inference.

ONE-DCO-1.0-Signed-off-by: Bokyeong Lee <kyeong8139@gmail.com>