### PR TITLE
[luci/pass] Adjust input channel for 3D InstNorm

### DIFF
--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -1075,6 +1075,11 @@ uint32_t PostFusion::input_channel(void)
   if (input_rank < 1)
     return 0;
 
+  if (input_rank == 3)
+  {
+    // use dim 1
+    return input->dim(1).value();
+  }
   // assume channel-last
   return input->dim(input_rank - 1).value();
 }


### PR DESCRIPTION
This will adjust input channel as second dimension for 3D Instance Norm,
in FuseInstanceNormPass.