### PR TITLE
[onert/backend] Fix checking indices tensor shape in GatherLayer

### DIFF
--- a/runtime/onert/backend/cpu/ops/GatherLayer.cc
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.cc
@@ -83,7 +83,7 @@ void GatherLayer::runByGGMLQuantInputType()
   if (getShape(_input).DimensionsCount() != 2)
     throw std::runtime_error("Gather: block quantized input tensor must be rank 2");
 
-  if (getShape(_indices).DimensionsCount() > 4 &&
+  if (getShape(_indices).DimensionsCount() >= 4 &&
       (getShape(_indices).DimensionsCount() != 4 || getShape(_indices).Dims(0) != 1))
     throw std::runtime_error("Gather: invalid indices tensor shape");
 


### PR DESCRIPTION
This fixes checking indices tensor shape in GatherLayer. 
If dimension count is 4 and dim(0) != 0, it should throw exception, but it didn't.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com