### PR TITLE
[onert/nnfw_api] Add unit tests for RoPE op

### DIFF
--- a/tests/nnfw_api/lib/CircleGen.cc
+++ b/tests/nnfw_api/lib/CircleGen.cc
@@ -596,9 +596,9 @@ uint32_t CircleGen::addOperatorRmsNorm(const OperatorParams &params, float epsil
                                 circle::BuiltinOptions_RmsNormOptions, options);
 }
 
-uint32_t CircleGen::addOperatorRoPE(const OperatorParams &params)
+uint32_t CircleGen::addOperatorRoPE(const OperatorParams &params, circle::RoPEMode mode)
 {
-  auto options = circle::CreateRoPEOptions(_fbb).Union();
+  auto options = circle::CreateRoPEOptions(_fbb, mode).Union();
   return addOperatorWithOptions(params, circle::BuiltinOperator_ROPE,
                                 circle::BuiltinOptions_RoPEOptions, options);
 }

--- a/tests/nnfw_api/lib/CircleGen.cc
+++ b/tests/nnfw_api/lib/CircleGen.cc
@@ -596,6 +596,13 @@ uint32_t CircleGen::addOperatorRmsNorm(const OperatorParams &params, float epsil
                                 circle::BuiltinOptions_RmsNormOptions, options);
 }
 
+uint32_t CircleGen::addOperatorRoPE(const OperatorParams &params)
+{
+  auto options = circle::CreateRoPEOptions(_fbb).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_ROPE,
+                                circle::BuiltinOptions_RoPEOptions, options);
+}
+
 // NOTE Please add addOperator functions ABOVE this lie
 //
 // %  How to add a new addOperatorXXX fuction

--- a/tests/nnfw_api/lib/CircleGen.h
+++ b/tests/nnfw_api/lib/CircleGen.h
@@ -202,7 +202,7 @@ public:
   uint32_t addOperatorReduce(const OperatorParams &params, circle::BuiltinOperator reduce_op,
                              bool keep_dims);
   uint32_t addOperatorRmsNorm(const OperatorParams &params, float epsilon);
-  uint32_t addOperatorRoPE(const OperatorParams &params);
+  uint32_t addOperatorRoPE(const OperatorParams &params, circle::RoPEMode mode);
   /**
    * @brief Create circle Reshape op
    *        the second param new_shape can be optional just like circle::CreateReshapeOptionsDirect

--- a/tests/nnfw_api/lib/CircleGen.h
+++ b/tests/nnfw_api/lib/CircleGen.h
@@ -202,6 +202,7 @@ public:
   uint32_t addOperatorReduce(const OperatorParams &params, circle::BuiltinOperator reduce_op,
                              bool keep_dims);
   uint32_t addOperatorRmsNorm(const OperatorParams &params, float epsilon);
+  uint32_t addOperatorRoPE(const OperatorParams &params);
   /**
    * @brief Create circle Reshape op
    *        the second param new_shape can be optional just like circle::CreateReshapeOptionsDirect

--- a/tests/nnfw_api/src/GenModelTests/one_op_tests/RoPE.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/one_op_tests/RoPE.test.cc
@@ -28,7 +28,7 @@ TEST_F(GenModelTest, OneOp_RoPE)
   int in = cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32});
   int out = cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32});
 
-  cgen.addOperatorRoPE({{in, sin_table, cos_table}, {out}});
+  cgen.addOperatorRoPE({{in, sin_table, cos_table}, {out}}, circle::RoPEMode_GPT_NEOX);
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
@@ -50,7 +50,7 @@ TEST_F(GenModelTest, neg_OneOp_RoPE_InvalidShape)
   int in = cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32});
   int out = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
 
-  cgen.addOperatorRoPE({{in, sin_table, cos_table}, {out}});
+  cgen.addOperatorRoPE({{in, sin_table, cos_table}, {out}}, circle::RoPEMode_GPT_NEOX);
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());

--- a/tests/nnfw_api/src/GenModelTests/one_op_tests/RoPE.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/one_op_tests/RoPE.test.cc
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+TEST_F(GenModelTest, OneOp_RoPE)
+{
+  CircleGen cgen;
+  uint32_t sin_table_buf = cgen.addBuffer(std::vector<float>{0.5, 1.0, 1.0, 0.5});
+  int sin_table =
+    cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32, sin_table_buf});
+  uint32_t cos_table_buf = cgen.addBuffer(std::vector<float>{1.0, 0.5, 0.5, 1.0});
+  int cos_table =
+    cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32, cos_table_buf});
+  int in = cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorRoPE({{in, sin_table, cos_table}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{0, 1.0, 2.0, 3.0}}, {{-1.0, -2.5, 1.0, 3.5}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_RoPE_InvalidShape)
+{
+  CircleGen cgen;
+  uint32_t sin_table_buf = cgen.addBuffer(std::vector<float>{0.5, 1.0, 1.0, 0.5});
+  int sin_table =
+    cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32, sin_table_buf});
+  uint32_t cos_table_buf = cgen.addBuffer(std::vector<float>{1.0, 0.5, 0.5, 1.0});
+  int cos_table =
+    cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32, cos_table_buf});
+  int in = cgen.addTensor({{1, 1, 1, 4}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorRoPE({{in, sin_table, cos_table}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->expectFailCompile();
+
+  SUCCEED();
+}


### PR DESCRIPTION
This commit adds unit tests for RoPE

ONE-DCO-1.0-Signed-off-by: youngsik kim <ys44.kim@samsung.com>

issue : https://github.com/Samsung/ONE/issues/14108
draft : https://github.com/Samsung/ONE/pull/14090