### PR TITLE
[onert/backend] Add RmsNorm operation for cpu backend

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -69,6 +69,7 @@
 #include "ops/FusedBatchNormLayer.h"
 #include "ops/LogSoftMaxLayer.h"
 #include "ops/StatelessRandomUniformLayer.h"
+#include "ops/RmsNormLayer.h"
 
 #include <backend/Backend.h>
 #include <backend/IConfig.h>
@@ -1097,6 +1098,24 @@ void KernelGenerator::visit(const ir::operation::Rank &node)
   auto fn = std::make_unique<ops::RankLayer>();
 
   fn->configure(ifm_tensor, ofm_tensor);
+
+  _return_fn = std::move(fn);
+}
+
+void KernelGenerator::visit(const ir::operation::RmsNorm &node)
+{
+  const auto ofm_index{node.getOutputs().at(0)};
+  const auto ifm_index{node.getInputs().at(ir::operation::RmsNorm::Input::INPUT)};
+  const auto gamma_index{node.getInputs().at(ir::operation::RmsNorm::Input::GAMMA)};
+
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
+  auto gamma_tensor = _tensor_reg->getPortableTensor(gamma_index);
+  auto epsilon = node.param().epsilon;
+
+  auto fn = std::make_unique<ops::RmsNormLayer>();
+
+  fn->configure(ifm_tensor, gamma_tensor, epsilon, ofm_tensor);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -81,6 +81,7 @@ public:
   void visit(const ir::operation::Reshape &) override;
   void visit(const ir::operation::ResizeBilinear &node) override;
   void visit(const ir::operation::Reverse &) override;
+  void visit(const ir::operation::RmsNorm &) override;
   void visit(const ir::operation::Select &) override;
   void visit(const ir::operation::Shape &) override;
   void visit(const ir::operation::Slice &) override;

--- a/runtime/onert/backend/cpu/ops/RmsNormLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RmsNormLayer.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RmsNormLayer.h"
+
+#include "OperationUtils.h"
+
+#include <cker/operation/RmsNorm.h>
+#include <cker/Types.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+namespace ops
+{
+
+void RmsNormLayer::configure(const IPortableTensor *input, const IPortableTensor *gamma,
+                             float epsilon, IPortableTensor *output)
+{
+  assert(input != nullptr);
+  assert(output != nullptr);
+
+  _input = input;
+  _output = output;
+  _gamma = gamma;
+  _epsilon = epsilon;
+}
+
+void RmsNormLayer::run()
+{
+  switch (_input->data_type())
+  {
+    case OperandType::FLOAT32:
+      nnfw::cker::RmsNormParams param;
+      param.epsilon = _epsilon;
+      nnfw::cker::RmsNorm(param, getShape(_input), getBuffer<float>(_input), getShape(_gamma),
+                          getBuffer<float>(_gamma), getShape(_output), getBuffer<float>(_output));
+      break;
+
+    default:
+      throw std::runtime_error{"RmsNorm: Unsupported data type"};
+  }
+}
+
+} // namespace ops
+} // namespace cpu
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/cpu/ops/RmsNormLayer.h
+++ b/runtime/onert/backend/cpu/ops/RmsNormLayer.h
@@ -32,15 +32,14 @@ namespace ops
 class RmsNormLayer : public ::onert::exec::IFunction
 {
 public:
-  RmsNormLayer()
-    : _input(nullptr), _output(nullptr), _gamma(nullptr), _epsilon(1e-06f)
+  RmsNormLayer() : _input(nullptr), _output(nullptr), _gamma(nullptr), _epsilon(1e-06f)
   {
     // Nothing
   }
 
 public:
-  void configure(const IPortableTensor *input, const IPortableTensor *gamma,
-                 float epsilon, IPortableTensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *gamma, float epsilon,
+                 IPortableTensor *output);
 
   void run() override;
 

--- a/runtime/onert/backend/cpu/ops/RmsNormLayer.h
+++ b/runtime/onert/backend/cpu/ops/RmsNormLayer.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in riting, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CPU_OPS_RMSNORM_LAYER_H__
+#define __ONERT_BACKEND_CPU_OPS_RMSNORM_LAYER_H__
+
+#include <backend/IPortableTensor.h>
+#include "OperationUtils.h"
+#include <exec/IFunction.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+namespace ops
+{
+class RmsNormLayer : public ::onert::exec::IFunction
+{
+public:
+  RmsNormLayer()
+    : _input(nullptr), _output(nullptr), _gamma(nullptr), _epsilon(1e-06f)
+  {
+    // Nothing
+  }
+
+public:
+  void configure(const IPortableTensor *input, const IPortableTensor *gamma,
+                 float epsilon, IPortableTensor *output);
+
+  void run() override;
+
+private:
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
+  const IPortableTensor *_gamma;
+  float _epsilon;
+};
+
+} // namespace ops
+} // namespace cpu
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CPU_OPS_RMSNORM_LAYER_H__


### PR DESCRIPTION
This commit adds RmsNorm operation for cpu backend.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14089
draft: https://github.com/Samsung/ONE/pull/14088
