### PR TITLE
[onert] fix tizen gbs build on odc_build=0

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -196,7 +196,6 @@ tar -xf %{SOURCE3016} -C ./externals
 	-DBUILD_WHITELIST="luci;foder;pepper-csv2vec;loco;locop;logo;logo-core;mio-circle08;luci-compute;oops;hermes;hermes-std;angkor;pp;pepper-strcast;pepper-str"
 %{nncc_env} ./nncc build %{build_jobs}
 cmake --install %{nncc_workspace} %{strip_options}
-%endif # odc_build
 
 # install angkor TensorIndex and oops InternalExn header (TODO: Remove this)
 mkdir -p %{overlay_path}/include/nncc/core/ADT/tensor
@@ -208,6 +207,7 @@ cp compiler/oops/include/oops/InternalExn.h %{overlay_path}/include/oops
 cp compiler/luci/lang/include/luci/IR/CircleNodes.lst %{overlay_path}/include/luci/IR
 cp %{nncc_workspace}/compiler/mio-circle08/gen/mio/circle/schema_generated.h %{overlay_path}/include/mio/circle
 cp -r %{nncc_workspace}/overlay/include/flatbuffers %{overlay_path}/include
+%endif # odc_build
 
 # runtime build
 %{build_env} ./nnfw configure %{build_options}


### PR DESCRIPTION
It fixes build error on odc_build=0.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

...........................

I would like to turn off `odc_build` because it builds `nncc`, which takes a long time.

However, building with `odc_build 0` causes the following error:

> cp: cannot stat `build/nncc/compiler/mio-circle08/gen/mio/circle/schema_generated.h': No such file or directory
> ...