### PR TITLE
[tools/mec] Fix the NOX to use the latest package

### DIFF
--- a/tools/model_explorer_circle/noxfile.py
+++ b/tools/model_explorer_circle/noxfile.py
@@ -36,7 +36,11 @@ def tests(session):
     build_and_check_dists(session)
 
     generated_files = os.listdir("dist/")
-    generated_sdist = os.path.join("dist/", generated_files[1])
+    # Sort files in descending order according to the version
+    generated_files.sort(
+        key=lambda x: [int(i, 10) for i in x.split('-')[1].split('.')[:3]], reverse=True)
+    # The sdist file 'model_explorer_circle.x.x.x.tar.gz' would be used
+    generated_sdist = os.path.join("dist/", generated_files[0])
 
     session.install(generated_sdist)
 


### PR DESCRIPTION
If there're multiple versions of package in the dist directory, the NOX used the oldest version. 
So, it fixes the NOX script to find the latest version even if there're multiple packages.

