### PR TITLE
[luci/pass] Add TaggedShapeAnalyzer::init() in RmUnnTransNetPass

### DIFF
--- a/compiler/luci/pass/src/RemoveUnnecessaryTransposeNetPass.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessaryTransposeNetPass.cpp
@@ -19,6 +19,7 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/Profile/CircleNodeOrigin.h>
 
+#include <limits>
 #include <vector>
 
 namespace

--- a/compiler/luci/pass/src/RemoveUnnecessaryTransposeNetPass.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessaryTransposeNetPass.cpp
@@ -261,7 +261,7 @@ bool TaggedShapeAnalyzer::verify_tag() const
 }
 
 /**
- * @brief Initialize the class member and checks under conditions
+ * @brief Initialize the class members and check under conditions
  *
  *  Condtiions that have to be met for analyzer
  *    c1: input rank >= output rank
@@ -358,7 +358,7 @@ bool TaggedShapeAnalyzer::init(const luci::CircleTranspose *front_transpose,
  */
 template <loco::DataType DType> bool TaggedShapeAnalyzer::can_remove_transposes()
 {
-  // TODO: Update methods to use std::vector<int32_t&> intead of CircleNode
+  // TODO: Update methods to use std::vector<int32_t&> intead of CircleNode ptr
   // For example,
   //  init_shape_with_tag(_in_shape);
   //  analyze_transpose(_fornt_perm);


### PR DESCRIPTION
This PR adds the TaggedShapeAnalyzer::init() function. The init() function explicitly checks some conditions that have to be met for the analyzer.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>

* draft : https://github.com/Samsung/ONE/pull/14121 
