### PR TITLE
[circlechef] Support mx data type

### DIFF
--- a/compiler/circlechef/circle/src/Convert.cpp
+++ b/compiler/circlechef/circle/src/Convert.cpp
@@ -39,6 +39,10 @@ circlechef::TensorType as_circlechef_type(const circle::TensorType type)
       return circlechef::INT16;
     case circle::TensorType_INT4:
       return circlechef::INT4;
+    case circle::TensorType_MXFP4:
+      return circlechef::MXFP4;
+    case circle::TensorType_MXINT8:
+      return circlechef::MXINT8;
     // TODO handle other types
     // TensorType_FLOAT16
     // TensorType_STRING

--- a/compiler/circlechef/core/src/Convert.cpp
+++ b/compiler/circlechef/core/src/Convert.cpp
@@ -72,6 +72,10 @@ circle::TensorType as_circle_tensortype(const circlechef::TensorType &value)
       return circle::TensorType_STRING;
     case circlechef::BOOL:
       return circle::TensorType_BOOL;
+    case circlechef::MXFP4:
+      return circle::TensorType_MXFP4;
+    case circlechef::MXINT8:
+      return circle::TensorType_MXINT8;
     default:
       break;
   }

--- a/compiler/circlechef/core/src/Convert.test.cpp
+++ b/compiler/circlechef/core/src/Convert.test.cpp
@@ -51,6 +51,8 @@ TEST(ConvertTest, as_circle_tensortype)
   ASSERT_EQ(circle::TensorType_UINT8, as_circle_tensortype(circlechef::UINT8));
   ASSERT_EQ(circle::TensorType_UINT4, as_circle_tensortype(circlechef::UINT4));
   ASSERT_EQ(circle::TensorType_BOOL, as_circle_tensortype(circlechef::BOOL));
+  ASSERT_EQ(circle::TensorType_MXFP4, as_circle_tensortype(circlechef::MXFP4));
+  ASSERT_EQ(circle::TensorType_MXINT8, as_circle_tensortype(circlechef::MXINT8));
 }
 
 TEST(ConvertTest, as_circle_tensortype_NEG)

--- a/compiler/circlechef/proto/circlechef.proto
+++ b/compiler/circlechef/proto/circlechef.proto
@@ -14,6 +14,8 @@ package circlechef;
 
 // This enum value corresponds to TensorType in TensorFlow Lite schema
 enum TensorType {
+  MXINT8 = -7;
+  MXFP4 = -6;
   UINT4 = -1;
   FLOAT32 = 0;
   INT32 = 2;


### PR DESCRIPTION
This introduces MXFP4 and MXINT8.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/14293
Draft PR: https://github.com/Samsung/ONE/pull/14294