### PR TITLE
[compute/cker] Remove the storage order parametrization from BatchMatMul

### DIFF
--- a/compute/cker/include/cker/operation/optimized/BatchMatMul.h
+++ b/compute/cker/include/cker/operation/optimized/BatchMatMul.h
@@ -33,17 +33,14 @@ inline void BatchMatMul(const BatchMatMulParams &params, const float *lhs_data,
                         const float *rhs_data, float *output_data)
 {
   MatrixParams<float> lhs_params;
-  lhs_params.order = Order::kRowMajor;
   lhs_params.rows = params.lhs_rows;
   lhs_params.cols = params.lhs_cols;
 
   MatrixParams<float> rhs_params;
-  rhs_params.order = Order::kRowMajor;
   rhs_params.rows = params.rhs_rows;
   rhs_params.cols = params.rhs_cols;
 
   MatrixParams<float> dst_params;
-  dst_params.order = Order::kRowMajor;
   dst_params.rows = params.lhs_rows;
   dst_params.cols = params.rhs_cols;
 

--- a/compute/cker/include/cker/operation/optimized/BatchMatMul.h
+++ b/compute/cker/include/cker/operation/optimized/BatchMatMul.h
@@ -33,14 +33,17 @@ inline void BatchMatMul(const BatchMatMulParams &params, const float *lhs_data,
                         const float *rhs_data, float *output_data)
 {
   MatrixParams<float> lhs_params;
+  lhs_params.order = Order::kRowMajor; // ignored by GemmImplUsingEigen
   lhs_params.rows = params.lhs_rows;
   lhs_params.cols = params.lhs_cols;
 
   MatrixParams<float> rhs_params;
+  lhs_params.order = Order::kRowMajor; // ignored by GemmImplUsingEigen
   rhs_params.rows = params.rhs_rows;
   rhs_params.cols = params.rhs_cols;
 
   MatrixParams<float> dst_params;
+  lhs_params.order = Order::kRowMajor; // ignored by GemmImplUsingEigen
   dst_params.rows = params.lhs_rows;
   dst_params.cols = params.rhs_cols;
 


### PR DESCRIPTION
This commit removes the obsolete parametrization of the BatchMatMul x86 optimized kernel. The reason is that the storage order attribute of the MatrixParams class is later ignored by the x86 Gemm implementation using Eigen.

ONE-DCO-1.0-Signed-off-by: Tomasz Dolbniak t.dolbniak@partner.samsung.com