### PR TITLE
[luci-interpreter] Removed beta(bias) of RmsNorm

### DIFF
--- a/compiler/luci-interpreter/src/kernels/RmsNorm.h
+++ b/compiler/luci-interpreter/src/kernels/RmsNorm.h
@@ -28,12 +28,10 @@ namespace kernels
 class RmsNorm : public KernelWithParams<RmsNormParams>
 {
 public:
-  RmsNorm(const Tensor *input, const Tensor *gamma, const Tensor *beta, Tensor *output,
-          const RmsNormParams &params);
+  RmsNorm(const Tensor *input, const Tensor *gamma, Tensor *output, const RmsNormParams &params);
 
   const Tensor *input() const { return _inputs[0]; }
   const Tensor *gamma() const { return _inputs[1]; }
-  const Tensor *beta() const { return _inputs[2]; }
   Tensor *output() const { return _outputs[0]; }
 
   void configure() override;

--- a/compiler/luci-interpreter/src/kernels/RmsNorm.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/RmsNorm.test.cpp
@@ -39,13 +39,12 @@ TEST_F(RmsNormTest, Simple)
   Tensor input_tensor =
     makeInputTensor<DataType::FLOAT32>({1, 2, 2, 1}, {0, 1, 2, 3}, _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.00001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   kernel.configure();
   _memory_manager->allocate_memory(output_tensor);
   kernel.execute();
@@ -54,18 +53,17 @@ TEST_F(RmsNormTest, Simple)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 2, 1}));
 }
 
-TEST_F(RmsNormTest, Default_gamma_beta)
+TEST_F(RmsNormTest, Default_gamma)
 {
   Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
                                                            _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   kernel.configure();
   _memory_manager->allocate_memory(output_tensor);
   kernel.execute();
@@ -81,13 +79,12 @@ TEST_F(RmsNormTest, Have_gamma)
   Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
                                                            _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {2}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   kernel.configure();
   _memory_manager->allocate_memory(output_tensor);
   kernel.execute();
@@ -98,18 +95,17 @@ TEST_F(RmsNormTest, Have_gamma)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 2, 2}));
 }
 
-TEST_F(RmsNormTest, Wrong_gamma_beta_dim_NEG)
+TEST_F(RmsNormTest, Wrong_gamma_dim_NEG)
 {
   Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 2, 2}, {0, 1, 2, 3, 4, 5, 6, 7},
                                                            _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({3}, {1, 1, 1}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({3}, {0, 0, 0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
 }
 
@@ -118,13 +114,12 @@ TEST_F(RmsNormTest, Unsupported_dims_NEG)
   Tensor input_tensor =
     makeInputTensor<DataType::FLOAT32>({2, 2}, {0, 1, 2, 3}, _memory_manager.get());
   Tensor gamma_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1}, _memory_manager.get());
-  Tensor beta_tensor = makeInputTensor<DataType::FLOAT32>({1}, {0}, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   RmsNormParams params{};
   params.epsilon = 0.001f;
 
-  RmsNorm kernel(&input_tensor, &gamma_tensor, &beta_tensor, &output_tensor, params);
+  RmsNorm kernel(&input_tensor, &gamma_tensor, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
 }
 

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -1101,12 +1101,10 @@ TEST_F(KernelBuilderTest, RmsNorm)
 {
   auto *input = createInputNode();
   auto *gamma = createInputNode();
-  auto *beta = createInputNode();
 
   auto *op = createNode<luci::CircleRmsNorm>();
   op->input(input);
   op->gamma(gamma);
-  op->beta(beta);
   op->epsilon(1e-06);
 
   auto kernel = buildKernel<kernels::RmsNorm>(op);
@@ -1114,7 +1112,6 @@ TEST_F(KernelBuilderTest, RmsNorm)
 
   checkTensor(kernel->input(), input);
   checkTensor(kernel->gamma(), gamma);
-  checkTensor(kernel->beta(), beta);
   checkTensor(kernel->output(), op);
   EXPECT_THAT(kernel->params().epsilon, Eq(op->epsilon()));
 }

--- a/compiler/luci-interpreter/src/loader/nodes/RmsNorm.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/RmsNorm.cpp
@@ -25,18 +25,17 @@ std::unique_ptr<Kernel> build_kernel_CircleRmsNorm(const luci::CircleNode *circl
                                                    KernelBuilderHelper &helper)
 {
   const auto *node = loco::must_cast<const luci::CircleRmsNorm *>(circle_node);
-  assert(node->arity() == 3);
+  // assert(node->arity() == 2);
 
   const Tensor *input = helper.getInputTensor(node->input());
   const Tensor *gamma = helper.getInputTensor(node->gamma());
-  const Tensor *beta = helper.getInputTensor(node->beta());
 
   Tensor *output = helper.getOutputTensor(node);
 
   RmsNormParams params{};
   params.epsilon = node->epsilon();
 
-  return std::make_unique<kernels::RmsNorm>(input, gamma, beta, output, params);
+  return std::make_unique<kernels::RmsNorm>(input, gamma, output, params);
 }
 
 } // namespace luci_interpreter


### PR DESCRIPTION
This commit removes beta(bias) of RmsNorm in kernel and loader.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169