### PR TITLE
[luci/pass] Removed beta(bias) from RmsNorm

### DIFF
--- a/compiler/luci/pass/src/QuantizePreCheckerPass.cpp
+++ b/compiler/luci/pass/src/QuantizePreCheckerPass.cpp
@@ -78,13 +78,13 @@ struct ConstInputChecker final : public luci::CircleNodeMutableVisitor<void>
 
   // Ops that receive one const nodes as inputs
   CHECK_NODE_WITH_ONE_INPUT_CONST(luci::CirclePRelu, alpha)
+  CHECK_NODE_WITH_ONE_INPUT_CONST(luci::CircleRmsNorm, gamma)
 
   // Ops that receive two const node as an inputs
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleConv2D, filter, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleDepthwiseConv2D, filter, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleFullyConnected, weights, bias)
   CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleInstanceNorm, gamma, beta)
-  CHECK_NODE_WITH_TWO_INPUT_CONST(luci::CircleRmsNorm, gamma, beta)
 
   // Ops that receive three const nodes as an inputs
   CHECK_NODE_WITH_THREE_INPUT_CONST(luci::CircleTransposeConv, inputSizes, filter, bias)

--- a/compiler/luci/pass/src/QuantizePreCheckerPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizePreCheckerPass.test.cpp
@@ -199,20 +199,18 @@ public:
   {
     rms_norm_node = g.nodes()->create<luci::CircleRmsNorm>();
     input_1 = g.nodes()->create<luci::CircleInput>();
-    gamma = g.nodes()->create<luci::CircleConst>();
 
     rms_norm_node->input(input_1);
-    rms_norm_node->gamma(gamma);
 
     if (make_valid)
     {
-      beta = g.nodes()->create<luci::CircleConst>();
-      rms_norm_node->beta(beta);
+      gamma = g.nodes()->create<luci::CircleConst>();
+      rms_norm_node->gamma(gamma);
     }
     else
     {
       input_2 = g.nodes()->create<luci::CircleInput>();
-      rms_norm_node->beta(input_2);
+      rms_norm_node->gamma(input_2);
     }
 
     output = g.nodes()->create<luci::CircleOutput>();
@@ -231,7 +229,6 @@ private:
   luci::CircleInput *input_1 = nullptr;
   luci::CircleInput *input_2 = nullptr;
   luci::CircleConst *gamma = nullptr;
-  luci::CircleConst *beta = nullptr;
   luci::CircleOutput *output = nullptr;
 };
 

--- a/compiler/luci/pass/src/QuantizeWeights.cpp
+++ b/compiler/luci/pass/src/QuantizeWeights.cpp
@@ -513,7 +513,6 @@ void QuantizeWeights::visit(luci::CircleRmsNorm *node)
   INFO(l) << "QuantizeWeights QuantizeWeights::visit node: " << node->name() << std::endl;
 
   auto gamma = loco::must_cast<luci::CircleConst *>(node->gamma());
-  auto beta = loco::must_cast<luci::CircleConst *>(node->beta());
 
   if (!is_quantized(gamma))
   {
@@ -524,16 +523,6 @@ void QuantizeWeights::visit(luci::CircleRmsNorm *node)
     else if (granularity == QuantizationGranularity::ChannelWise)
       quant_const_per_channel(new_gamma, output_type);
     node->gamma(new_gamma);
-  }
-  if (!is_quantized(beta))
-  {
-    assert(beta->dtype() == loco::DataType::FLOAT32);
-    auto new_beta = luci::clone(beta);
-    if (granularity == QuantizationGranularity::LayerWise)
-      quant_const(new_beta, output_type);
-    else if (granularity == QuantizationGranularity::ChannelWise)
-      quant_const_per_channel(new_beta, output_type);
-    node->beta(new_beta);
   }
 }
 

--- a/compiler/luci/pass/src/VerifyQuantizedNodeGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeGranularity.h
@@ -518,7 +518,6 @@ private:
     RETURN_FALSE_UNLESS(is_lwq(node))
     RETURN_FALSE_UNLESS(is_lwq(node->input()))
     RETURN_FALSE_UNLESS(is_cwq_const(node->gamma(), rank(node->gamma()) - 1))
-    RETURN_FALSE_UNLESS(is_cwq_const(node->beta(), rank(node->beta()) - 1))
     return true;
   }
 
@@ -611,7 +610,6 @@ private:
     RETURN_FALSE_UNLESS(is_lwq(node))
     RETURN_FALSE_UNLESS(is_lwq(node->input()))
     RETURN_FALSE_UNLESS(is_lwq_const(node->gamma()))
-    RETURN_FALSE_UNLESS(is_lwq_const(node->beta()))
     return true;
   }
 


### PR DESCRIPTION
This commit removes beta(bias) from RmsNorm in luci pass.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169