### PR TITLE
[mir] Minor doc fix

### DIFF
--- a/compiler/mir/Readme.md
+++ b/compiler/mir/Readme.md
@@ -21,7 +21,7 @@ special attributes specific to different operation types.
 Mir has a protobuf serializer/deserializer for shapes and tensors (see `mir.proto` schema).
 
 For list of currently supported operations, see `mir/ops/operations.lst.h`.
- 
+
 ### How to use
 Can be included as a `CMake` target.
 
@@ -29,8 +29,8 @@ Can be included as a `CMake` target.
 
 * Expand serialization
 * Add More to readme 
- 
+
 ### Dependencies
 
-Mir depends on `adtitas` library, which provides the `small_vector` data type.
-    
+Mir depends on the `adtitas` library, which provides the `small_vector` data type.
+


### PR DESCRIPTION
This removes trailing whitespace and adds a missing article.

ONE-DCO-1.0-Signed-off-by: Piotr Fusik <p.fusik@samsung.com>