### PR TITLE
[DRAFT][tools/mec] Fix the node id error for constant tensor

### DIFF
--- a/tools/model_explorer_circle/src/model_explorer_circle/main.py
+++ b/tools/model_explorer_circle/src/model_explorer_circle/main.py
@@ -172,13 +172,13 @@ class CircleAdapter(Adapter):
         # Create pseudo const node for orphan tensors (= const tensors)
         for tensor_id, tensor in enumerate(sub_graph.tensors):
             if (self.get_source_of(tensor_id)) is None:
-                me_node = graph_builder.GraphNode(id=f'{input_id + tensor_id}',
+                me_node = graph_builder.GraphNode(id=f'{input_id + tensor_id + 1}',
                                                   label='pseudo_const',
                                                   namespace=tensor.name.decode('utf-8'))
                 me_graph.nodes.append(me_node)
                 # Map source and output tensors of const tensor
                 self.set_source_of(tensor_id=tensor_id,
-                                   source_id=input_id + tensor_id,
+                                   source_id=input_id + tensor_id + 1,
                                    output_id=0)
                 # Add output metadata to the pseudo const node
                 self.add_output_tensor_info(me_node=me_node, tensor_id=tensor_id)

--- a/tools/model_explorer_circle/src/model_explorer_circle/main.py
+++ b/tools/model_explorer_circle/src/model_explorer_circle/main.py
@@ -170,7 +170,7 @@ class CircleAdapter(Adapter):
                 self.set_source_of(tensor_id=tensor_id, source_id=op_id, output_id=i)
 
         # Create pseudo const node for orphan tensors (= const tensors)
-        for tensor_id, tensor in enumerate(sub_graph.tensors, start=1):
+        for tensor_id, tensor in enumerate(sub_graph.tensors):
             if (self.get_source_of(tensor_id)) is None:
                 me_node = graph_builder.GraphNode(id=f'{input_id + tensor_id}',
                                                   label='pseudo_const',


### PR DESCRIPTION
This draft PR is not queit set of commits for verification of implementation,
but to show the commit series that will be applied to correct previous mistakes.

- Previous faulty PR (already merged) : #14393 
- Why is it imcomplete fix?
  - Range of node ids in ModelExplorer Graph
     - **Operator nodes** : $` 0 \le id < \#\_of\_Operators `$
     - **Global inputs node** : $`id = \#\_of\_Operators `$
     - **Constant tensor node** : $` (\#\_of\_Operators) + 1 \le id < (\#\_of\_Operators + \#\_of\_Constant\_tensors)`$
     - **Global outputs node** : $`id = \#\_of\_total\_nodes`$
   - In previous PR, node id of constant tensor was defined as expected as above range.
   - However, while it creates map between tensor's id (not node id) and source, it used wrong index (= expected + 1) which is not intended.
     ```cpp
        # Create pseudo const node for orphan tensors (= const tensors)
        for tensor_id, tensor in enumerate(sub_graph.tensors, start=1):
            if (self.get_source_of(tensor_id)) is None:
                me_node = graph_builder.GraphNode(id=f'{input_id + tensor_id}',        // Correct
                                                  label='pseudo_const',
                                                  namespace=tensor.name.decode('utf-8'))
                me_graph.nodes.append(me_node)
                # Map source and output tensors of const tensor
                self.set_source_of(tensor_id=tensor_id,         // Wrong
                                   source_id=input_id + tensor_id,
                                   output_id=0)
     ```
   - As a result, the edge connection was made wrong and exceptions were raised.