### PR TITLE
[tools/mec] Add namespace to operator

### DIFF
--- a/tools/model_explorer_circle/src/circle_adapter/main.py
+++ b/tools/model_explorer_circle/src/circle_adapter/main.py
@@ -114,7 +114,6 @@ class CircleAdapter(Adapter):
                 ns = '/'.join(ns.strip('/').split('/')[:2])
             me_node = graph_builder.GraphNode(id=f'{idx}', label=name, namespace=ns)
             me_graph.nodes.append(me_node)
-
             # Connect edges from inputs to this operator node
             for i, tensor_id in enumerate(op.inputs):
                 if tensor_id < 0:

--- a/tools/model_explorer_circle/src/circle_adapter/main.py
+++ b/tools/model_explorer_circle/src/circle_adapter/main.py
@@ -104,8 +104,17 @@ class CircleAdapter(Adapter):
         for idx, op in enumerate(sub_graph.operators):
             name = self.opcode_to_name(
                 self.model.operatorCodes[op.opcodeIndex].builtinCode)
-            me_node = graph_builder.GraphNode(id=f'{idx}', label=name)
+            # Construct namespace following output tensor's name
+            output_tensor_id = op.outputs[0]
+            output_tensor = sub_graph.tensors[output_tensor_id]
+            ns = output_tensor.name.decode("utf-8")
+            if '/' in ns:
+                # Let's take maximum 2 depths of the tensor name
+                # '/A/B/C/D' becomes 'A/B'
+                ns = '/'.join(ns.strip('/').split('/')[:2])
+            me_node = graph_builder.GraphNode(id=f'{idx}', label=name, namespace=ns)
             me_graph.nodes.append(me_node)
+
             # Connect edges from inputs to this operator node
             for i, tensor_id in enumerate(op.inputs):
                 if tensor_id < 0:


### PR DESCRIPTION
It adds a namespace to the operator node based on the name of its output tensor.
It helps folding graph by grouping of operators that uses same namespace.


---

* issue: https://github.com/Samsung/ONE/issues/14307
* draft: https://github.com/Samsung/ONE/pull/14318
