### PR TITLE
[common-artifacts] Enable RmsNorm test

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -2,7 +2,6 @@
 ## TensorFlowLiteRecipes
 
 ## CircleRecipes
-optimize(RmsNorm_000)
 
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
@@ -183,5 +182,4 @@ tcgenerate(CircleFullyConnected_U4_002)
 tcgenerate(GRU_000) # luci-interpreter does not support custom GRU
 tcgenerate(InstanceNorm_000)
 tcgenerate(InstanceNorm_001)
-tcgenerate(RmsNorm_000)
 tcgenerate(RoPE_000)


### PR DESCRIPTION
This commit enables RmsNorm test which was temporarily disabled.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14132
draft: https://github.com/Samsung/ONE/pull/14169