### PR TITLE
[onert/odc] Auto-compilation. Minmax threshold and quantization Readiness

### DIFF
--- a/runtime/onert/core/include/odc/IQuantizer.h
+++ b/runtime/onert/core/include/odc/IQuantizer.h
@@ -18,6 +18,7 @@
 #define __ONERT_ODC_IQUANTIZER_H__
 
 #include "odc/QuantizeType.h"
+#include <cstdint>
 
 namespace onert
 {
@@ -30,6 +31,25 @@ public:
   virtual ~IQuantizer() = default;
 
   virtual int quantize(const char *in, const char *out, QuantizeType qtype) = 0;
+
+  /**
+   * @brief Set the number of minmax records enough for quantization
+   */
+  virtual void setMinMaxRecordsThreshold(uint32_t value) = 0;
+
+  /**
+   * @brief Checking the number of minmax records enough for quantization
+   *
+   * @return True if ready, False otherwise
+   */
+  virtual bool readyForQuantize() = 0;
+
+  /**
+   * @brief Delete minmax file
+   *
+   * @return True if there were no errors, False otherwise
+   */
+  virtual bool deleteMinMaxFile() = 0;
 };
 
 } // namespace odc

--- a/runtime/onert/core/include/odc/QuantizeManager.h
+++ b/runtime/onert/core/include/odc/QuantizeManager.h
@@ -69,6 +69,24 @@ public:
    */
   bool quantize(const std::string &model_path);
 
+  /**
+   * @brief Set the number of minmax records enough for quantization
+   * @return    @c true if success, otherwise @c false
+   */
+  bool setMinMaxRecordsThreshold(uint32_t value);
+
+  /**
+   * @brief     checking minmax recording count and threshold for quantization
+   * @return    @c true if ready, otherwise @c false
+   */
+  bool readyForQuantize();
+
+  /**
+   * @brief     Delete MinMax File of on-device compiler
+   * @return    Return true if file removed successfully
+   */
+  bool deleteMinMaxFile();
+
 private:
   std::string _export_model_path = "";
   QuantizeType _qtype = ODC_QTYPE_NOT_SET;

--- a/runtime/onert/core/src/odc/QuantizeManager.cc
+++ b/runtime/onert/core/src/odc/QuantizeManager.cc
@@ -46,5 +46,41 @@ bool QuantizeManager::quantize(const std::string &model_path)
   return (result == 0);
 }
 
+bool QuantizeManager::setMinMaxRecordsThreshold(uint32_t value)
+{
+  auto &quantize_loader = QuantizerLoader::instance();
+  if (quantize_loader.loadLibrary() != 0)
+    return false;
+
+  auto quantizer = quantize_loader.get();
+  quantizer->setMinMaxRecordsThreshold(value);
+
+  return true;
+}
+
+bool QuantizeManager::readyForQuantize()
+{
+  auto &quantize_loader = QuantizerLoader::instance();
+  if (quantize_loader.loadLibrary() != 0)
+    return false;
+
+  auto quantizer = quantize_loader.get();
+  bool result = quantizer->readyForQuantize();
+
+  return result;
+}
+
+bool QuantizeManager::deleteMinMaxFile()
+{
+  auto &quantize_loader = QuantizerLoader::instance();
+  if (quantize_loader.loadLibrary() != 0)
+    return false;
+
+  auto quantizer = quantize_loader.get();
+  bool result = quantizer->deleteMinMaxFile();
+
+  return result;
+}
+
 } // namespace odc
 } // namespace onert

--- a/runtime/onert/odc/MinMaxReader.cc
+++ b/runtime/onert/odc/MinMaxReader.cc
@@ -236,5 +236,23 @@ MinMaxVectors MinMaxReader::readInput(uint32_t model_idx, uint32_t subg_idx,
   return mmv;
 }
 
+uint32_t MinMaxReader::readNumRuns() const
+{
+  // Find file to read
+  auto file = std::fopen(_filepath.c_str(), "rb");
+  if (!file)
+    throw std::runtime_error("Cannot open file: " + _filepath);
+
+  checkHeader(file);
+
+  // Read num_run
+  uint32_t num_run = 0;
+  readMMFile(&num_run, sizeof(uint32_t), 1, file, "Cannot read num_run from file");
+
+  std::fclose(file);
+
+  return num_run;
+}
+
 } // namespace odc
 } // namespace onert

--- a/runtime/onert/odc/MinMaxReader.h
+++ b/runtime/onert/odc/MinMaxReader.h
@@ -72,6 +72,13 @@ public:
    */
   MinMaxVectors readInput(uint32_t model_idx, uint32_t subg_idx, uint32_t input_idx) const;
 
+  /**
+   * @brief Returns minmax recording count
+   *
+   * @return minmax recording count
+   */
+  uint32_t readNumRuns() const;
+
 private:
   std::string _filepath;
 };

--- a/runtime/onert/odc/Quantizer.h
+++ b/runtime/onert/odc/Quantizer.h
@@ -31,6 +31,29 @@ public:
   ~Quantizer() = default;
 
   int quantize(const char *in, const char *out, QuantizeType qtype) override;
+
+  /**
+   * @brief Set the number of minmax records enough for quantization
+   */
+  void setMinMaxRecordsThreshold(uint32_t value) { _minmax_threshold = value; };
+
+  /**
+   * @brief Checking the number of minmax records enough for quantization (comparison with
+   * threshold)
+   *
+   * @return True if ready, False otherwise
+   */
+  bool readyForQuantize() override;
+
+  /**
+   * @brief Delete minmax file
+   *
+   * @return True if there were no errors, False otherwise
+   */
+  bool deleteMinMaxFile() override;
+
+private:
+  uint32_t _minmax_threshold = 0;
 };
 
 } // namespace odc


### PR DESCRIPTION
This PR for `odc: auto-compilation` (hidden switching mechanism) introduces changes in Quantizer, MinMaxReader and QuantizeManager. 
Introduction functions for set up of the minmax threshold and cheсking readiness for quantization. 
Function for removing minmax file also was added.

For [Issue]( https://github.com/Samsung/ONE/issues/13288). 
From [Draft](https://github.com/Samsung/ONE/pull/13530).


ONE-DCO-1.0-Signed-off-by: Evgenii Maltsev e.maltsev@samsung.com