### PR TITLE
[fme-detect] Do not forward Gelu

### DIFF
--- a/compiler/fme-detect/src/EqualizePatternFinder.cpp
+++ b/compiler/fme-detect/src/EqualizePatternFinder.cpp
@@ -173,7 +173,7 @@ Forwardable forwardable(luci::CircleNode *node)
     case luci::CircleOpcode::LEAKY_RELU:
       return {true, false};
     case luci::CircleOpcode::GELU:
-      return {true, false};
+      return {false, false};
     default:
       return {false, false};
   }


### PR DESCRIPTION
This commit doesn't forward Gelu when finding a pattern. Turns out that Gelu shouldn't have been forwarded with this case.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>