### PR TITLE
[onert] Revisit CPU ExternalContext

### DIFF
--- a/runtime/onert/backend/cpu/ExternalContext.cc
+++ b/runtime/onert/backend/cpu/ExternalContext.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ExternalContext.h"
+
+#include <fstream>
+#include <string>
+#include <thread>
+#include <unordered_set>
+
+namespace
+{
+
+int32_t countPhysicalCores()
+{
+#ifdef __linux__
+  // Count physical cores, not threads by checking thread_siblings.
+  std::unordered_set<std::string> siblings;
+  for (uint32_t cpu = 0; cpu < UINT32_MAX; ++cpu)
+  {
+    std::ifstream thread_siblings("/sys/devices/system/cpu/cpu" + std::to_string(cpu) +
+                                  "/topology/thread_siblings");
+    if (!thread_siblings.is_open())
+    {
+      break;
+    }
+
+    std::string line;
+    if (std::getline(thread_siblings, line))
+    {
+      siblings.insert(line);
+    }
+  }
+  if (!siblings.empty())
+  {
+    return static_cast<int32_t>(siblings.size());
+  }
+#endif
+
+  unsigned int n_threads = std::thread::hardware_concurrency();
+  return n_threads > 0 ? (n_threads <= 4 ? n_threads : n_threads / 2) : 1;
+}
+
+} // namespace
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+
+ExternalContext::ExternalContext() : _ruy_context(new ruy::Context)
+{
+  setMaxNumThreads(onert::util::getConfigInt(onert::util::config::NUM_THREADS));
+}
+
+void ExternalContext::setMaxNumThreads(int max_num_threads)
+{
+  _max_num_threads = max_num_threads > -1 ? max_num_threads : countPhysicalCores();
+  _ruy_context->set_max_num_threads(_max_num_threads);
+}
+
+void ExternalContext::initGgmlContext()
+{
+  if (_ggml_context == nullptr)
+    _ggml_context = std::unique_ptr<ggml_context, decltype(&ggml_free)>(
+      ggml_init({.mem_size = 0, .mem_buffer = nullptr, .no_alloc = true}), &ggml_free);
+}
+
+} // namespace cpu
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/cpu/ExternalContext.h
+++ b/runtime/onert/backend/cpu/ExternalContext.h
@@ -32,32 +32,20 @@ namespace cpu
 
 class ExternalContext
 {
-private:
-  static const int kDefaultNumThreadpoolThreads = 1;
+public:
+  ExternalContext();
 
 public:
-  ExternalContext() : _ruy_context(new ruy::Context)
-  {
-    setMaxNumThreads(onert::util::getConfigInt(onert::util::config::NUM_THREADS));
-  }
+  void setMaxNumThreads(int max_num_threads);
 
-  void setMaxNumThreads(int max_num_threads)
-  {
-    const int target_num_threads =
-      max_num_threads > -1 ? max_num_threads : kDefaultNumThreadpoolThreads;
-    _ruy_context->set_max_num_threads(target_num_threads);
-  }
+  int32_t maxNumThreads() const { return _max_num_threads; }
 
-  void initGgmlContext()
-  {
-    if (_ggml_context == nullptr)
-      _ggml_context = std::unique_ptr<ggml_context, decltype(&ggml_free)>(
-        ggml_init({.mem_size = 0, .mem_buffer = nullptr, .no_alloc = true}), &ggml_free);
-  }
+  void initGgmlContext();
 
   ruy::Context *ruy_context() const { return _ruy_context.get(); }
 
 private:
+  int32_t _max_num_threads;
   const std::unique_ptr<ruy::Context> _ruy_context;
   std::unique_ptr<ggml_context, decltype(&ggml_free)> _ggml_context{nullptr, &ggml_free};
 };

--- a/runtime/onert/backend/cpu/ops/GatherLayer.cc
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.cc
@@ -113,7 +113,7 @@ void GatherLayer::runByGGMLQuantInputType()
   }
 
   // get cplan
-  auto cplan = ggml_graph_plan(&graph, _ctx->ruy_context()->max_num_threads());
+  auto cplan = ggml_graph_plan(&graph, _ctx->maxNumThreads());
   cplan.work_data = (uint8_t *)(malloc(cplan.work_size));
 
   // compute


### PR DESCRIPTION
- Introduce thread count getter
- Count physical core on default setting and use it as thread count

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>