### PR TITLE
[circlechef, res] Removed beta(bias) from RmsNorm

### DIFF
--- a/compiler/circlechef/circle/src/Op/RmsNorm.cpp
+++ b/compiler/circlechef/circle/src/Op/RmsNorm.cpp
@@ -24,12 +24,11 @@ namespace circlechef
 void CircleOpRmsNorm::filler(const circle::Operator *op, CircleImport *import,
                              circlechef::ModelRecipe *model_recipe) const
 {
-  // index 1 and 2 maybe constant
+  // index 1 maybe constant
   const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
-  assert(inputs.size() == 3);
+  assert(inputs.size() == 2);
 
   import->set_tensor_filler(inputs[1]); // set gaussian filler
-  import->set_tensor_filler(inputs[2]);
 }
 
 circlechef::Operation *CircleOpRmsNorm::build(const circle::Operator *op, CircleImport *import,

--- a/res/CircleRecipes/RmsNorm_000/test.recipe
+++ b/res/CircleRecipes/RmsNorm_000/test.recipe
@@ -16,18 +16,6 @@ operand {
   }
 }
 operand {
-  name: "beta"
-  type: FLOAT32
-  shape { dim: 4 }
-  filler {
-    tag: "explicit"
-    arg: "0.0"
-    arg: "0.0"
-    arg: "0.0"
-    arg: "0.0"
-  }
-}
-operand {
   name: "ofm"
   type: FLOAT32
   shape { dim: 1 dim: 3 dim: 3 dim: 4 }
@@ -36,7 +24,6 @@ operation {
   type: "RmsNorm"
   input: "ifm"
   input: "gamma"
-  input: "beta"
   output: "ofm"
   rms_norm_options {
     epsilon: 0.0001


### PR DESCRIPTION
This commit removes beta(bias) from RmsNorm in circlechef and recipe.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169