### PR TITLE
[docs/howto] Fix broken link in 'how to use nnfw api'

### DIFF
--- a/docs/howto/how-to-use-nnfw-api.md
+++ b/docs/howto/how-to-use-nnfw-api.md
@@ -10,7 +10,7 @@ Please see [model2nnpkg](https://github.com/Samsung/ONE/tree/master/tools/nnpack
 
 ## Build app with NNFW API
 
-Here are basic steps to build app with [NNFW C API](https://github.com/Samsung/ONE/blob/master/runtime/onert/api/include/nnfw.h)
+Here are basic steps to build app with [NNFW C API](https://github.com/Samsung/ONE/blob/master/runtime/onert/api/nnfw/include/nnfw.h)
 
 1) Initialize nnfw_session
 ``` c


### PR DESCRIPTION
This fixes a broken link in the how-to-use-nnfw-api.md file.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com