### PR TITLE
[compute/cker] Fix RmsNorm cker

### DIFF
--- a/compute/cker/include/cker/operation/RmsNorm.h
+++ b/compute/cker/include/cker/operation/RmsNorm.h
@@ -48,6 +48,7 @@ inline void RmsNorm(const RmsNormParams &params, const Shape &input_shape, const
       {
         for (int32_t width = 0; width < widths; width++)
         {
+          // normalize over last-axis
           double square_sum = 0.0f;
           for (int32_t channel = 0; channel < channels; channel++)
           {
@@ -75,6 +76,7 @@ inline void RmsNorm(const RmsNormParams &params, const Shape &input_shape, const
     {
       for (int32_t width = 0; width < widths; width++)
       {
+        // normalize over last-axis
         double square_sum = 0.0f;
         for (int32_t channel = 0; channel < channels; channel++)
         {

--- a/compute/cker/src/RmsNorm.test.cc
+++ b/compute/cker/src/RmsNorm.test.cc
@@ -67,22 +67,21 @@ TEST(CKer_Operation, RmsNorm)
   }
 }
 
-TEST(CKer_Operation, neg_RmsNormWrongGammaDims)
+TEST(CKer_Operation, neg_RmsNormWrongInputDims)
 {
   {
-    std::vector<float> input = {0, 1, 2, 3, 4, 5, 6, 7};
-    nnfw::cker::Shape input_shape{1, 2, 2, 2};
+    std::vector<float> input = {0, 1, 2, 3};
+    nnfw::cker::Shape input_shape{2, 2};
 
-    std::vector<float> expected_output = {0,        1.412802, 0.784404, 1.176606,
-                                          0.883431, 1.104288, 0.920347, 1.073738};
+    std::vector<float> expected_output = {0, 1, 1, 1};
     std::vector<float> output(expected_output.size());
-    nnfw::cker::Shape output_shape{1, 2, 2, 2};
+    nnfw::cker::Shape output_shape{2, 2};
 
     std::vector<float> gamma = {1};
     nnfw::cker::Shape gamma_shape{1};
 
     nnfw::cker::RmsNormParams param;
-    param.epsilon = 0.001f;
+    param.epsilon = 0.00001f;
 
     EXPECT_ANY_THROW(nnfw::cker::RmsNorm(param, input_shape, input.data(), gamma_shape,
                                          gamma.data(), output_shape, output.data()));


### PR DESCRIPTION
This commit fixes RmsNorm cker to accept 3 dimension input and single gamma.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/14089
draft: https://github.com/Samsung/ONE/pull/14088