### PR TITLE
[luci/pass] Add fp32_to_uint8_cast to header

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -63,6 +63,9 @@ void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2);
 // Return true if the node is quantized
 bool is_quantized(const CircleNode *node);
 
+// Cast a floating-point number to an unsigned 8-bit integer
+uint8_t fp32_to_uint8_cast(float f);
+
 // Return true if the node is fp32
 bool is_fp32(const CircleNode *node);
 


### PR DESCRIPTION
This commit add the `fp32_to_uint8_cast` in the header file.

Related Issue : https://github.com/Samsung/ONE/issues/13480
Draft PR: https://github.com/Samsung/ONE/pull/13585

ONE-DCO-1.0-Signed-off-by: y01000.you <y01000.you@samsung.com>

