### PR TITLE
[nnpackage] Add mx dtypes to schema

### DIFF
--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -78,6 +78,11 @@ enum TensorType : byte {
   GGML_Q4_1 = -3,
   GGML_Q8_0 = -4,
   GGML_Q8_1 = -5,
+
+
+  // MX dtypes
+  MXFP4 = -6,
+  MXINT8 = -7,
 }
 
 // Custom quantization parameters for experimenting with new quantization

--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -35,6 +35,7 @@
 // Version 0.8: GRU op is added. UINT4 is added.
 // Version 0.9: GGML_Q{X}_{Y} types are added. Weight compression option is added.
 //              ROPE op is added.
+// Version 0.10: MXFP4, MXINT8 types are added.
 
 namespace circle;
 

--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -79,7 +79,6 @@ enum TensorType : byte {
   GGML_Q8_0 = -4,
   GGML_Q8_1 = -5,
 
-
   // MX dtypes
   MXFP4 = -6,
   MXINT8 = -7,

--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -34,8 +34,7 @@
 // Version 0.7: Base up to TensorFlow Lite v2.15.0 schema, deprecate data_format in Subgraph table
 // Version 0.8: GRU op is added. UINT4 is added.
 // Version 0.9: GGML_Q{X}_{Y} types are added. Weight compression option is added.
-//              ROPE op is added.
-// Version 0.10: MXFP4, MXINT8 types are added.
+//              ROPE op is added. MXFP4, MXINT8 types are added.
 
 namespace circle;
 


### PR DESCRIPTION
This adds mxfp4 and mxint8 to circle schema.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/14293
Draft PR: #14294