### PR TITLE
[onert/core] Add RmsNorm to ShapeValidator

### DIFF
--- a/runtime/onert/core/src/compiler/ShapeValidator.cc
+++ b/runtime/onert/core/src/compiler/ShapeValidator.cc
@@ -1132,7 +1132,7 @@ void ShapeValidator::visit(const ir::operation::RmsNorm &node)
 
   const auto ifm_index{node.getInputs().at(ir::operation::RmsNorm::Input::INPUT)};
   const auto gamma_index{node.getInputs().at(ir::operation::RmsNorm::Input::GAMMA)};
-  
+
   OP_REQUIRES(operands.at(ifm_index).shape().rank() == 4);
   OP_REQUIRES(operands.at(ifm_index).shape() == operands.at(ofm_index).shape());
   OP_REQUIRES(operands.at(gamma_index).shape().rank() == 1);

--- a/runtime/onert/core/src/compiler/ShapeValidator.cc
+++ b/runtime/onert/core/src/compiler/ShapeValidator.cc
@@ -1123,5 +1123,20 @@ void ShapeValidator::visit(const ir::operation::LogSoftmax &node)
   OP_REQUIRES(operands.at(output_index).shape().rank() == operands.at(input_index).shape().rank());
 }
 
+void ShapeValidator::visit(const ir::operation::RmsNorm &node)
+{
+  const auto &operands = _graph.operands();
+  const auto ofm_index{node.getOutputs().at(0)};
+  if (operands.at(ofm_index).info().isDynamic())
+    return;
+
+  const auto ifm_index{node.getInputs().at(ir::operation::RmsNorm::Input::INPUT)};
+  const auto gamma_index{node.getInputs().at(ir::operation::RmsNorm::Input::GAMMA)};
+  
+  OP_REQUIRES(operands.at(ifm_index).shape().rank() == 4);
+  OP_REQUIRES(operands.at(ifm_index).shape() == operands.at(ofm_index).shape());
+  OP_REQUIRES(operands.at(gamma_index).shape().rank() == 1);
+}
+
 } // namespace compiler
 } // namespace onert

--- a/runtime/onert/core/src/compiler/ShapeValidator.h
+++ b/runtime/onert/core/src/compiler/ShapeValidator.h
@@ -93,6 +93,7 @@ public:
   void visit(const ir::operation::Range &node) override;
   void visit(const ir::operation::MatrixBandPart &node) override;
   void visit(const ir::operation::LogSoftmax &node) override;
+  void visit(const ir::operation::RmsNorm &node) override;
 
 private:
   void checkUnaryOp(const ir::Operation &node);


### PR DESCRIPTION
This commit adds RmsNorm to ShapeValidator.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14089
draft: https://github.com/Samsung/ONE/pull/14088