### PR TITLE
[dalgona] Support ubuntu 24.04

### DIFF
--- a/compiler/dalgona/CMakeLists.txt
+++ b/compiler/dalgona/CMakeLists.txt
@@ -2,18 +2,44 @@
 #   Ubuntu18.04; explictly installed python3.8 (default is python3.6)
 #   Ubuntu20.04; default python3.8
 #   Ubuntu22.04; default python3.10
+#   Ubuntu24.04; explictly installed python3.8 (default is python3.12)
 #   refer https://github.com/Samsung/ONE/issues/9962
-find_package(PythonInterp 3.8 QUIET)
-find_package(PythonLibs 3.8 QUIET)
+if(CMAKE_VERSION VERSION_LESS 3.12)
+  find_package(PythonInterp 3.8 QUIET)
+  find_package(PythonLibs 3.8 QUIET)
 
-if(NOT ${PYTHONINTERP_FOUND})
-  message(STATUS "Build dalgona: FAILED (Python3 is missing)")
-  return()
-endif()
+  if(NOT ${PYTHONINTERP_FOUND})
+    message(STATUS "Build dalgona: FAILED (Python3 is missing)")
+    return()
+  endif()
 
-if(${PYTHON_VERSION_MINOR} LESS 8)
-  message(STATUS "Build dalgona: FAILED (Install Python version higher than or equal to 3.8)")
-  return()
+  if(${PYTHON_VERSION_MINOR} LESS 8)
+    message(STATUS "Build dalgona: FAILED (Install Python version higher than or equal to 3.8)")
+    return()
+  endif()
+else()
+  find_package(Python 3.8 EXACT COMPONENTS Development QUIET)
+  if(NOT Python_FOUND)
+    find_package(Python 3.8 COMPONENTS Development QUIET)
+  endif()
+
+  # Require same python version of common-artifacts
+  if(Python_VERSION VERSION_GREATER_EQUAL 3.12)
+    message(STATUS "Build dalgona: FALSE (Python version 3.12 or higher is not supported yet)")
+    return()
+  endif()
+  if(Python_VERSION VERSION_LESS 3.8)
+    message(STATUS "Build dalgona: FAILED (Install Python version 3.8 or 3.10)")
+    return()
+  endif()
+
+  if(NOT Python_Development_FOUND)
+    message(STATUS "Build dalgona: FAILED (Python3 development package is missing)")
+    return()
+  endif()
+
+  set(PYTHON_INCLUDE_DIRS ${Python_INCLUDE_DIRS})
+  set(PYTHON_LIBRARIES ${Python_LIBRARIES})
 endif()
 
 nnas_find_package(Pybind11)


### PR DESCRIPTION
This commit updates cmake to support ubuntu 24.04. 
It requires to install python 3.8 explicitly because the default python version is 3.12.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>