### PR TITLE
[recipe] Add recipe for ExpandDims

### DIFF
--- a/res/TensorFlowLiteRecipes/ExpandDims_005/test.recipe
+++ b/res/TensorFlowLiteRecipes/ExpandDims_005/test.recipe
@@ -1,0 +1,30 @@
+operand {
+  name: "ifm1"
+  type: FLOAT32
+  shape { dim: 3 dim: 3 }
+}
+
+operand {
+  name: "ifm2"
+  type: INT32
+  shape { dim: 1 }
+  filler {
+    tag: "constant"
+    arg: "1"
+  }
+}
+
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 3 }
+}
+
+operation {
+  type: "ExpandDims"
+  input: "ifm1"
+  input: "ifm2"
+  output: "ofm"
+}
+input: "ifm1"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/ExpandDims_005/test.rule
+++ b/res/TensorFlowLiteRecipes/ExpandDims_005/test.rule
@@ -1,0 +1,6 @@
+# To check if ExpandDims is transformed to Reshape.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "RESHAPE_COUNT"           $(op_count RESHAPE) '=' 1
+RULE    "NO_EXPAND_DIMS"           $(op_count EXPAND_DIMS) '=' 0

--- a/res/TensorFlowLiteRecipes/ExpandDims_005/test.rule
+++ b/res/TensorFlowLiteRecipes/ExpandDims_005/test.rule
@@ -3,4 +3,4 @@
 RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
 
 RULE    "RESHAPE_COUNT"           $(op_count RESHAPE) '=' 1
-RULE    "NO_EXPAND_DIMS"           $(op_count EXPAND_DIMS) '=' 0
+RULE    "NO_EXPAND_DIMS"          $(op_count EXPAND_DIMS) '=' 0


### PR DESCRIPTION
This commit adds recipe for ExpandDims which has constant operand with shape.

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

WHY - does it need a new recipe, not existing ones?

This new recipe is to make a new dredd test for expand_dims operator. Currently, the existing expand_dims recipes have no 'shape' for axis - which is not allowed for current substitute_expand_dims_to_reshape pass I want to test.

To see the full draft, with dredd test passed: https://github.com/Samsung/ONE/pull/14164 