### PR TITLE
[luci-interpreter] Enable assertion of RmsNorm in loader

### DIFF
--- a/compiler/luci-interpreter/src/loader/nodes/RmsNorm.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/RmsNorm.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<Kernel> build_kernel_CircleRmsNorm(const luci::CircleNode *circl
                                                    KernelBuilderHelper &helper)
 {
   const auto *node = loco::must_cast<const luci::CircleRmsNorm *>(circle_node);
-  // assert(node->arity() == 2);
+  assert(node->arity() == 2);
 
   const Tensor *input = helper.getInputTensor(node->input());
   const Tensor *gamma = helper.getInputTensor(node->gamma());


### PR DESCRIPTION
This commit enables assertion which is temporarily disabled.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169