### PR TITLE
[tests/nnfw_api] Add RmsNorm test cases for nnfw API

### DIFF
--- a/tests/nnfw_api/lib/CircleGen.cc
+++ b/tests/nnfw_api/lib/CircleGen.cc
@@ -589,6 +589,13 @@ uint32_t CircleGen::addOperatorBatchToSpaceND(const OperatorParams &params)
                                 circle::BuiltinOptions_BatchToSpaceNDOptions, options);
 }
 
+uint32_t CircleGen::addOperatorRmsNorm(const OperatorParams &params, float epsilon)
+{
+  auto options = circle::CreateRmsNormOptions(_fbb, epsilon).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_RMS_NORM,
+                                circle::BuiltinOptions_RmsNormOptions, options);
+}
+
 // NOTE Please add addOperator functions ABOVE this lie
 //
 // %  How to add a new addOperatorXXX fuction

--- a/tests/nnfw_api/lib/CircleGen.h
+++ b/tests/nnfw_api/lib/CircleGen.h
@@ -201,6 +201,7 @@ public:
   uint32_t addOperatorRank(const OperatorParams &params);
   uint32_t addOperatorReduce(const OperatorParams &params, circle::BuiltinOperator reduce_op,
                              bool keep_dims);
+  uint32_t addOperatorRmsNorm(const OperatorParams &params, float epsilon);
   /**
    * @brief Create circle Reshape op
    *        the second param new_shape can be optional just like circle::CreateReshapeOptionsDirect

--- a/tests/nnfw_api/src/GenModelTests/one_op_tests/RmsNorm.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/one_op_tests/RmsNorm.test.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+TEST_F(GenModelTest, OneOp_RmsNorm)
+{
+  CircleGen cgen;
+  uint32_t gamma_buf = cgen.addBuffer(std::vector<float>{1});
+  int gamma = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, gamma_buf});
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorRmsNorm({{in, gamma}, {out}}, 0.00001f);
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{0, 1, 2, 3}}, {{0, 1, 1, 1}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_RmsNorm_InvalidShape)
+{
+  CircleGen cgen;
+  uint32_t gamma_buf = cgen.addBuffer(std::vector<float>{2});
+  int gamma = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, gamma_buf});
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 2, 2, 2}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorRmsNorm({{in, gamma}, {out}}, 0.00001f);
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->expectFailCompile();
+
+  SUCCEED();
+}


### PR DESCRIPTION
This commit adds RmsNorm test cases for nnfw API.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14089
draft: https://github.com/Samsung/ONE/pull/14088
