### PR TITLE
[DRAFT][compiler] Remove beta(bias) from RmsNorm

### DIFF
--- a/compiler/circlechef/circle/src/Op/RmsNorm.cpp
+++ b/compiler/circlechef/circle/src/Op/RmsNorm.cpp
@@ -24,12 +24,11 @@ namespace circlechef
 void CircleOpRmsNorm::filler(const circle::Operator *op, CircleImport *import,
                              circlechef::ModelRecipe *model_recipe) const
 {
-  // index 1 and 2 maybe constant
+  // index 1 maybe constant
   const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
-  assert(inputs.size() == 3);
+  assert(inputs.size() == 2);
 
   import->set_tensor_filler(inputs[1]); // set gaussian filler
-  import->set_tensor_filler(inputs[2]);
 }
 
 circlechef::Operation *CircleOpRmsNorm::build(const circle::Operator *op, CircleImport *import,

--- a/compiler/luci-interpreter/src/kernels/RmsNorm.h
+++ b/compiler/luci-interpreter/src/kernels/RmsNorm.h
@@ -28,12 +28,10 @@ namespace kernels
 class RmsNorm : public KernelWithParams<RmsNormParams>
 {
 public:
-  RmsNorm(const Tensor *input, const Tensor *gamma, const Tensor *beta, Tensor *output,
-          const RmsNormParams &params);
+  RmsNorm(const Tensor *input, const Tensor *gamma, Tensor *output, const RmsNormParams &params);
 
   const Tensor *input() const { return _inputs[0]; }
   const Tensor *gamma() const { return _inputs[1]; }
-  const Tensor *beta() const { return _inputs[2]; }
   Tensor *output() const { return _outputs[0]; }
 
   void configure() override;

--- a/compiler/luci-interpreter/src/kernels/RmsNorm.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/RmsNorm.test.cpp
@@ -39,13 +39,12 @@ TEST_F(RmsNormTest, Simple)
   Tensor input_tensor =
     makeInputTensor<DataType::FLOAT32>({1, 2, 2, 1}, {0, 1, 2, 3}, _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.00001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   kernel.configure();
   _memory_manager->allocate_memory(output_tensor);
   kernel.execute();
@@ -54,18 +53,17 @@ TEST_F(RmsNormTest, Simple)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 2, 1}));
 }
 
-TEST_F(RmsNormTest, Default_gamma_beta)
+TEST_F(RmsNormTest, Default_gamma)
 {
   Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
                                                            _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   kernel.configure();
   _memory_manager->allocate_memory(output_tensor);
   kernel.execute();
@@ -81,13 +79,12 @@ TEST_F(RmsNormTest, Have_gamma)
   Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
                                                            _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {2}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   kernel.configure();
   _memory_manager->allocate_memory(output_tensor);
   kernel.execute();
@@ -98,18 +95,17 @@ TEST_F(RmsNormTest, Have_gamma)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 2, 2}));
 }
 
-TEST_F(RmsNormTest, Wrong_gamma_beta_dim_NEG)
+TEST_F(RmsNormTest, Wrong_gamma_dim_NEG)
 {
   Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
                                                            _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({3}, {1, 1, 1}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({3}, {0, 0, 0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
 }
 
@@ -118,13 +114,12 @@ TEST_F(RmsNormTest, Unsupported_dims_NEG)
   Tensor input_tensor =
     makeInputTensor<DataType::FLOAT32>({2, 2}, {0, 1, 2, 3}, _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
 }
 

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -1101,12 +1101,10 @@ TEST_F(KernelBuilderTest, RmsNorm)
 {
   auto *input = createInputNode();
   auto *gamma = createInputNode();
-  auto *beta = createInputNode();
 
   auto *op = createNode<luci::CircleRmsNorm>();
   op->input(input);
   op->gamma(gamma);
-  op->beta(beta);
   op->epsilon(1e-06);
 
   auto kernel = buildKernel<kernels::RmsNorm>(op);
@@ -1114,7 +1112,6 @@ TEST_F(KernelBuilderTest, RmsNorm)
 
   checkTensor(kernel->input(), input);
   checkTensor(kernel->gamma(), gamma);
-  checkTensor(kernel->beta(), beta);
   checkTensor(kernel->output(), op);
   EXPECT_THAT(kernel->params().epsilon, Eq(op->epsilon()));
 }

--- a/compiler/luci-interpreter/src/loader/nodes/RmsNorm.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/RmsNorm.cpp
@@ -25,18 +25,17 @@ std::unique_ptr<Kernel> build_kernel_CircleRmsNorm(const luci::CircleNode *circl
                                                    KernelBuilderHelper &helper)
 {
   const auto *node = loco::must_cast<const luci::CircleRmsNorm *>(circle_node);
-  assert(node->arity() == 3);
+  assert(node->arity() == 2);
 
   const Tensor *input = helper.getInputTensor(node->input());
   const Tensor *gamma = helper.getInputTensor(node->gamma());
-  const Tensor *beta = helper.getInputTensor(node->beta());
 
   Tensor *output = helper.getOutputTensor(node);
 
   RmsNormParams params{};
   params.epsilon = node->epsilon();
 
-  return std::make_unique<kernels::RmsNorm>(input, gamma, beta, output, params);
+  return std::make_unique<kernels::RmsNorm>(input, gamma, output, params);
 }
 
 } // namespace luci_interpreter

--- a/compiler/luci/import/src/Nodes/CircleRmsNorm.cpp
+++ b/compiler/luci/import/src/Nodes/CircleRmsNorm.cpp
@@ -26,7 +26,7 @@ namespace luci
 bool CircleRmsNormGraphBuilder::validate(const ValidateArgs &args) const
 {
   // TODO check dtypes
-  return GraphBuilder::validate(args, 3);
+  return GraphBuilder::validate(args, 2);
 }
 
 CircleNode *CircleRmsNormGraphBuilder::build_node(const circle::OperatorT &op,
@@ -36,7 +36,6 @@ CircleNode *CircleRmsNormGraphBuilder::build_node(const circle::OperatorT &op,
   auto *node = graph->nodes()->create<CircleRmsNorm>();
   node->input(inputs.at(0));
   node->gamma(inputs.at(1));
-  node->beta(inputs.at(2));
 
   const auto *options = op.builtin_options.AsRmsNormOptions();
   node->epsilon(options->epsilon);

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleRmsNorm.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleRmsNorm.h
@@ -28,7 +28,7 @@ namespace luci
 /**
  * @brief RMS_NORM in Circle
  */
-class CircleRmsNorm final : public FixedArityNode<3, CircleNodeImpl<CircleOpcode::RMS_NORM>>
+class CircleRmsNorm final : public FixedArityNode<2, CircleNodeImpl<CircleOpcode::RMS_NORM>>
 {
 public:
   loco::Node *input(void) const { return at(0)->node(); }
@@ -36,9 +36,6 @@ public:
 
   loco::Node *gamma(void) const { return at(1)->node(); }
   void gamma(loco::Node *node) { at(1)->node(node); }
-
-  loco::Node *beta(void) const { return at(2)->node(); }
-  void beta(loco::Node *node) { at(2)->node(node); }
 
 public:
   float epsilon() const { return _epsilon; }

--- a/compiler/luci/lang/src/Nodes/CircleRmsNorm.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleRmsNorm.test.cpp
@@ -30,7 +30,6 @@ TEST(CircleRmsNormTest, constructor)
 
   ASSERT_EQ(nullptr, rms_norm.input());
   ASSERT_EQ(nullptr, rms_norm.gamma());
-  ASSERT_EQ(nullptr, rms_norm.beta());
   ASSERT_FLOAT_EQ(rms_norm.epsilon(), 1e-06);
 }
 
@@ -41,25 +40,21 @@ TEST(CircleRmsNormTest, input_NEG)
 
   rms_norm.input(&node);
   rms_norm.gamma(&node);
-  rms_norm.beta(&node);
   ASSERT_NE(nullptr, rms_norm.input());
   ASSERT_NE(nullptr, rms_norm.gamma());
-  ASSERT_NE(nullptr, rms_norm.beta());
 
   rms_norm.input(nullptr);
   rms_norm.gamma(nullptr);
-  rms_norm.beta(nullptr);
   ASSERT_EQ(nullptr, rms_norm.input());
   ASSERT_EQ(nullptr, rms_norm.gamma());
-  ASSERT_EQ(nullptr, rms_norm.beta());
 }
 
 TEST(CircleRmsNormTest, arity_NEG)
 {
   luci::CircleRmsNorm rms_norm;
 
-  ASSERT_NO_THROW(rms_norm.arg(2));
-  ASSERT_THROW(rms_norm.arg(3), std::out_of_range);
+  ASSERT_NO_THROW(rms_norm.arg(1));
+  ASSERT_THROW(rms_norm.arg(2), std::out_of_range);
 }
 
 TEST(CircleRmsNormTest, visit_mutable_NEG)

--- a/compiler/luci/logex/src/CircleNodeSummaryBuilders.cpp
+++ b/compiler/luci/logex/src/CircleNodeSummaryBuilders.cpp
@@ -905,7 +905,7 @@ std::vector<std::string> CircleReverseV2SummaryBuilder::get_input_names(const lu
 
 std::vector<std::string> CircleRmsNormSummaryBuilder::get_input_names(const luci::CircleNode *)
 {
-  return {"input", "gamma", "beta"};
+  return {"input", "gamma"};
 }
 
 void CircleRmsNormSummaryBuilder::build_attributes(const luci::CircleNode *node,

--- a/compiler/luci/partition/src/Nodes/CircleRmsNorm.cpp
+++ b/compiler/luci/partition/src/Nodes/CircleRmsNorm.cpp
@@ -25,11 +25,9 @@ void connect(luci::ConnectNode *cn, const luci::CircleRmsNorm *node)
 
   luci::CircleNode *input = loco::must_cast<luci::CircleNode *>(node->input());
   luci::CircleNode *gamma = loco::must_cast<luci::CircleNode *>(node->gamma());
-  luci::CircleNode *beta = loco::must_cast<luci::CircleNode *>(node->beta());
 
   cloned->input(cn->find_clone(input));
   cloned->gamma(cn->find_clone(gamma));
-  cloned->beta(cn->find_clone(beta));
 }
 
 } // namespace

--- a/compiler/luci/partition/src/Nodes/CircleRmsNorm.test.cpp
+++ b/compiler/luci/partition/src/Nodes/CircleRmsNorm.test.cpp
@@ -36,7 +36,7 @@ public:
   void init(loco::Graph *g) override { NodeGraphletT<luci::CircleRmsNorm>::init(g); }
 };
 
-class TestNodeGraph : public TestIsOGraph<3>, public NodeGraphlet
+class TestNodeGraph : public TestIsOGraph<2>, public NodeGraphlet
 {
 public:
   TestNodeGraph() = default;
@@ -44,12 +44,11 @@ public:
 public:
   void init(const ShapeU32 shape)
   {
-    TestIsOGraph<3>::init({shape, shape, shape}, shape);
+    TestIsOGraph<2>::init({shape, shape}, shape);
     NodeGraphlet::init(g());
 
     node()->input(input(0));
     node()->gamma(input(1));
-    node()->beta(input(2));
 
     output()->from(node());
   }
@@ -73,10 +72,9 @@ TEST(ConnectNodeTest, connect_RmsNorm)
 
   cth.clone_connect(node, clone);
 
-  ASSERT_EQ(3, clone->arity());
+  ASSERT_EQ(2, clone->arity());
   ASSERT_EQ(cth.inputs(0), clone->arg(0));
   ASSERT_EQ(cth.inputs(1), clone->arg(1));
-  ASSERT_EQ(cth.inputs(2), clone->arg(2));
 }
 
 TEST(ConnectNodeTest, connect_RmsNorm_NEG)

--- a/compiler/luci/pass/src/QuantizePreCheckerPass.cpp
+++ b/compiler/luci/pass/src/QuantizePreCheckerPass.cpp
@@ -78,13 +78,13 @@ struct ConstInputChecker final : public luci::CircleNodeMutableVisitor<void>
 
   // Ops that receive one const nodes as inputs
   CHECK_NODE_WITH_ONE_INPUT_CONST(luci::CirclePRelu, alpha)
+  CHECK_NODE_WITH_ONE_INPUT_CONST(luci::CircleRmsNorm, gamma)
 
   // Ops that receive two const node as an inputs
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleConv2D, filter, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleDepthwiseConv2D, filter, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleFullyConnected, weights, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleInstanceNorm, gamma, beta)
-  CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleRmsNorm, gamma, beta)
 
   // Ops that receive three const nodes as an inputs
   CHECK_NODE_WITH_THREE_INPUT_CONST(luci::CircleTransposeConv, inputSizes, filter, bias)

--- a/compiler/luci/pass/src/QuantizePreCheckerPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizePreCheckerPass.test.cpp
@@ -199,20 +199,18 @@ public:
   {
     rms_norm_node = g.nodes()->create<luci::CircleRmsNorm>();
     input_1 = g.nodes()->create<luci::CircleInput>();
-    gamma = g.nodes()->create<luci::CircleConst>();
 
     rms_norm_node->input(input_1);
-    rms_norm_node->gamma(gamma);
 
     if (make_valid)
     {
-      beta = g.nodes()->create<luci::CircleConst>();
-      rms_norm_node->beta(beta);
+      gamma = g.nodes()->create<luci::CircleConst>();
+      rms_norm_node->gamma(gamma);
     }
     else
     {
       input_2 = g.nodes()->create<luci::CircleInput>();
-      rms_norm_node->beta(input_2);
+      rms_norm_node->gamma(input_2);
     }
 
     output = g.nodes()->create<luci::CircleOutput>();
@@ -231,7 +229,6 @@ private:
   luci::CircleInput *input_1 = nullptr;
   luci::CircleInput *input_2 = nullptr;
   luci::CircleConst *gamma = nullptr;
-  luci::CircleConst *beta = nullptr;
   luci::CircleOutput *output = nullptr;
 };
 

--- a/compiler/luci/pass/src/QuantizeWeights.cpp
+++ b/compiler/luci/pass/src/QuantizeWeights.cpp
@@ -513,7 +513,6 @@ void QuantizeWeights::visit(luci::CircleRmsNorm *node)
   INFO(l) << "QuantizeWeights QuantizeWeights::visit node: " << node->name() << std::endl;
 
   auto gamma = loco::must_cast<luci::CircleConst *>(node->gamma());
-  auto beta = loco::must_cast<luci::CircleConst *>(node->beta());
 
   if (!is_quantized(gamma))
   {
@@ -524,16 +523,6 @@ void QuantizeWeights::visit(luci::CircleRmsNorm *node)
     else if (granularity == QuantizationGranularity::ChannelWise)
       quant_const_per_channel(new_gamma, output_type);
     node->gamma(new_gamma);
-  }
-  if (!is_quantized(beta))
-  {
-    assert(beta->dtype() == loco::DataType::FLOAT32);
-    auto new_beta = luci::clone(beta);
-    if (granularity == QuantizationGranularity::LayerWise)
-      quant_const(new_beta, output_type);
-    else if (granularity == QuantizationGranularity::ChannelWise)
-      quant_const_per_channel(new_beta, output_type);
-    node->beta(new_beta);
   }
 }
 

--- a/compiler/luci/pass/src/VerifyQuantizedNodeGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeGranularity.h
@@ -518,7 +518,6 @@ private:
     RETURN_FALSE_UNLESS(is_lwq(node))
     RETURN_FALSE_UNLESS(is_lwq(node->input()))
     RETURN_FALSE_UNLESS(is_cwq_const(node->gamma(), rank(node->gamma()) - 1))
-    RETURN_FALSE_UNLESS(is_cwq_const(node->beta(), rank(node->beta()) - 1))
     return true;
   }
 
@@ -611,7 +610,6 @@ private:
     RETURN_FALSE_UNLESS(is_lwq(node))
     RETURN_FALSE_UNLESS(is_lwq(node->input()))
     RETURN_FALSE_UNLESS(is_lwq_const(node->gamma()))
-    RETURN_FALSE_UNLESS(is_lwq_const(node->beta()))
     return true;
   }
 

--- a/res/CircleRecipes/RmsNorm_000/test.recipe
+++ b/res/CircleRecipes/RmsNorm_000/test.recipe
@@ -16,18 +16,6 @@ operand {
   }
 }
 operand {
-  name: "beta"
-  type: FLOAT32
-  shape { dim: 4 }
-  filler {
-    tag: "explicit"
-    arg: "0.0"
-    arg: "0.0"
-    arg: "0.0"
-    arg: "0.0"
-  }
-}
-operand {
   name: "ofm"
   type: FLOAT32
   shape { dim: 1 dim: 3 dim: 3 dim: 4 }
@@ -36,7 +24,6 @@ operation {
   type: "RmsNorm"
   input: "ifm"
   input: "gamma"
-  input: "beta"
   output: "ofm"
   rms_norm_options {
     epsilon: 0.0001


### PR DESCRIPTION
This commit removes beta(bias) from RmsNorm.
It's decided to remove the bias because it's not used in our model.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com