### PR TITLE
[compute/cker] Optimize BMM for X86

### DIFF
--- a/compute/cker/include/cker/operation/reference/BatchMatMul.h
+++ b/compute/cker/include/cker/operation/reference/BatchMatMul.h
@@ -142,37 +142,36 @@ inline void bmm_reference(const BMMParams &bmm_params, const float *lhs_data, co
 inline void bmm_optimized(const BMMParams &bmm_params, const float *lhs_data, const float *rhs_data,
                           float *output_data)
 {
+  MatrixParams<float> lhs_params;
+  lhs_params.order = Order::kRowMajor;
+  lhs_params.rows = bmm_params.lhs_rows;
+  lhs_params.cols = bmm_params.lhs_cols;
+
+  MatrixParams<float> rhs_params;
+  rhs_params.order = Order::kRowMajor;
+  rhs_params.rows = bmm_params.rhs_rows;
+  rhs_params.cols = bmm_params.rhs_cols;
+
+  MatrixParams<float> dst_params;
+  dst_params.order = Order::kColMajor;
+  dst_params.rows = bmm_params.lhs_rows;
+  dst_params.cols = bmm_params.rhs_cols;
+  
   for (int b0 = 0; b0 < bmm_params.batch_dim0; ++b0)
   {
-    const float *lhs_ptr0 = lhs_data + (b0 * bmm_params.lhs_ext0);
-    const float *rhs_ptr0 = rhs_data + (b0 * bmm_params.rhs_ext0);
     for (int b1 = 0; b1 < bmm_params.batch_dim1; ++b1)
     {
-      const float *lhs_ptr1 = lhs_ptr0 + b1 * bmm_params.lhs_ext1;
-      const float *rhs_ptr1 = rhs_ptr0 + b1 * bmm_params.rhs_ext1;
       for (int b2 = 0; b2 < bmm_params.batch_dim2; ++b2)
       {
-        const float *lhs_ptr2 = lhs_ptr1 + b2 * bmm_params.lhs_ext2;
-        const float *rhs_ptr2 = rhs_ptr1 + b2 * bmm_params.rhs_ext2;
-        float *out_ptr = output_data + ((b0 * bmm_params.batch_dim1 * bmm_params.batch_dim2) +
-                                        b1 * bmm_params.batch_dim2 + b2) *
-                                         bmm_params.lhs_rows * bmm_params.rhs_cols;
-        MatrixParams<float> lhs_params;
-        lhs_params.order = Order::kRowMajor;
-        lhs_params.rows = bmm_params.lhs_rows;
-        lhs_params.cols = bmm_params.lhs_cols;
+        const float *lhs_data =
+          lhs_data + b0 * bmm_params.lhs_ext0 + b1 * bmm_params.lhs_ext1 + b2 * bmm_params.lhs_ext2;
+        const float *rhs_data =
+          rhs_data + b0 * bmm_params.rhs_ext0 + b1 * bmm_params.rhs_ext1 + b2 * bmm_params.rhs_ext2;
+        float *out_data = output_data + ((b0 * bmm_params.batch_dim1 * bmm_params.batch_dim2) +
+                                         b1 * bmm_params.batch_dim2 + b2) *
+                                          bmm_params.lhs_rows * bmm_params.rhs_cols;
 
-        MatrixParams<float> rhs_params;
-        rhs_params.order = Order::kRowMajor;
-        rhs_params.rows = bmm_params.rhs_rows;
-        rhs_params.cols = bmm_params.rhs_cols;
-
-        MatrixParams<float> dst_params;
-        dst_params.order = Order::kColMajor;
-        dst_params.rows = bmm_params.lhs_rows;
-        dst_params.cols = bmm_params.rhs_cols;
-
-        optimized::Gemm(lhs_params, lhs_ptr2, rhs_params, rhs_ptr2, dst_params, out_ptr,
+        optimized::Gemm(lhs_params, lhs_data, rhs_params, rhs_data, dst_params, out_data,
                         GemmParams<float, float>{});
       }
     }

--- a/compute/cker/include/cker/operation/reference/BatchMatMul.h
+++ b/compute/cker/include/cker/operation/reference/BatchMatMul.h
@@ -142,25 +142,41 @@ inline void bmm_reference(const BMMParams &bmm_params, const float *lhs_data, co
 inline void bmm_optimized(const BMMParams &bmm_params, const float *lhs_data, const float *rhs_data,
                           float *output_data)
 {
-  MatrixParams<float> lhs_params; // should it be created from rhs?
-  lhs_params.order = Order::kRowMajor;
-  lhs_params.rows = bmm_params.lhs_rows;
-  lhs_params.cols = bmm_params.lhs_cols;
-  lhs_params.cache_policy = nnfw::cker::optimized::DefaultCachePolicy(false);
+  for (int b0 = 0; b0 < bmm_params.batch_dim0; ++b0)
+  {
+    const float *lhs_ptr0 = lhs_data + (b0 * bmm_params.lhs_ext0);
+    const float *rhs_ptr0 = rhs_data + (b0 * bmm_params.rhs_ext0);
+    for (int b1 = 0; b1 < bmm_params.batch_dim1; ++b1)
+    {
+      const float *lhs_ptr1 = lhs_ptr0 + b1 * bmm_params.lhs_ext1;
+      const float *rhs_ptr1 = rhs_ptr0 + b1 * bmm_params.rhs_ext1;
+      for (int b2 = 0; b2 < bmm_params.batch_dim2; ++b2)
+      {
+        const float *lhs_ptr2 = lhs_ptr1 + b2 * bmm_params.lhs_ext2;
+        const float *rhs_ptr2 = rhs_ptr1 + b2 * bmm_params.rhs_ext2;
+        float *out_ptr = output_data + ((b0 * bmm_params.batch_dim1 * bmm_params.batch_dim2) +
+                                        b1 * bmm_params.batch_dim2 + b2) *
+                                         bmm_params.lhs_rows * bmm_params.rhs_cols;
+        MatrixParams<float> lhs_params;
+        lhs_params.order = Order::kRowMajor;
+        lhs_params.rows = bmm_params.lhs_rows;
+        lhs_params.cols = bmm_params.lhs_cols;
 
-  MatrixParams<float> rhs_params;
-  rhs_params.order = Order::kRowMajor;
-  rhs_params.rows = bmm_params.rhs_rows;
-  rhs_params.cols = bmm_params.rhs_cols;
-  rhs_params.cache_policy = nnfw::cker::optimized::DefaultCachePolicy(false);
+        MatrixParams<float> rhs_params;
+        rhs_params.order = Order::kRowMajor;
+        rhs_params.rows = bmm_params.rhs_rows;
+        rhs_params.cols = bmm_params.rhs_cols;
 
-  MatrixParams<float> dst_params;
-  dst_params.order = Order::kColMajor;
-  dst_params.rows = bmm_params.lhs_rows;
-  dst_params.cols = bmm_params.rhs_cols;
+        MatrixParams<float> dst_params;
+        dst_params.order = Order::kColMajor;
+        dst_params.rows = bmm_params.lhs_rows;
+        dst_params.cols = bmm_params.rhs_cols;
 
-  GemmParams<float, float> gemm_params;
-  optimized::Gemm(lhs_params, lhs_data, rhs_params, rhs_data, dst_params, output_data, gemm_params);
+        optimized::Gemm(lhs_params, lhs_ptr2, rhs_params, rhs_ptr2, dst_params, out_ptr,
+                        GemmParams<float, float>{});
+      }
+    }
+  }
 }
 #endif
 } // namespace impl

--- a/compute/cker/include/cker/operation/reference/BatchMatMul.h
+++ b/compute/cker/include/cker/operation/reference/BatchMatMul.h
@@ -153,25 +153,25 @@ inline void bmm_optimized(const BMMParams &bmm_params, const float *lhs_data, co
   rhs_params.cols = bmm_params.rhs_cols;
 
   MatrixParams<float> dst_params;
-  dst_params.order = Order::kColMajor;
+  dst_params.order = Order::kRowMajor;
   dst_params.rows = bmm_params.lhs_rows;
   dst_params.cols = bmm_params.rhs_cols;
-  
+
   for (int b0 = 0; b0 < bmm_params.batch_dim0; ++b0)
   {
     for (int b1 = 0; b1 < bmm_params.batch_dim1; ++b1)
     {
       for (int b2 = 0; b2 < bmm_params.batch_dim2; ++b2)
       {
-        const float *lhs_data =
+        const float *lhs_ptr =
           lhs_data + b0 * bmm_params.lhs_ext0 + b1 * bmm_params.lhs_ext1 + b2 * bmm_params.lhs_ext2;
-        const float *rhs_data =
+        const float *rhs_ptr =
           rhs_data + b0 * bmm_params.rhs_ext0 + b1 * bmm_params.rhs_ext1 + b2 * bmm_params.rhs_ext2;
-        float *out_data = output_data + ((b0 * bmm_params.batch_dim1 * bmm_params.batch_dim2) +
-                                         b1 * bmm_params.batch_dim2 + b2) *
-                                          bmm_params.lhs_rows * bmm_params.rhs_cols;
+        float *out_ptr = output_data + ((b0 * bmm_params.batch_dim1 * bmm_params.batch_dim2) +
+                                        b1 * bmm_params.batch_dim2 + b2) *
+                                         bmm_params.lhs_rows * bmm_params.rhs_cols;
 
-        optimized::Gemm(lhs_params, lhs_data, rhs_params, rhs_data, dst_params, out_data,
+        optimized::Gemm(lhs_params, lhs_ptr, rhs_params, rhs_ptr, dst_params, out_ptr,
                         GemmParams<float, float>{});
       }
     }


### PR DESCRIPTION
This commit rewrites the BatchMatMul reference implementation with the usage of optimized::Gemm

ONE-DCO-1.0-Signed-off-by: Tomasz Dolbniak <t.dolbniak@partner.samsung.com>

This draft is a follow-up of https://github.com/Samsung/ONE/pull/13919 and is an attempt to solve https://github.com/Samsung/ONE/issues/12140 which I took over after Jan