### PR TITLE
[compute/cker] Fix a build error in RmsNorm.h

### DIFF
--- a/compute/cker/include/cker/operation/RmsNorm.h
+++ b/compute/cker/include/cker/operation/RmsNorm.h
@@ -22,6 +22,7 @@
 #include "cker/Utils.h"
 
 #include <cmath>
+#include <stdexcept>
 
 namespace nnfw
 {


### PR DESCRIPTION
This commit fixes a build error coming from a missing exceptions-related include

ONE-DCO-1.0-Signed-off-by: Tomasz Dołbniak t.dolbniak@partner.samsung.com