### PR TITLE
[github] Introduce workflow to publish model-explorer-circle

### DIFF
--- a/.github/workflows/pub-tools-mec-pypi.yml
+++ b/.github/workflows/pub-tools-mec-pypi.yml
@@ -1,0 +1,32 @@
+name: Publish model-explorer-circle to pypi
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install build dependencies
+        run: python -m pip install -U setuptools wheel build
+
+      - name: Build
+        run: |
+          cd tools/model_explorer_circle/
+          python -m build .
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: tools/model_explorer_circle/dist/
+          skip-existing: true


### PR DESCRIPTION
This will introduce workflow to publish model-explorer-circle to pypi.org.
