### PR TITLE
[circle2circle-dredd-recipe-test] Add Inf_Mul_000 test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -147,4 +147,5 @@ Add(REGRESS_ONNX_Mul_Mul_000 PASS
 Add(REGRESS_Issue_13863 PASS substitute_pack_to_reshape)
 
 # SHAPE INFERENCE test
+Add(Inf_Mul_000 PASS)
 Add(Inf_Pad_000 PASS)


### PR DESCRIPTION
This commit adds Inf_Mul_000 to circle2circle-dredd-recipe-test.

ONE-DCO-1.0-Signed-off-by: sunki <ajsthfldu@outlook.com>

---
- Related: #13998
- Draft: #14143