### PR TITLE
[onert/backend] Add LayerScopeTensor Planning

### DIFF
--- a/runtime/onert/backend/train/BackendContext.cc
+++ b/runtime/onert/backend/train/BackendContext.cc
@@ -179,6 +179,11 @@ FunctionMap BackendContext::gen()
   //   fn_seq->iterate([&](exec::IFunction &ifunc) { ifunc.prepare(); });
   // }
 
+  // NOTE: Since LayerScopeTensors is defined in each kernel(layer),
+  //       It should be planned and allocated after the kernels generated.
+  planLayerScopeTensors(fn_map);
+  _tensor_builder->allocateLayerScope();
+
   return fn_map;
 }
 
@@ -253,6 +258,16 @@ FunctionMap BackendContext::generateFunctionMap()
   AddBackPropInitializers(tgraph, *tensor_reg, ret);
 
   return ret;
+}
+
+void BackendContext::planLayerScopeTensors([[maybe_unused]] const FunctionMap &fn_map)
+{
+  // TODO: Register LayerScopeTensors
+
+  const auto ctx_data = data();
+  TensorPlanner tensor_planner{*ctx_data->tgraph.get(), ctx_data->external_operands};
+  tensor_planner.planLayerScopeTensors(_tensor_builder.get());
+  return;
 }
 
 } // namespace train

--- a/runtime/onert/backend/train/BackendContext.h
+++ b/runtime/onert/backend/train/BackendContext.h
@@ -73,6 +73,7 @@ public:
 private:
   void planForwardTensors();
   void planBackwardTensors();
+  void planLayerScopeTensors(const FunctionMap &fn_map);
 
 public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }

--- a/runtime/onert/backend/train/TensorPlanner.h
+++ b/runtime/onert/backend/train/TensorPlanner.h
@@ -45,6 +45,7 @@ public:
   void planBackPropTensors(TensorBuilder *tensor_builder);
   void planGradientTensors(TensorBuilder *tensor_builder);
   void planDisposableBackPropTensors(TensorBuilder *tensor_builder);
+  void planLayerScopeTensors(TensorBuilder *tensor_builder);
 
 private:
   ir::OperandIndexSequence getOutgoingBackPropSeq(const ir::OperationIndex &op_index,


### PR DESCRIPTION
This PR adds TensorPlanner::planLayerScopeTensors() and its caller part in BackendContext.

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>

--------------------------------------

draft : https://github.com/Samsung/ONE/pull/13486