### PR TITLE
[onert/odc] Auto-compilation. Input/output buffers in Execution

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -176,6 +176,20 @@ public:
   size_t getInputTotalSize(ir::IOIndex ind) const;
   size_t getOutputTotalSize(ir::IOIndex ind) const;
 
+  /**
+   * @brief     Get pointer of Input Buffer
+   * @param[in] index     Input index
+   * @return    Pointer of Input Buffer
+   */
+  const void *getInputBuffer(ir::IOIndex ind) const;
+
+  /**
+   * @brief     Get pointer of Output Buffer
+   * @param[in] index     Output index
+   * @return    Pointer of Output Buffer
+   */
+  void *getOutputBuffer(ir::IOIndex ind);
+
   ExecutionOptions &executionOptions() { return _ctx.options; }
 
 private:

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -223,5 +223,15 @@ size_t Execution::getOutputTotalSize(ir::IOIndex ind) const
   return _ctx.desc.outputs.at(ind.value())->info.total_size();
 }
 
+const void *Execution::getInputBuffer(ir::IOIndex ind) const
+{
+  return _ctx.desc.inputs.at(ind.value())->buffer;
+}
+
+void *Execution::getOutputBuffer(ir::IOIndex ind)
+{
+  return _ctx.desc.outputs.at(ind.value())->buffer;
+}
+
 } // namespace exec
 } // namespace onert


### PR DESCRIPTION
This PR for `odc:auto-compilation` introduces OdcInfo structure and input/output buffers in Execution. 

For [Issue]( https://github.com/Samsung/ONE/issues/13288). 
From [Draft](https://github.com/Samsung/ONE/pull/13530).

ONE-DCO-1.0-Signed-off-by: Evgenii Maltsev e.maltsev@samsung.com