### PR TITLE
[luci] static cast from uint32 to int64

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
+++ b/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
@@ -99,7 +99,7 @@ struct StridedSliceContext
     strides = loco::must_cast<luci::CircleConst *>(node->strides());
 
     loco::TensorShape input_shape = circle_shape(input);
-    input_dims = input_shape.rank();
+    input_dims = static_cast<int64_t>(input_shape.rank());
   }
   StridedSliceParams params;
   luci::CircleNode *input = nullptr;


### PR DESCRIPTION
This commit explicitly casts uint32 to int64.

This change is for resolving static analysis tool warning.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>