### PR TITLE
[circlechef] Enable assertion of RmsNorm

### DIFF
--- a/compiler/circlechef/circle/src/Op/RmsNorm.cpp
+++ b/compiler/circlechef/circle/src/Op/RmsNorm.cpp
@@ -26,8 +26,7 @@ void CircleOpRmsNorm::filler(const circle::Operator *op, CircleImport *import,
 {
   // index 1 maybe constant
   const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
-  // TODO: Enable assert after recipe updated.
-  // assert(inputs.size() == 2);
+  assert(inputs.size() == 2);
 
   import->set_tensor_filler(inputs[1]); // set gaussian filler
 }


### PR DESCRIPTION
This commit enables assertion of RmsNorm, which is temporarily commented.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169