### PR TITLE
[tools/model_explorer_circle] Add graph nodes in circle model

### DIFF
--- a/tools/model_explorer_circle/src/circle_adapter/main.py
+++ b/tools/model_explorer_circle/src/circle_adapter/main.py
@@ -30,6 +30,10 @@ class CircleAdapter(Adapter):
     def __init__(self):
         super().__init__()
         self.model = None
+        self.dict_opcode_to_name = {
+            v: k
+            for k, v in circle_schema.BuiltinOperator.__dict__.items()
+        }
 
     def load_model(self, model_path: str) -> None:
         """Load the model from the given path."""
@@ -38,10 +42,40 @@ class CircleAdapter(Adapter):
 
         self.model = circle_schema.ModelT.InitFromObj(model_)
 
+    def opcode_to_name(self, opcode: int) -> str:
+        """Convert the opcode to its name."""
+        return self.dict_opcode_to_name[opcode]
+
+    def build_graph(self, me_graph: graph_builder.Graph) -> None:
+        """Build the graph using the model."""
+
+        sub_graph = self.model.subgraphs[0]
+
+        # Create Input nodes
+        input_id = len(sub_graph.operators)
+        me_node = graph_builder.GraphNode(id=f'{input_id}',
+                                          label="GraphInputs",
+                                          namespace="GraphInputs")
+        me_graph.nodes.append(me_node)
+
+        # Create operator nodes
+        for idx, op in enumerate(sub_graph.operators):
+            name = self.opcode_to_name(
+                self.model.operatorCodes[op.opcodeIndex].builtinCode)
+            me_node = graph_builder.GraphNode(id=f'{idx}', label=name)
+            me_graph.nodes.append(me_node)
+
+        # Create Output nodes
+        me_node = graph_builder.GraphNode(id=f'{len(me_graph.nodes)}',
+                                          label="GraphOutputs",
+                                          namespace="GraphOutputs")
+        me_graph.nodes.append(me_node)
+
     def convert(self, model_path: str, settings: Dict) -> ModelExplorerGraphs:
         """Convert the model to a set of graphs."""
         graph = graph_builder.Graph(id='main')
 
         self.load_model(model_path)
+        self.build_graph(graph)
 
         return {'graphs': [graph]}


### PR DESCRIPTION
It adds input, output and operators in circle model to model explorer graph as a separted nodes.
For Input and Output, it added extra nodes named as 'GraphInputs' and 'GraphOutputs'.
They are the root and the leaf node in the graph respectively.
The notation is followed the view of the `tflite` model in Model Explorer.

---
draft: #14318
issue: #14307 