### PR TITLE
[circle2circle-dredd-recipe-test] Add Inf_FullyConnected test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -147,5 +147,7 @@ Add(REGRESS_ONNX_Mul_Mul_000 PASS
 Add(REGRESS_Issue_13863 PASS substitute_pack_to_reshape)
 
 # SHAPE INFERENCE test
+Add(Inf_FullyConnected_000 PASS)
+Add(Inf_FullyConnected_001 PASS)
 Add(Inf_Mul_000 PASS)
 Add(Inf_Pad_000 PASS)


### PR DESCRIPTION
This commit adds Inf_FullyConnected tests to
circle2circle-dredd-recipe-test.

- Related : https://github.com/Samsung/ONE/issues/13998
- Related : https://github.com/Samsung/ONE/pull/13875
- Related : https://github.com/Samsung/ONE/pull/14157

ONE-DCO-1.0-Signed-off-by: HanJin Choi hanjin4647@gmail.com