### PR TITLE
[onert] Use filesystem path for model path

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -31,6 +31,7 @@
 
 #include <util/TracingCtx.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <thread>
@@ -211,7 +212,7 @@ private:
   //     const char *path;
   //     const uint8 *buf;
   //   }
-  std::string _model_path;
+  std::filesystem::path _model_path;
 };
 
 #endif // __API_NNFW_API_INTERNAL_H__


### PR DESCRIPTION
This commit updates nnfw_api_internal to use filesystem path for model path.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>