### PR TITLE
[souschef] Add cstdint header include

### DIFF
--- a/compiler/souschef/src/LexicalCast.cpp
+++ b/compiler/souschef/src/LexicalCast.cpp
@@ -17,6 +17,7 @@
 #include "souschef/LexicalCast.h"
 
 #include <cassert>
+#include <cstdint>
 #include <limits>
 #include <stdexcept>
 


### PR DESCRIPTION
This commit adds cstdint header include.
It will resolve build fail on gcc-13.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>