### PR TITLE
[onert] Clean up header include in nnfw_api_internal

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -15,34 +15,30 @@
  */
 
 #include "nnfw_api_internal.h"
-#include "CustomKernelRegistry.h"
+
 #include "compiler/CompilerFactory.h"
-#include "util/ConfigSource.h"
-#include "util/Exceptions.h"
-#include "util/logging.h"
-#include "exec/Execution.h"
+#include "exporter/CircleExporter.h"
+#include "exporter/train/CheckpointExporter.h"
+#include "ir/OpCode.h"
+#include "json/json.h"
 #include "loader/CircleLoader.h"
 #include "loader/ModelLoader.h"
 #include "loader/TFLiteLoader.h"
 #include "loader/TrainInfoLoader.h"
 #include "loader/train/CheckpointLoader.h"
-#include "exporter/CircleExporter.h"
-#include "exporter/train/CheckpointExporter.h"
-#include "json/json.h"
-#include "ir/NNPkg.h"
-#include "ir/OpCode.h"
-#include "ir/train/TrainingInfo.h"
+#include "util/ConfigSource.h"
+#include "util/Exceptions.h"
+#include "util/logging.h"
 #include "util/TracingCtx.h"
-#include "odc/QuantizeManager.h"
-#include "odc/CodegenManager.h"
 
+#include <misc/string_helpers.h>
+
+#include <dirent.h>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
-#include <dirent.h>
-#include <misc/string_helpers.h>
 
 /*
  * API does not accept string argument longer than max length below

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -20,45 +20,21 @@
 #include "nnfw.h"
 #include "nnfw_experimental.h"
 
+#include "CustomKernelRegistry.h"
+#include "compiler/CompilerOptions.h"
+#include "compiler/ICompiler.h"
+#include "exec/Execution.h"
+#include "ir/NNPkg.h"
+#include "ir/train/TrainingInfo.h"
+#include "odc/CodegenManager.h"
+#include "odc/QuantizeManager.h"
+
 #include <util/TracingCtx.h>
 
-#include <string>
 #include <memory>
+#include <string>
 #include <thread>
 #include <vector>
-
-namespace onert
-{
-namespace api
-{
-class CustomKernelRegistry;
-} // namespace api
-namespace exec
-{
-class Execution;
-struct ExecutionOptions;
-} // namespace exec
-namespace ir
-{
-struct IGraph;
-class Model;
-class NNPkg;
-namespace train
-{
-class TrainingInfo;
-}
-} // namespace ir
-namespace compiler
-{
-struct CompilerArtifact;
-struct CompilerOptions;
-} // namespace compiler
-namespace odc
-{
-class QuantizeManager;
-class CodegenManager;
-} // namespace odc
-} // namespace onert
 
 struct nnfw_session
 {


### PR DESCRIPTION
This commit cleans up header includes in nnfw_api_internal.h/cc.
- Reorder includes
- Remove class/struct declaration in nnfw_api_internal.h
  - Use header include because it is not public header

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>