### PR TITLE
[onert] Remove unnecessary op conversion

### DIFF
--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
@@ -66,17 +66,6 @@ void TrainableOperationConverter::visit(const ir::operation::FullyConnected &nod
   _return_op = std::make_unique<ir::train::operation::FullyConnected>(node);
 }
 
-void TrainableOperationConverter::visit(const ir::operation::Loss &node)
-{
-  const auto &y_pred_index = node.getInputs().at(ir::operation::Loss::Input::Y_PRED);
-  const auto &y_pred = _tgraph.operands().at(y_pred_index);
-  const auto &y_pred_node = _tgraph.operations().at(y_pred.getDef());
-  const auto y_pred_op_code = y_pred_node.opcode();
-
-  _return_op =
-    std::make_unique<ir::train::operation::Loss>(node, _training_info->lossInfo(), y_pred_op_code);
-}
-
 void TrainableOperationConverter::visit(const ir::operation::Pad &node)
 {
   _return_op = std::make_unique<ir::train::operation::Pad>(node);

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
@@ -42,7 +42,7 @@ private:
   void visit(const ir::operation::DepthwiseConv2D &) override;
   void visit(const ir::operation::ElementwiseActivation &) override;
   void visit(const ir::operation::FullyConnected &) override;
-  void visit(const ir::operation::Loss &node) override;
+  // ir::operation::Loss is inserted and converted only by LossInsertionPass
   void visit(const ir::operation::Pad &node) override;
   void visit(const ir::operation::Permute &node) override;
   void visit(const ir::operation::Pool2D &node) override;


### PR DESCRIPTION
This commit removes unnecessary Loss op conversion from TrainableOperationConverter.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>