### PR TITLE
[compute] Remove variable length array

### DIFF
--- a/compute/cker/include/cker/operation/Conv.h
+++ b/compute/cker/include/cker/operation/Conv.h
@@ -122,20 +122,9 @@ public:
     }
 
     int im2col_size = _need_im2col ? _im2col_shape.FlatSize() : 1;
-
-    // Use heap if size is larger than 8MB
-    if (im2col_size > 8 * 1024 * 1024)
-    {
-      std::unique_ptr<uint8_t[]> im2col_data = std::make_unique<uint8_t[]>(im2col_size);
-      optimized::Conv(params, input_shape, input_data, filter_shape, filter_data, bias_shape,
-                      bias_data, output_shape, output_data, _im2col_shape, im2col_data.get());
-    }
-    else
-    {
-      uint8_t im2col_data[im2col_size];
-      optimized::Conv(params, input_shape, input_data, filter_shape, filter_data, bias_shape,
-                      bias_data, output_shape, output_data, _im2col_shape, im2col_data);
-    }
+    std::vector<uint8_t> im2col_data(im2col_size);
+    optimized::Conv(params, input_shape, input_data, filter_shape, filter_data, bias_shape,
+                    bias_data, output_shape, output_data, _im2col_shape, im2col_data.data());
   }
 
   void operator()(const ConvParams &params, const Shape &input_shape, const uint8_t *input_data,

--- a/compute/ruy/include/ruy/operation/Conv.h
+++ b/compute/ruy/include/ruy/operation/Conv.h
@@ -65,19 +65,11 @@ public:
     }
 
     int im2col_size = _need_im2col ? _im2col_shape.FlatSize() : 0;
-
-    // Use heap if size is larger than 8MB
-    if (im2col_size > 2 * 1024 * 1024)
+    std::vector<float> im2col_data(im2col_size);
+    if (im2col_size > 0)
     {
-      std::unique_ptr<float[]> im2col_data = std::make_unique<float[]>(im2col_size);
       ConvFloat(params, input_shape, input_data, filter_shape, filter_data, bias_shape, bias_data,
-                output_shape, output_data, _im2col_shape, im2col_data.get(), ruy_context);
-    }
-    else if (im2col_size > 0)
-    {
-      float im2col_data[im2col_size];
-      ConvFloat(params, input_shape, input_data, filter_shape, filter_data, bias_shape, bias_data,
-                output_shape, output_data, _im2col_shape, im2col_data, ruy_context);
+                output_shape, output_data, _im2col_shape, im2col_data.data(), ruy_context);
     }
     else
     {


### PR DESCRIPTION
This commit changes variable length array to vector in cker and ruy.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

VLA fails on clang 18. (#14385)