### PR TITLE
[fme-detect] Support one more forwardable successors

### DIFF
--- a/compiler/fme-detect/src/EqualizePatternFinder.cpp
+++ b/compiler/fme-detect/src/EqualizePatternFinder.cpp
@@ -186,8 +186,11 @@ void match(luci::CircleNode *front, std::vector<EqualizePattern> &res)
     throw std::invalid_argument("front");
 
   auto front_fusability = fusability(front);
-
-  for (auto succ : loco::succs(front))
+  auto succs = loco::succs(front);
+  // TODO Support multiple successors.
+  if (succs.size() != 1)
+    return;
+  for (auto succ : succs)
   {
     // Check succ fusability
     auto back = loco::must_cast<luci::CircleNode *>(succ);
@@ -201,15 +204,24 @@ void match(luci::CircleNode *front, std::vector<EqualizePattern> &res)
       auto f = forwardable(back);
       if (f.scale_forwardable)
       {
-        auto succ_succs = loco::succs(back);
+        auto back_succs = loco::succs(back);
         // Only support single successor for simplicity
-        if (succ_succs.size() != 1)
+        if (back_succs.size() != 1)
           continue;
-        auto next_succ = *succ_succs.begin();
-        auto next_back = loco::must_cast<luci::CircleNode *>(next_succ);
-        back_fusability = fusability(next_back);
-        back_fusability.pre_scale &= f.scale_forwardable;
-        back = next_back;
+        back = loco::must_cast<luci::CircleNode *>(*back_succs.begin());
+        back_fusability = fusability(back);
+        if (not back_fusability.pre_scale)
+        {
+          f = forwardable(back);
+          if (f.scale_forwardable)
+          {
+            back_succs = loco::succs(back);
+            if (back_succs.size() != 1)
+              continue;
+            back = loco::must_cast<luci::CircleNode *>(*back_succs.begin());
+            back_fusability = fusability(back);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This commit supports one more forwardable successors.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>