### PR TITLE
[common-artifacts] Disable RmsNorm test temporarily

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -2,6 +2,7 @@
 ## TensorFlowLiteRecipes
 
 ## CircleRecipes
+optimize(RmsNorm_000)
 
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
@@ -182,4 +183,5 @@ tcgenerate(CircleFullyConnected_U4_002)
 tcgenerate(GRU_000) # luci-interpreter does not support custom GRU
 tcgenerate(InstanceNorm_000)
 tcgenerate(InstanceNorm_001)
+tcgenerate(RmsNorm_000)
 tcgenerate(RoPE_000)


### PR DESCRIPTION
This commit disables RmsNorm test temporarily.
It will be reverted after all related codes are applied.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169