### PR TITLE
[recipe] Fix typo in MaxPoolWithArgmax rule

### DIFF
--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_000/test.rule
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_000/test.rule
@@ -3,7 +3,7 @@
 RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
 
 RULE    "ARG_MAX_COUNT"           $(op_count ARG_MAX) '=' 1
-RULE    "ARG_MAX_COUNT"           $(op_count MAX_POOL_2D) '=' 1
+RULE    "MAX_POOL_2D_COUNT"       $(op_count MAX_POOL_2D) '=' 1
 RULE    "CONV_COUNT"              $(op_count CONV_2D) '=' 1
 RULE    "SPLIT_COUNT"             $(op_count SPLIT) '=' 1
 RULE    "RESHAPE_COUNT"           $(op_count RESHAPE) '=' 1


### PR DESCRIPTION
THis commit fixes wrong name of the rule

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>