### PR TITLE
[cker] Storage order testing

### DIFF
--- a/compute/cker/include/cker/operation/Helper/BatchMatMulParams.h
+++ b/compute/cker/include/cker/operation/Helper/BatchMatMulParams.h
@@ -23,6 +23,11 @@ namespace nnfw
 {
 namespace cker
 {
+enum StorageOrder
+{
+  RowMajor = 0,
+  ColumnMajor = 1
+};
 struct BatchMatMulParams
 {
   BatchMatMulParams(const Shape &lhs_shape, const Shape &rhs_shape)
@@ -63,6 +68,7 @@ struct BatchMatMulParams
   int rhs_rows;
   int rhs_cols;
   int accum_depth;
+  StorageOrder storage_order;
 
 private:
   // Determines which dimension is the broadcast dimension.

--- a/compute/cker/include/cker/operation/optimized/BatchMatMul.h
+++ b/compute/cker/include/cker/operation/optimized/BatchMatMul.h
@@ -38,12 +38,12 @@ inline void BatchMatMul(const BatchMatMulParams &params, const float *lhs_data,
   lhs_params.cols = params.lhs_cols;
 
   MatrixParams<float> rhs_params;
-  rhs_params.order = Order::kRowMajor;
+  rhs_params.order = params.storage_order == StorageOrder::RowMajor ? Order::kRowMajor : Order::kColMajor;
   rhs_params.rows = params.rhs_rows;
   rhs_params.cols = params.rhs_cols;
 
   MatrixParams<float> dst_params;
-  dst_params.order = Order::kRowMajor;
+  rhs_params.order = params.storage_order == StorageOrder::RowMajor ? Order::kRowMajor : Order::kColMajor;
   dst_params.rows = params.lhs_rows;
   dst_params.cols = params.rhs_cols;
 

--- a/compute/cker/src/BMM.test.cc
+++ b/compute/cker/src/BMM.test.cc
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cker/operation/optimized/BatchMatMul.h"
+
+#include <gtest/gtest.h>
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <Eigen/Core>
+
+static void cker_bmm(benchmark::State &state)
+{
+  nnfw::cker::Shape input_shape1{1, 1, 3, 100, 2000};
+  nnfw::cker::Shape input_shape2{1, 1, 3, 2000, 150};
+  nnfw::cker::Shape output_shape{1, 1, 3, 100, 150};
+
+  std::vector<float> input1;
+  input1.reserve(3 * 100 * 2000);
+  std::generate(std::begin(input1), std::end(input1), []() { return rand(); });
+  std::vector<float> input2;
+  std::generate(std::begin(input2), std::end(input2), []() { return rand(); });
+  input2.reserve(3 * 2000 * 150);
+  std::vector<float> output;
+  output.reserve(3 * 100 * 150);
+
+  nnfw::cker::BatchMatMulParams params{input_shape1, input_shape2};
+  params.storage_order = static_cast<nnfw::cker::StorageOrder>(state.range(0));
+
+  for (auto _ : state)
+    nnfw::cker::optimized::BatchMatMul(params, input1.data(), input2.data(), output.data());
+}
+
+static void eigen_cm(benchmark::State &state)
+{
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> lhs =
+    Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>::Random(1000, 2000);
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> rhs =
+    Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>::Random(2000, 1500);
+
+  for (auto _ : state) 
+    [[maybe_unused]] volatile const auto result = lhs * rhs;
+}
+
+static void eigen_rm(benchmark::State &state)
+{
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> lhs =
+    Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>::Random(1000, 2000);
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> rhs =
+    Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>::Random(2000, 1500);
+
+  for (auto _ : state)
+     [[maybe_unused]] const auto result = lhs * rhs;
+}
+
+static void eigen_mix(benchmark::State &state)
+{
+  const auto common_dim = (rand() % 5000) + 2000;
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> lhs =
+    Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>::Random(5000, common_dim);
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> rhs =
+    Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>::Random(common_dim, 6000);
+
+  for (auto _ : state)
+    [[maybe_unused]] const auto result = lhs * rhs;
+}
+
+BENCHMARK(cker_bmm)->Arg(0)->Name("cker RowMajor")->Unit(benchmark::kMillisecond);
+BENCHMARK(cker_bmm)->Arg(1)->Name("cker ColMajor")->Unit(benchmark::kMillisecond);
+BENCHMARK(eigen_cm)->Name("eigen ColMajor")->Unit(benchmark::kNanosecond);
+BENCHMARK(eigen_rm)->Name("eigen RowMajor")->Unit(benchmark::kNanosecond);
+BENCHMARK(eigen_mix)->Name("eigen RowMajor + ColMajor")->Unit(benchmark::kNanosecond);
+
+TEST(cker_benchmark, bmm_benchmarks) { ::benchmark::RunSpecifiedBenchmarks(); }


### PR DESCRIPTION
Some benchmarking for https://github.com/Samsung/ONE/pull/14238#discussion_r1851466333

I've done some research to verify how things work and here are my most important findings:

## MatrixParams Order field
The `order` field in the MatrixParams class is set by default to "column major" https://github.com/Samsung/ONE/blob/master/compute/cker/include/cker/Types.h#L442. It is then set to different values in particular op contexts, for example here in the FullyConnected op https://github.com/Samsung/ONE/blob/master/compute/cker/include/cker/operation/FullyConnected.h#L80

However when those objects are passed to the optimized Gemm implementation the storage order field is ignored and the implementation always uses the following Eigen configuration https://github.com/Samsung/ONE/blob/master/compute/cker/include/cker/eigen/eigen_gemm_eigen.h#L62-L64 - lhs is parametrized by the "row major" order while rhs and the output use "column major".

I think the MatrixParams order field could be left as default when using this class with the Gemm optimized kernel.

## Performance considerations
I've done some microbenchmarking to see if the storage order changes anything performance-wise and this is in fact how I discovered that the Eigen-based implementation of Gemm ignores this setting.
I've also found the information that the storage order of Eigen matrices does not affect the performance when the Matrix acts like a "view" over the existing data in a C++ array/container. C++ stores the data in row-major format by default and I thought that traversing it in column-major order would affect the performance but apparently with Eigen it does not (I did not dwelve into more details or the implementation to figure out why).
I've also experimented with pure-Eigen matmuls to see how they perform and the results seem to be the same no matter if you multiply in row-major, column-major or mixed way.