### PR TITLE
[compute/ruy] Remove UNUSED_RELEASE macro

### DIFF
--- a/compute/ruy/include/ruy/Shape.h
+++ b/compute/ruy/include/ruy/Shape.h
@@ -23,8 +23,6 @@
 #include <cassert>
 #include <vector>
 
-#define UNUSED_RELEASE(a) (void)(a)
-
 namespace nnfw
 {
 namespace ruy
@@ -220,20 +218,18 @@ private:
   };
 };
 
-inline int MatchingDim(const Shape &shape1, int index1, const Shape &shape2, int index2)
+inline int MatchingDim(const Shape &shape1, int index1, [[maybe_unused]] const Shape &shape2,
+                       [[maybe_unused]] int index2)
 {
-  UNUSED_RELEASE(shape2);
-  UNUSED_RELEASE(index2);
   assert(shape1.Dims(index1) == shape2.Dims(index2));
   return shape1.Dims(index1);
 }
 
 template <typename... Args>
-int MatchingDim(const Shape &shape1, int index1, const Shape &shape2, int index2, Args... args)
+int MatchingDim(const Shape &shape1, int index1, [[maybe_unused]] const Shape &shape2,
+                [[maybe_unused]] int index2, Args... args)
 {
   assert(shape1.Dims(index1) == shape2.Dims(index2));
-  UNUSED_RELEASE(shape2);
-  UNUSED_RELEASE(index2);
   return MatchingDim(shape1, index1, args...);
 }
 
@@ -306,9 +302,9 @@ template <typename... Ts> inline int MatchingFlatSize(const Shape &shape, Ts... 
   return shape.FlatSize();
 }
 
-inline int MatchingFlatSizeSkipDim(const Shape &shape, int skip_dim, const Shape &check_shape_0)
+inline int MatchingFlatSizeSkipDim(const Shape &shape, int skip_dim,
+                                   [[maybe_unused]] const Shape &check_shape_0)
 {
-  UNUSED_RELEASE(check_shape_0);
   const int dims_count = shape.DimensionsCount();
   for (int i = 0; i < dims_count; ++i)
   {
@@ -320,10 +316,10 @@ inline int MatchingFlatSizeSkipDim(const Shape &shape, int skip_dim, const Shape
   return FlatSizeSkipDim(shape, skip_dim);
 }
 
-inline int MatchingFlatSizeSkipDim(const Shape &shape, int skip_dim, const Shape &check_shape_0,
+inline int MatchingFlatSizeSkipDim(const Shape &shape, int skip_dim,
+                                   [[maybe_unused]] const Shape &check_shape_0,
                                    const Shape &check_shape_1)
 {
-  UNUSED_RELEASE(check_shape_0);
   const int dims_count = shape.DimensionsCount();
   for (int i = 0; i < dims_count; ++i)
   {
@@ -339,12 +335,10 @@ inline int MatchingElementsSize(const Shape &shape, const Shape &check_shape_0,
                                 const Shape &check_shape_1)
 {
   const int size_1 = shape.FlatSize();
-  const int size_2 = check_shape_0.FlatSize();
-  const int size_3 = check_shape_1.FlatSize();
+  [[maybe_unused]] const int size_2 = check_shape_0.FlatSize();
+  [[maybe_unused]] const int size_3 = check_shape_1.FlatSize();
   assert(size_1 == size_2);
   assert(size_2 == size_3);
-  UNUSED_RELEASE(size_2);
-  UNUSED_RELEASE(size_3);
   return size_1;
 }
 

--- a/compute/ruy/include/ruy/Types.h
+++ b/compute/ruy/include/ruy/Types.h
@@ -226,7 +226,8 @@ struct GemmParams
 
 // Validates self-consistency of GemmParams.
 template <typename AccumScalar, typename DstScalar, QuantizationFlavor quantization_flavor>
-void ValidateGemmParams(const GemmParams<AccumScalar, DstScalar, quantization_flavor> &params)
+void ValidateGemmParams(
+  [[maybe_unused]] const GemmParams<AccumScalar, DstScalar, quantization_flavor> &params)
 {
   // Guard consistency of the quantized multiplier fields.
   if (quantization_flavor == QuantizationFlavor::kFloatingPoint)
@@ -261,7 +262,6 @@ void ValidateGemmParams(const GemmParams<AccumScalar, DstScalar, quantization_fl
     assert(!params.multiplier_fixedpoint_perchannel);
     assert(!params.multiplier_exponent_perchannel);
   }
-  UNUSED_RELEASE(params);
 }
 
 inline CachePolicy DefaultCachePolicy(bool is_constant_data)

--- a/compute/ruy/include/ruy/operation/Conv.h
+++ b/compute/ruy/include/ruy/operation/Conv.h
@@ -88,11 +88,11 @@ public:
 
 private:
   void ConvFloat(const ConvParams &params, const Shape &input_shape, const float *input_data,
-                 const Shape &filter_shape, const float *filter_data, const Shape &bias_shape,
-                 const float *bias_data, const Shape &output_shape, float *output_data,
-                 const Shape &im2col_shape, float *im2col_data, ::ruy::Context *ruy_context)
+                 const Shape &filter_shape, const float *filter_data,
+                 [[maybe_unused]] const Shape &bias_shape, const float *bias_data,
+                 const Shape &output_shape, float *output_data, const Shape &im2col_shape,
+                 float *im2col_data, ::ruy::Context *ruy_context)
   {
-    UNUSED_RELEASE(bias_shape);
     const int stride_width = params.stride_width;
     const int stride_height = params.stride_height;
     const int dilation_width_factor = params.dilation_width_factor;


### PR DESCRIPTION
This commit removes UNUSED_RELEASE() macro in compute/ruy.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Refer #14336 