### PR TITLE
[fme-apply] Apply abs to weight

### DIFF
--- a/compiler/fme-apply/src/InsertScaleShift.cpp
+++ b/compiler/fme-apply/src/InsertScaleShift.cpp
@@ -125,7 +125,8 @@ bool calculate_smooth_quant_scale(luci::CircleNode *node, EqualizePattern *p)
         cur = i;
         for (uint32_t j = 0; j < norm_dim; j++)
         {
-          weight_max.at(i) = std::max(weight_max.at(i), weight->at<loco::DataType::FLOAT32>(cur));
+          weight_max.at(i) =
+            std::max(weight_max.at(i), std::abs(weight->at<loco::DataType::FLOAT32>(cur)));
           cur += weight_I;
         }
       }
@@ -166,7 +167,8 @@ bool calculate_smooth_quant_scale(luci::CircleNode *node, EqualizePattern *p)
         cur = i;
         for (uint32_t j = 0; j < weight_O; j++)
         {
-          weight_max.at(i) = std::max(weight_max.at(i), weight->at<loco::DataType::FLOAT32>(cur));
+          weight_max.at(i) =
+            std::max(weight_max.at(i), std::abs(weight->at<loco::DataType::FLOAT32>(cur)));
           cur += weight_I;
         }
       }


### PR DESCRIPTION
This commit applies missing abs to weight.


ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>