### PR TITLE
[loco] Add mx data type

### DIFF
--- a/compiler/loco/include/loco/IR/DataType.h
+++ b/compiler/loco/include/loco/IR/DataType.h
@@ -49,6 +49,10 @@ enum class DataType
 
   // WARNING STRING is NOT fully supported yet
   STRING, // String
+
+  // Microscaling data type
+  MXFP4,
+  MXINT8,
 };
 
 } // namespace loco


### PR DESCRIPTION
This adds MXFP4 and MXINT8.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/14293
Draft PR: https://github.com/Samsung/ONE/pull/14294