### PR TITLE
[res/CircleRecipes] Removed beta(bias) from RmsNorm

### DIFF
--- a/res/CircleRecipes/RmsNorm_000/test.recipe
+++ b/res/CircleRecipes/RmsNorm_000/test.recipe
@@ -16,18 +16,6 @@ operand {
   }
 }
 operand {
-  name: "beta"
-  type: FLOAT32
-  shape { dim: 4 }
-  filler {
-    tag: "explicit"
-    arg: "0.0"
-    arg: "0.0"
-    arg: "0.0"
-    arg: "0.0"
-  }
-}
-operand {
   name: "ofm"
   type: FLOAT32
   shape { dim: 1 dim: 3 dim: 3 dim: 4 }
@@ -36,7 +24,6 @@ operation {
   type: "RmsNorm"
   input: "ifm"
   input: "gamma"
-  input: "beta"
   output: "ofm"
   rms_norm_options {
     epsilon: 0.0001


### PR DESCRIPTION
This commit removes beta from RmsNorm in circle recipe

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169