### PR TITLE
[circlechef] Removed beta(bias) from RmsNorm

### DIFF
--- a/compiler/circlechef/circle/src/Op/RmsNorm.cpp
+++ b/compiler/circlechef/circle/src/Op/RmsNorm.cpp
@@ -24,12 +24,11 @@ namespace circlechef
 void CircleOpRmsNorm::filler(const circle::Operator *op, CircleImport *import,
                              circlechef::ModelRecipe *model_recipe) const
 {
-  // index 1 and 2 maybe constant
+  // index 1 maybe constant
   const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
-  assert(inputs.size() == 3);
+  // assert(inputs.size() == 2);
 
   import->set_tensor_filler(inputs[1]); // set gaussian filler
-  import->set_tensor_filler(inputs[2]);
 }
 
 circlechef::Operation *CircleOpRmsNorm::build(const circle::Operator *op, CircleImport *import,

--- a/compiler/circlechef/circle/src/Op/RmsNorm.cpp
+++ b/compiler/circlechef/circle/src/Op/RmsNorm.cpp
@@ -26,6 +26,7 @@ void CircleOpRmsNorm::filler(const circle::Operator *op, CircleImport *import,
 {
   // index 1 maybe constant
   const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
+  // TODO: Enable assert after recipe updated.
   // assert(inputs.size() == 2);
 
   import->set_tensor_filler(inputs[1]); // set gaussian filler


### PR DESCRIPTION
This commit removes beta(bias) from RmsNorm

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169