### PR TITLE
[CI] Extend the commit message check

### DIFF
--- a/.github/workflows/check-pr-commit.yml
+++ b/.github/workflows/check-pr-commit.yml
@@ -42,6 +42,7 @@ jobs:
           # Check string starting from "Signed-off-by:"
           count=$(cat commit_body.txt | grep 'Signed-off-by:' | wc -l)
           if [[ ! "$count" -ge "1" ]]; then
+            echo "Your commit message does not contain the expected signoff information."
             exit 1
           fi
 
@@ -54,5 +55,7 @@ jobs:
           count=$(cat commit_body.txt | sed '/Signed-off-by:/d' | wc -w)
           echo "Commit body word check: $count words"
           if [[ "$count" -lt "5" ]]; then
+            echo "The body of your commit does not satisfy this repository requirements."
+            echo "The body needs to contain at least 5 words."
             exit 1
           fi


### PR DESCRIPTION
This commit extends the commit message check by adding a human-readable explanation of the failure. The message is displayed when the commit message does not contain the signoff information or when the commit body is too short.

ONE-DCO-1.0-Signed-off-by: Tomasz Dołbniak <t.dolbniak@partner.samsung.com>