### PR TITLE
[tools/mec] Fix module name in HOWTO

### DIFF
--- a/tools/model_explorer_circle/HOWTO.md
+++ b/tools/model_explorer_circle/HOWTO.md
@@ -12,7 +12,7 @@ pip install -e .
 
 * Execute Model Explorer with Circle adapter extension
 ```
-model-explorer --extensions circle_adapter --no_open_in_browser
+model-explorer --extensions model_explorer_circle --no_open_in_browser
 ```
 
 * Execute Unittest


### PR DESCRIPTION
Since module name was changed from 'circle_adapter' to 'module_explorer_circle',
it also needs to update the extension name in HOWTO.

---

* Related w/ : #14365 