### PR TITLE
[circle2circle-dredd-recipe-test] Add Inf_Neg_000 test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -148,4 +148,5 @@ Add(REGRESS_Issue_13863 PASS substitute_pack_to_reshape)
 
 # SHAPE INFERENCE test
 Add(Inf_Mul_000 PASS)
+Add(Inf_Neg_000 PASS)
 Add(Inf_Pad_000 PASS)


### PR DESCRIPTION
This commit adds Inf_Neg_000 to circle2circle-dredd-recipe-test.

- Related : https://github.com/Samsung/ONE/issues/13998
- Related : https://github.com/Samsung/ONE/pull/14158

ONE-DCO-1.0-Signed-off-by: HanJin Choi hanjin4647@gmail.com