### PR TITLE
[one-cmds] Add substitute_expand_dims_to_reshape to one command

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -218,6 +218,7 @@ Current transformation options are
   to net of builtin operators.
 - shuffle_weight_to_16x1float32 : This will convert weight format of FullyConnected to SHUFFLED16x1FLOAT32.
   Note that it only converts weights whose row is a multiple of 16.
+- substitute_expand_dims_to_reshape : This will convert ExpandDims with constant axis to Reshape.
 - substitute_pack_to_reshape : This will convert single input Pack to Reshape.
 - substitute_padv2_to_pad : This will convert certain condition PadV2 to Pad.
 - substitute_splitv_to_split : This will convert certain condition SplitV to Split.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -78,6 +78,7 @@ class CONSTANT:
         'resolve_customop_matmul',
         'resolve_customop_max_pool_with_argmax',
         'resolve_customop_splitv',
+        'substitute_expand_dims_to_reshape',
         'substitute_pack_to_reshape',
         'substitute_padv2_to_pad',
         'substitute_splitv_to_split',
@@ -179,6 +180,8 @@ class CONSTANT:
         ('shuffle_weight_to_16x1float32',
          'convert weight format of FullyConnected op to SHUFFLED16x1FLOAT32.'
          ' Note that it only converts weights whose row is a multiple of 16'),
+        ('substitute_expand_dims_to_reshape',
+         'convert ExpandDims with constant axis to Reshape op'),
         ('substitute_pack_to_reshape', 'convert single input Pack op to Reshape op'),
         ('substitute_padv2_to_pad', 'convert certain condition PadV2 to Pad'),
         ('substitute_splitv_to_split', 'convert certain condition SplitV to Split'),


### PR DESCRIPTION
Let's add substitute_expand_dims_to_reshape to one command.

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

DRAFT: https://github.com/Samsung/ONE/pull/14164