### PR TITLE
[onert] Remove UNUSED_RELEASE macro

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -30,7 +30,6 @@
 #include "exec/NopFunction.h"
 #include "exec/FunctionSequence.h"
 #include "util/logging.h"
-#include "util/Utils.h"
 #include "AclKernelGen.h"
 
 namespace onert
@@ -419,13 +418,10 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
     assert(_ctx.at(sizes_index).data());
     auto beginData_base = _ctx.at(begins_index).data()->base();
     auto sizeData_base = _ctx.at(sizes_index).data()->base();
-    const int beginData_size = _ctx.at(begins_index).shape().num_elements();
-    const int sizeData_size = _ctx.at(sizes_index).shape().num_elements();
+    [[maybe_unused]] const int beginData_size = _ctx.at(begins_index).shape().num_elements();
+    [[maybe_unused]] const int sizeData_size = _ctx.at(sizes_index).shape().num_elements();
 
     using ir::DataType;
-
-    UNUSED_RELEASE(beginData_size);
-    UNUSED_RELEASE(sizeData_size);
 
     assert(_ctx.at(begins_index).typeInfo().type() == DataType::INT32);
     assert(_ctx.at(sizes_index).typeInfo().type() == DataType::INT32);
@@ -486,15 +482,11 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
     auto startData_base = _ctx.at(starts_index).data()->base();
     auto endData_base = _ctx.at(ends_index).data()->base();
     auto stridesData_base = _ctx.at(strides_index).data()->base();
-    const int startData_size = _ctx.at(starts_index).shape().num_elements();
-    const int endData_size = _ctx.at(ends_index).shape().num_elements();
-    const int stridesData_size = _ctx.at(strides_index).shape().num_elements();
+    [[maybe_unused]] const int startData_size = _ctx.at(starts_index).shape().num_elements();
+    [[maybe_unused]] const int endData_size = _ctx.at(ends_index).shape().num_elements();
+    [[maybe_unused]] const int stridesData_size = _ctx.at(strides_index).shape().num_elements();
 
     using ir::DataType;
-
-    UNUSED_RELEASE(startData_size);
-    UNUSED_RELEASE(endData_size);
-    UNUSED_RELEASE(stridesData_size);
 
     assert(_ctx.at(starts_index).typeInfo().type() == DataType::INT32);
     assert(_ctx.at(ends_index).typeInfo().type() == DataType::INT32);

--- a/runtime/onert/backend/acl_common/AclKernelGen.h
+++ b/runtime/onert/backend/acl_common/AclKernelGen.h
@@ -238,9 +238,8 @@ kernelGenFullyConnected(const ir::operation::FullyConnected &node, const ir::Ope
 
   const auto input_rank = operands.at(input_index).shape().rank();
 
-  const auto output_size =
+  [[maybe_unused]] const auto output_size =
     operands.at(output_index).shape().dim(operands.at(output_index).shape().rank() - 1);
-  UNUSED_RELEASE(output_size);
   assert(bias_index.undefined() || operands.at(bias_index).shape().dim(0) == output_size);
   assert(operands.at(weight_index).shape().dim(0) == output_size);
   const auto batch_size =
@@ -254,13 +253,12 @@ kernelGenFullyConnected(const ir::operation::FullyConnected &node, const ir::Ope
   if (input_rank == 3 || input_rank == 4)
   {
     const auto &ifm_shape = operands.at(input_index).shape();
-    auto feature_size = 1;
+    [[maybe_unused]] auto feature_size = 1;
     for (int i = 0; i < ifm_shape.rank(); ++i)
     {
       feature_size *= ifm_shape.dim(i);
     }
 
-    UNUSED_RELEASE(feature_size);
     assert(feature_size == batch_size * input_size);
 
     // for reshaping

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -29,7 +29,6 @@
 #include "ir/InternalType.h"
 #include "exec/NopFunction.h"
 #include "util/logging.h"
-#include "util/Utils.h"
 #include "AclKernelGen.h"
 
 namespace onert
@@ -751,8 +750,7 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
     padding_list[axis] = ::arm_compute::PaddingInfo{from[0], from[1]};
   }
 
-  const auto input_type = _ctx.at(input_index).typeInfo();
-  UNUSED_RELEASE(input_type);
+  [[maybe_unused]] const auto input_type = _ctx.at(input_index).typeInfo();
   assert(input->info()->data_type() == acl_common::asDataType(input_type.type()));
   assert(input->info()->quantization_info() ==
          ::arm_compute::QuantizationInfo(input_type.scale(), input_type.zero_point()));
@@ -1041,13 +1039,10 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
   {
     auto beginData_base = _ctx.at(begins_index).data()->base();
     auto sizeData_base = _ctx.at(sizes_index).data()->base();
-    const int beginData_size = _ctx.at(begins_index).shape().num_elements();
-    const int sizeData_size = _ctx.at(sizes_index).shape().num_elements();
+    [[maybe_unused]] const int beginData_size = _ctx.at(begins_index).shape().num_elements();
+    [[maybe_unused]] const int sizeData_size = _ctx.at(sizes_index).shape().num_elements();
 
     using ir::DataType;
-
-    UNUSED_RELEASE(beginData_size);
-    UNUSED_RELEASE(sizeData_size);
 
     assert(_ctx.at(begins_index).typeInfo().type() == DataType::INT32);
     assert(_ctx.at(sizes_index).typeInfo().type() == DataType::INT32);
@@ -1105,15 +1100,11 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
     auto startData_base = _ctx.at(starts_index).data()->base();
     auto endData_base = _ctx.at(ends_index).data()->base();
     auto stridesData_base = _ctx.at(strides_index).data()->base();
-    const int startData_size = _ctx.at(starts_index).shape().num_elements();
-    const int endData_size = _ctx.at(ends_index).shape().num_elements();
-    const int stridesData_size = _ctx.at(strides_index).shape().num_elements();
+    [[maybe_unused]] const int startData_size = _ctx.at(starts_index).shape().num_elements();
+    [[maybe_unused]] const int endData_size = _ctx.at(ends_index).shape().num_elements();
+    [[maybe_unused]] const int stridesData_size = _ctx.at(strides_index).shape().num_elements();
 
     using ir::DataType;
-
-    UNUSED_RELEASE(startData_size);
-    UNUSED_RELEASE(endData_size);
-    UNUSED_RELEASE(stridesData_size);
 
     assert(_ctx.at(starts_index).typeInfo().type() == DataType::INT32);
     assert(_ctx.at(ends_index).typeInfo().type() == DataType::INT32);

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -251,7 +251,7 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
   {
     dyn_ctx->op = &_operations_ctx.at(ind);
-    dyn_ctx->dynamic_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
+    dyn_ctx->dynamic_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_tensor_reg);
   }
   ret->dynamic_tensor_ctx(dyn_ctx);
 

--- a/runtime/onert/backend/cpu/ops/OperationUtils.cc
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.cc
@@ -85,10 +85,10 @@ void GetQuantizedConvolutionMultiplier(const IPortableTensor *input, const IPort
                                        double *multiplier)
 {
   const double input_product_scale = input->data_scale() * filter->data_scale();
-  const double bias_scale = (bias != nullptr) ? bias->data_scale() : input_product_scale;
+  [[maybe_unused]] const double bias_scale =
+    (bias != nullptr) ? bias->data_scale() : input_product_scale;
   const double output_scale = output->data_scale();
   // The following conditions must be guaranteed by the training pipeline.
-  UNUSED_RELEASE(bias_scale);
   assert(std::abs(input_product_scale - bias_scale) <=
          1e-6 * std::min(input_product_scale, bias_scale));
   assert(input_product_scale >= 0);

--- a/runtime/onert/backend/ruy/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/ruy/ops/FullyConnectedLayer.cc
@@ -60,11 +60,9 @@ void FullyConnectedLayer::fullyConnectedFloat32()
 
 void FullyConnectedLayer::configure(const IPortableTensor *input, const IPortableTensor *weights,
                                     const IPortableTensor *bias, ir::Activation activation,
-                                    ir::FullyConnectedWeightsFormat weights_format,
                                     IPortableTensor *output,
                                     const std::shared_ptr<ExternalContext> &external_context)
 {
-  UNUSED_RELEASE(weights_format);
   _input = input;
   _weights = weights;
   _bias = bias;

--- a/runtime/onert/backend/ruy/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/ruy/ops/FullyConnectedLayer.h
@@ -42,8 +42,7 @@ public:
   void fullyConnectedFloat32();
 
   void configure(const IPortableTensor *input, const IPortableTensor *weights,
-                 const IPortableTensor *bias, ir::Activation activation,
-                 ir::FullyConnectedWeightsFormat weights_format, IPortableTensor *output,
+                 const IPortableTensor *bias, ir::Activation activation, IPortableTensor *output,
                  const std::shared_ptr<ExternalContext> &external_context);
 
   void run() override;

--- a/runtime/onert/backend/train/KernelGenerator.cc
+++ b/runtime/onert/backend/train/KernelGenerator.cc
@@ -34,7 +34,6 @@
 #include <backend/Backend.h>
 #include <backend/IConfig.h>
 #include <memory>
-#include <util/Utils.h>
 #include <util/logging.h>
 #include <exec/DynamicShapeInferer.h>
 
@@ -622,8 +621,8 @@ IPortableTensor *KernelGenerator::getBackPropIn(const ir::IOperation &node,
     _tensor_reg->getDisposableBackPropTensor(DisposableTensorIndex{op_index, operand_index});
   if (disposable_tensor != nullptr)
   {
-    const auto &training_usedefs = _tgraph.trainingUseDefs().at(backwarding_operand_index);
-    UNUSED_RELEASE(training_usedefs);
+    [[maybe_unused]] const auto &training_usedefs =
+      _tgraph.trainingUseDefs().at(backwarding_operand_index);
     assert(std::count_if(training_usedefs.getTrainingDefs().begin(),
                          training_usedefs.getTrainingDefs().end(),
                          [&](const ir::train::TrainingOperationIndex &op_index) {

--- a/runtime/onert/backend/train/TensorPlanner.cc
+++ b/runtime/onert/backend/train/TensorPlanner.cc
@@ -30,9 +30,6 @@ TensorPlanner::TensorPlanner(const ir::train::TrainableGraph &tgraph,
   : _tgraph{tgraph}, _external_operands{external_operands}
 {
   // DO NOTHING
-  // TODO Remove the following lines
-  UNUSED_RELEASE(_tgraph);
-  UNUSED_RELEASE(_external_operands);
 }
 
 void TensorPlanner::planNonConstTensors(TensorBuilder *tensor_builder)

--- a/runtime/onert/backend/xnnpack/KernelGenerator.cc
+++ b/runtime/onert/backend/xnnpack/KernelGenerator.cc
@@ -59,7 +59,7 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
   {
     dyn_ctx->op = &_operations_ctx.at(ind);
-    dyn_ctx->dynamic_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
+    dyn_ctx->dynamic_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_tensor_reg);
   }
   ret->dynamic_tensor_ctx(dyn_ctx);
 

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -26,7 +26,6 @@
 #include "ir/Layout.h"
 #include "ir/Shape.h"
 #include "ir/Coordinates.h"
-#include "util/Utils.h"
 
 namespace onert
 {
@@ -96,9 +95,8 @@ public:
    * @brief Set the shape of tenser to new_shape
    * @note  Higer dimension will be placed on front.
    */
-  virtual void setShape(const ir::Shape &new_shape)
+  virtual void setShape(const ir::Shape &)
   {
-    UNUSED_RELEASE(new_shape);
     throw std::runtime_error("This backend does not support dynamic setShape");
   }
 

--- a/runtime/onert/core/include/exec/DynamicShapeInferer.h
+++ b/runtime/onert/core/include/exec/DynamicShapeInferer.h
@@ -36,12 +36,10 @@ namespace exec
 class DynamicShapeInferer : public ir::OperationVisitor
 {
 public:
-  DynamicShapeInferer(const ir::Operands &operands,
-                      const std::shared_ptr<backend::ITensorRegistry> &tensor_registry)
-    : _operands(operands), _tensor_registry(tensor_registry)
+  DynamicShapeInferer(const std::shared_ptr<backend::ITensorRegistry> &tensor_registry)
+    : _tensor_registry(tensor_registry)
   {
-    UNUSED_RELEASE(_operands);
-    UNUSED_RELEASE(_tensor_registry);
+    // DO NOTHING
   }
 
 public:
@@ -120,10 +118,6 @@ private:
   bool currently_static(backend::ITensor *op_input) { return !op_input->is_dynamic(); }
 
 private:
-  /**
-   * @brief To get operand-level info, e.g., ir::Operand::isConstant()
-   */
-  const ir::Operands &_operands;
   /**
    * @brief To get tensor object and access tensor-level info, e.g., ITensor::buffer()
    */

--- a/runtime/onert/core/include/util/Utils.h
+++ b/runtime/onert/core/include/util/Utils.h
@@ -25,8 +25,6 @@
 #include "ir/Coordinates.h"
 #include "ir/Shape.h"
 
-#define UNUSED_RELEASE(a) (void)(a)
-
 template <size_t rest> struct ForEachDimension
 {
   template <typename L>
@@ -53,10 +51,8 @@ template <size_t rest> struct ForEachDimension
 template <> struct ForEachDimension<0>
 {
   template <typename L>
-  static void unroll(const onert::ir::Shape &shape, onert::ir::Coordinates &coords,
-                     L lambda_function)
+  static void unroll(const onert::ir::Shape &, onert::ir::Coordinates &coords, L lambda_function)
   {
-    UNUSED_RELEASE(shape);
     lambda_function(coords);
   }
 };

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -36,9 +36,7 @@ KernelGenerator::KernelGenerator(const ir::Graph &graph, DynamicTensorManager *d
     _tensor_reg{tensor_reg}, _tensor_registries{}, _executors{nullptr}, _model_index{},
     _external_context{external_context}
 {
-  UNUSED_RELEASE(_graph);
-  UNUSED_RELEASE(_tensor_registries);
-  UNUSED_RELEASE(_executors);
+  // DO NOTHING
 }
 
 std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationIndex ind)
@@ -52,8 +50,7 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
   {
     dyn_ctx->op = &_graph.operations().at(ind);
-    dyn_ctx->dynamic_shape_inferer =
-      std::make_unique<exec::DynamicShapeInferer>(_graph.operands(), _tensor_reg);
+    dyn_ctx->dynamic_shape_inferer = std::make_unique<exec::DynamicShapeInferer>(_tensor_reg);
   }
   ret->dynamic_tensor_ctx(dyn_ctx);
 

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -174,8 +174,8 @@ createBackendContexts(compiler::ILoweredGraph &lgraph, bool linear_executor,
     auto new_operand = std::make_unique<ir::Operand>(operand);
     new_operand->clearDefUse();
     operand.releaseData(); // Deref data of LoweredGraph
-    auto new_operand_ind = partial_graph.addOperand(operand_ind, std::move(new_operand));
-    UNUSED_RELEASE(new_operand_ind);
+    [[maybe_unused]] auto new_operand_ind =
+      partial_graph.addOperand(operand_ind, std::move(new_operand));
     assert(new_operand_ind == operand_ind);
   });
   // Separate operations into partial graphs
@@ -202,15 +202,14 @@ createBackendContexts(compiler::ILoweredGraph &lgraph, bool linear_executor,
           const auto &operand = whole_graph.operands().at(operand_ind);
           auto new_operand = std::make_unique<ir::Operand>(operand);
           new_operand->clearDefUse();
-          auto new_operand_ind = partial_graph.addOperand(operand_ind, std::move(new_operand));
-          UNUSED_RELEASE(new_operand_ind);
+          [[maybe_unused]] auto new_operand_ind =
+            partial_graph.addOperand(operand_ind, std::move(new_operand));
           assert(new_operand_ind == operand_ind);
 
           external_operands.add(operand_ind);
         }
 
-        auto new_op_ind = partial_graph.addOperation(op_ind, clone(operation));
-        UNUSED_RELEASE(new_op_ind);
+        [[maybe_unused]] auto new_op_ind = partial_graph.addOperation(op_ind, clone(operation));
         assert(new_op_ind == op_ind);
       }
     });
@@ -649,7 +648,8 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
                                                            const onert::ir::IOperation &op) {
     try
     {
-      UNUSED_RELEASE(dynamic_cast<const ir::train::ITrainableOperation &>(op));
+      [[maybe_unused]] const auto &casted_op =
+        dynamic_cast<const ir::train::ITrainableOperation &>(op);
     }
     catch (std::bad_cast &)
     {
@@ -674,8 +674,7 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
       [&](const onert::ir::OperationIndex &op_index, const onert::ir::IOperation &) {
         const auto &orig_tgraph = lowered_graph->trainable_graph();
         const auto &trainable_op = orig_tgraph.operation(op_index);
-        auto gen_index = tgraph->replaceOperation(op_index, trainable_op.clone());
-        UNUSED_RELEASE(gen_index);
+        [[maybe_unused]] auto gen_index = tgraph->replaceOperation(op_index, trainable_op.clone());
         assert(gen_index == op_index);
       });
     data.graph->operands().iterate([&](const ir::OperandIndex &index, const ir::Operand &) {
@@ -684,8 +683,8 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
       {
         const auto &bwd_operand = orig_tgraph.backward_operands().at(index);
         auto new_bwd_operand = std::make_unique<ir::Operand>(bwd_operand);
-        auto gen_index = tgraph->addBackwardOperand(index, std::move(new_bwd_operand));
-        UNUSED_RELEASE(gen_index);
+        [[maybe_unused]] auto gen_index =
+          tgraph->addBackwardOperand(index, std::move(new_bwd_operand));
         assert(gen_index == index);
       }
     });

--- a/runtime/onert/core/src/compiler/HEScheduler.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.cc
@@ -289,10 +289,10 @@ void HEScheduler::makeRank()
     [&](const ir::OperationIndex &index, const ir::IOperation &) { DFSMaxRank(index); });
 
   // Check that ranks are calculated for all operations(nodes)
-  _graph->operations().iterate([&](const ir::OperationIndex &index, const ir::IOperation &) {
-    UNUSED_RELEASE(index);
-    assert(_op_to_rank->find(index) != _op_to_rank->end());
-  });
+  _graph->operations().iterate(
+    [&]([[maybe_unused]] const ir::OperationIndex &index, const ir::IOperation &) {
+      assert(_op_to_rank->find(index) != _op_to_rank->end());
+    });
   VERBOSE(HEScheduler::makeRank) << "task prioritizing finished" << std::endl;
 }
 

--- a/runtime/onert/core/src/compiler/ShapeValidator.cc
+++ b/runtime/onert/core/src/compiler/ShapeValidator.cc
@@ -20,7 +20,6 @@
 
 #include "ir/Graph.h"
 #include "util/logging.h"
-#include "util/Utils.h"
 
 #define OP_REQUIRES(EXP)                                                                     \
   do                                                                                         \
@@ -975,8 +974,7 @@ void ShapeValidator::visit(const ir::operation::Shape &node)
   if (operands.at(output_index).info().isDynamic())
     return;
 
-  const auto input_index{node.getInputs().at(0)};
-  UNUSED_RELEASE(input_index);
+  [[maybe_unused]] const auto input_index{node.getInputs().at(0)};
   OP_REQUIRES(operands.at(output_index).shape().rank() == 1);
 }
 

--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -17,7 +17,6 @@
 #include "ConstantInsertionPass.h"
 
 #include "ir/Graph.h"
-#include "util/Utils.h"
 #include "util/logging.h"
 
 namespace onert
@@ -85,9 +84,9 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::I
   }
 
   // Now this runtime does not support the node making output as constant
-  for (const auto &output : node.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+  for ([[maybe_unused]] const auto &output :
+       node.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
   {
-    UNUSED_RELEASE(output);
     assert(!_graph.operands().at(output).isConstant());
   }
 }

--- a/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
@@ -19,7 +19,6 @@
 #include "ir/Graph.h"
 #include "ir/operation/Permute.h"
 #include "util/logging.h"
-#include "util/Utils.h"
 
 namespace onert
 {
@@ -48,7 +47,6 @@ void OddOutputPass::run()
   std::unordered_set<ir::OperandIndex> occurence;
   for (auto &&ind : outputs)
   {
-    auto &obj = _graph.operands().at(ind);
     if (occurence.count(ind) == 0)
     {
       occurence.insert(ind);
@@ -56,7 +54,7 @@ void OddOutputPass::run()
     }
 
     // Panic when it is const, it must have been handled earlier in another pass
-    UNUSED_RELEASE(obj);
+    [[maybe_unused]] auto &obj = _graph.operands().at(ind);
     assert(!obj.isConstant());
 
     auto permute_output_ind = insertPermute(ind);

--- a/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
+++ b/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
@@ -112,8 +112,8 @@ void LoweredTrainableGraph::lowerGraph(const CompilerOptions &options)
       {
         auto trainable_op = op_converter(op);
         trainable_op->enableBackward();
-        auto gen_index = _trainable_graph.replaceOperation(index, std::move(trainable_op));
-        UNUSED_RELEASE(gen_index);
+        [[maybe_unused]] auto gen_index =
+          _trainable_graph.replaceOperation(index, std::move(trainable_op));
         assert(gen_index == index);
       }
     });

--- a/runtime/onert/core/src/compiler/train/StaticBackwardShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/train/StaticBackwardShapeInferer.cc
@@ -96,10 +96,9 @@ void StaticBackwardShapeInferer::setShape(const ir::OperandIndex &index, const i
   {
     // NOTE This code assumes the types are always the same, but I'm not sure.
     const auto &type = tgraph.operands().at(index).typeInfo();
-    const auto new_index =
+    [[maybe_unused]] const auto new_index =
       tgraph.addBackwardOperand(index, std::make_unique<ir::Operand>(shape, type));
     assert(new_index == index);
-    UNUSED_RELEASE(new_index);
   }
 }
 

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
@@ -17,7 +17,6 @@
 #include "TrainableOperationConverter.h"
 
 #include "ir/train/Operations.Include.h"
-#include "util/Utils.h"
 
 namespace onert
 {
@@ -30,8 +29,7 @@ TrainableOperationConverter::TrainableOperationConverter(
   ir::train::TrainableGraph &tgraph, const ir::train::TrainingInfo *training_info)
   : UntrainableOperationConverter{tgraph}, _training_info{training_info}
 {
-  // Avoid unused-private-field error
-  UNUSED_RELEASE(_training_info);
+  // DO NOTHING
 }
 
 void TrainableOperationConverter::visit(const ir::operation::BinaryArithmetic &node)

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
@@ -51,7 +51,7 @@ private:
   void visit(const ir::operation::Softmax &) override;
 
 private:
-  const ir::train::TrainingInfo *_training_info;
+  [[maybe_unused]] const ir::train::TrainingInfo *_training_info;
 };
 
 } // namespace train

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -120,8 +120,8 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
               min_trainable_op_idx = op_index;
             }
           }
-          auto gen_index = trainable_subg->replaceOperation(op_index, std::move(trainable_op));
-          UNUSED_RELEASE(gen_index);
+          [[maybe_unused]] auto gen_index =
+            trainable_subg->replaceOperation(op_index, std::move(trainable_op));
           assert(gen_index == op_index);
         });
 
@@ -226,9 +226,9 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
       if (!obj.isConstant())
       {
         auto bwd_operand = std::make_unique<ir::Operand>(obj);
-        const auto gen_index = tgraph.addBackwardOperand(index, std::move(bwd_operand));
+        [[maybe_unused]] const auto gen_index =
+          tgraph.addBackwardOperand(index, std::move(bwd_operand));
         assert(gen_index == index);
-        UNUSED_RELEASE(gen_index);
       }
     });
   }

--- a/runtime/onert/core/src/exec/feature/nchw/Reader.h
+++ b/runtime/onert/core/src/exec/feature/nchw/Reader.h
@@ -41,7 +41,6 @@ public:
   Reader(const ir::FeatureShape &shape, const Strides &strides, const T *ptr, size_t len)
     : _shape{shape}, _strides{strides}, _ptr{reinterpret_cast<const uint8_t *>(ptr)}, _len{len}
   {
-    UNUSED_RELEASE(len); // Workaround for unused variable in release mode
     assert(len == static_cast<size_t>(strides.N != 0   ? shape.N * strides.N
                                       : strides.C != 0 ? shape.C * strides.C
                                       : strides.H != 0 ? shape.H * strides.H

--- a/runtime/onert/core/src/exec/feature/nhwc/Reader.h
+++ b/runtime/onert/core/src/exec/feature/nhwc/Reader.h
@@ -23,7 +23,6 @@
 
 #include "backend/ITensor.h"
 #include "ir/Shape.h"
-#include "util/Utils.h"
 
 namespace onert
 {
@@ -42,7 +41,6 @@ public:
   Reader(const ir::FeatureShape &shape, const Strides &strides, const T *ptr, size_t len)
     : _shape{shape}, _strides{strides}, _ptr{reinterpret_cast<const uint8_t *>(ptr)}, _len{len}
   {
-    UNUSED_RELEASE(len); // Workaround for unused variable in release mode
     assert(len == static_cast<size_t>(strides.N != 0   ? shape.N * strides.N
                                       : strides.H != 0 ? shape.H * strides.H
                                       : strides.W != 0 ? shape.W * strides.W

--- a/runtime/onert/core/src/ir/Padding.cc
+++ b/runtime/onert/core/src/ir/Padding.cc
@@ -16,8 +16,6 @@
 
 #include "ir/Padding.h"
 
-#include "util/Utils.h"
-
 #include <stdexcept>
 #include <cassert>
 
@@ -84,19 +82,17 @@ inline ExplicitPadding samePaddingUsingIFM(const FeatureShape &ifm_shape, const 
   return padding;
 }
 
-inline ExplicitPadding samePadding(const FeatureShape &ifm_shape, const FeatureShape &ofm_shape,
+inline ExplicitPadding samePadding(const FeatureShape &ifm_shape,
+                                   [[maybe_unused]] const FeatureShape &ofm_shape,
                                    const Stride &stride, uint32_t kw, uint32_t kh, uint32_t dwf,
                                    uint32_t dhf)
 {
-  const int32_t vertical_expected_output = (ifm_shape.H + stride.vertical - 1) / stride.vertical;
-  const int32_t horizontal_expected_output =
+  [[maybe_unused]] const int32_t vertical_expected_output =
+    (ifm_shape.H + stride.vertical - 1) / stride.vertical;
+  [[maybe_unused]] const int32_t horizontal_expected_output =
     (ifm_shape.W + stride.horizontal - 1) / stride.horizontal;
   assert(vertical_expected_output == ofm_shape.H);
   assert(horizontal_expected_output == ofm_shape.W);
-
-  UNUSED_RELEASE(ofm_shape);
-  UNUSED_RELEASE(vertical_expected_output);
-  UNUSED_RELEASE(horizontal_expected_output);
 
   return samePaddingUsingIFM(ifm_shape, stride, kw, kh, dwf, dhf);
 }

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -18,7 +18,6 @@
 
 #include "ir/OperandIndexMap.h"
 #include "UseDefGenerator.h"
-#include "util/Utils.h"
 #include "util/Set.h"
 #include "../verifier/Verifier.h"
 
@@ -159,7 +158,8 @@ void TrainableGraph::verify(void) const
   operations().iterate([](const onert::ir::OperationIndex &, const onert::ir::IOperation &op) {
     try
     {
-      UNUSED_RELEASE(dynamic_cast<const onert::ir::train::ITrainableOperation &>(op));
+      [[maybe_unused]] const auto &casted_op =
+        dynamic_cast<const onert::ir::train::ITrainableOperation &>(op);
     }
     catch (const std::bad_cast &)
     {

--- a/runtime/onert/core/src/odc/CodegenManager.cc
+++ b/runtime/onert/core/src/odc/CodegenManager.cc
@@ -16,17 +16,18 @@
 
 #include "CodegenLoader.h"
 #include "odc/CodegenManager.h"
-#include "util/Utils.h"
 
 #include <mutex>
+#include <stdexcept>
 
 namespace onert
 {
 namespace odc
 {
 
+// TODO Use compile preference
 bool CodegenManager::codegen(const std::string &model_path, const char *target,
-                             CodegenPreference pref)
+                             [[maybe_unused]] CodegenPreference pref)
 {
   if (target == nullptr)
     throw std::runtime_error("Target string is not set");
@@ -44,8 +45,6 @@ bool CodegenManager::codegen(const std::string &model_path, const char *target,
   auto &codegen_loader = CodegenLoader::instance();
   codegen_loader.loadLibrary(target);
   const auto code_generator = codegen_loader.get();
-  // TODO Use compile preference
-  UNUSED_RELEASE(pref);
   const auto result = code_generator->codegen(model_path.c_str(), _export_model_path.c_str());
   codegen_loader.unloadLibrary();
 

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include "util/Utils.h"
 #include "ir/InternalType.h"
 #include "ir/Shape.h"
 #include "util/ShapeInference.h"
@@ -751,9 +750,10 @@ template ir::Shape inferSliceShape(const ir::Shape &input_shape, const int32_t *
 template ir::Shape inferSliceShape(const ir::Shape &input_shape, const int64_t *begins_buf,
                                    const int64_t *sizes_buf);
 
-ir::Shape inferSpaceToBatchNDShape(const ir::Shape &input_shape, const ir::Shape &block_shape_shape,
-                                   const ir::Shape &padding_shape, const int32_t *block_shape_buf,
-                                   const int32_t *padding_buf)
+ir::Shape inferSpaceToBatchNDShape(const ir::Shape &input_shape,
+                                   [[maybe_unused]] const ir::Shape &block_shape_shape,
+                                   [[maybe_unused]] const ir::Shape &padding_shape,
+                                   const int32_t *block_shape_buf, const int32_t *padding_buf)
 {
   const uint32_t rank = input_shape.rank();
   ir::Shape out_shape(rank);
@@ -761,14 +761,9 @@ ir::Shape inferSpaceToBatchNDShape(const ir::Shape &input_shape, const ir::Shape
   // Currently, only 4D NHWC input/output op_context are supported.
   // The 4D array need to have exactly 2 spatial dimensions.
   // TODO(nupurgarg): Support arbitrary dimension in SpaceToBatchND.
-  const int32_t kInputDimensionNum = 4;
-  const int32_t kBlockSizeDimensionNum = 1;
+  [[maybe_unused]] const int32_t kInputDimensionNum = 4;
+  [[maybe_unused]] const int32_t kBlockSizeDimensionNum = 1;
   const int32_t kSpatialDimensionNum = 2;
-
-  UNUSED_RELEASE(kInputDimensionNum);
-  UNUSED_RELEASE(kBlockSizeDimensionNum);
-  UNUSED_RELEASE(block_shape_shape);
-  UNUSED_RELEASE(padding_shape);
 
   assert(block_shape_shape.rank() == kBlockSizeDimensionNum);
   assert(block_shape_shape.dim(0) == kSpatialDimensionNum);


### PR DESCRIPTION
This commit removes UNUSED_RELEASE() macro in onert. 
UNUSED_RELEASE() macro is introduced to avoid unused variable warning when the variable is only used in debug build. 
However, it is not necessary because we can use c++17 [[maybe_unused]] instead.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>