### PR TITLE
[res] Add mx type BatchMatMul recipes

### DIFF
--- a/res/CircleRecipes/CircleBatchMatMul_MXFP4_000/test.recipe
+++ b/res/CircleRecipes/CircleBatchMatMul_MXFP4_000/test.recipe
@@ -1,0 +1,59 @@
+operand {
+  name: "ifm1"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ifm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ifm1_mxfp4"
+  type: MXFP4
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ifm2_mxfp4"
+  type: MXFP4
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ofm_mxfp4"
+  type: MXFP4
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operation {
+  type: "Quantize"
+  input: "ifm1"
+  output: "ifm1_mxfp4"
+}
+operation {
+  type: "Quantize"
+  input: "ifm2"
+  output: "ifm2_mxfp4"
+}
+operation {
+  type: "BatchMatMul"
+  input: "ifm1_mxfp4"
+  input: "ifm2_mxfp4"
+  output: "ofm_mxfp4"
+  batch_matmul_options {
+    adjoint_lhs: false
+    adjoint_rhs: false
+  }
+}
+operation {
+  type: "Dequantize"
+  input: "ofm_mxfp4"
+  output: "ofm"
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm"
+

--- a/res/CircleRecipes/CircleBatchMatMul_MXINT8_000/test.recipe
+++ b/res/CircleRecipes/CircleBatchMatMul_MXINT8_000/test.recipe
@@ -1,0 +1,59 @@
+operand {
+  name: "ifm1"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ifm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ifm1_mxint8"
+  type: MXINT8
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ifm2_mxint8"
+  type: MXINT8
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ofm_mxint8"
+  type: MXINT8
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 32 dim: 32 }
+}
+operation {
+  type: "Quantize"
+  input: "ifm1"
+  output: "ifm1_mxint8"
+}
+operation {
+  type: "Quantize"
+  input: "ifm2"
+  output: "ifm2_mxint8"
+}
+operation {
+  type: "BatchMatMul"
+  input: "ifm1_mxint8"
+  input: "ifm2_mxint8"
+  output: "ofm_mxint8"
+  batch_matmul_options {
+    adjoint_lhs: false
+    adjoint_rhs: false
+  }
+}
+operation {
+  type: "Dequantize"
+  input: "ofm_mxint8"
+  output: "ofm"
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm"
+


### PR DESCRIPTION
This adds mx type BMM recipes.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/14293
Draft PR: https://github.com/Samsung/ONE/pull/14294