### PR TITLE
[onert/odc] Auto-compilation. Add nnfw_run_with_auto_compilation method.

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -558,6 +558,58 @@ NNFW_STATUS nnfw_set_codegen_model_path(nnfw_session *session, const char *path)
  */
 NNFW_STATUS nnfw_codegen(nnfw_session *session, const char *target, NNFW_CODEGEN_PREF pref);
 
+/**
+ * @brief  Set MinMax records count in auto compilation mode with on-device compiler
+ *
+ * This function set MinMax records count for quantization in auto compilation mode.
+ * To enable automatic compilation mode, use  {@link nnfw_run_with_auto_compilation}
+ *
+ * @param[in] session nnfw_session
+ * @param[in] minmax_records_count    minmax records count
+ * @return    @c NNFW_STATUS_NO_ERROR if successful, otherwise return @c NNFW_STATUS_ERROR
+ */
+NNFW_STATUS nnfw_set_odc_param_minmax_records_count(nnfw_session *session,
+                                                    int minmax_records_count);
+
+/**
+ * @brief  Delete MinMax file for on-device compiler
+ *
+ * @param[in] session nnfw_session
+ * @return    @c NNFW_STATUS_NO_ERROR if successful, otherwise return @c NNFW_STATUS_ERROR
+ */
+NNFW_STATUS nnfw_odc_delete_minmax_file(nnfw_session *session);
+
+/**
+ * @brief  Run inference with auto compilation
+ *
+ * <p>This function runs inference with automatic compilation and replaces
+ *  the original model with a quantized or compiled model inside.
+ * During the inference the minmax statistics is collected and after that quantization is performed.
+ * If quantization was successful, try to code generating for target backend, otherwise run original
+ float model.
+ * If compilation was successful, run compiled model, otherwise run quantized model.
+ * On-device compiler (ODC) provides quantization and compilation functionality.
+ * Function should be called after model is loaded by {@link nnfw_load_model_from_file},
+ * session is prepared for inference by {@link nnfw_prepare}, set input and output buffers
+ * by {@link nnfw_set_input} and {@link nnfw_set_output}.
+ *
+ * Additionally the following parameters should be set up :
+ * 1. Quantization type {@link nnfw_set_quantization_type }
+ * 2. Quantizated model path {@link  nnfw_set_quantized_model_path }
+ * 3. Minmax records threshold for quantization {@link nnfw_set_odc_param_minmax_records_count }
+ * 3. File with minMax statistics can be removed by {@link nnfw_odc_delete_minmax_file}
+ * 4. Compiled model path {@link  nnfw_set_codegen_model_path}
+ * </p>
+ *
+ * @param[in] session nnfw_session
+ * @param[in] target  Target backend to generate code as in {@link nnfw_codegen}
+ * @param[in] pref @c NNFW_CODEGEN_PREF
+
+ * @return    @c NNFW_STATUS_NO_ERROR if successful, otherwise return @c NNFW_STATUS_ERROR
+ */
+NNFW_STATUS nnfw_run_with_auto_compilation(nnfw_session *session, const char *target,
+                                           NNFW_CODEGEN_PREF pref);
+
 //////////////////////////////////////////////
 // APIs for configuration
 //////////////////////////////////////////////

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -508,6 +508,25 @@ NNFW_STATUS nnfw_codegen(nnfw_session *session, const char *target, NNFW_CODEGEN
   return session->codegen(target, pref);
 }
 
+NNFW_STATUS nnfw_set_odc_param_minmax_records_count(nnfw_session *session, int minmax_records_count)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_odc_param_minmax_records_count(minmax_records_count);
+}
+
+NNFW_STATUS nnfw_odc_delete_minmax_file(nnfw_session *session)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->delete_odc_minmax_file();
+}
+
+NNFW_STATUS nnfw_run_with_auto_compilation(nnfw_session *session, const char *target,
+                                           NNFW_CODEGEN_PREF pref)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->run_with_auto_compilation(target, pref);
+}
+
 // Configuration
 
 NNFW_STATUS nnfw_set_prepare_config(nnfw_session *session, const NNFW_PREPARE_CONFIG key,

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -86,6 +86,13 @@ private:
     FINISHED_TRAINING  //< Trained at least once
   };
 
+  enum class AutoCompilationState
+  {
+    INITIAL_STATE,          //< Initial state
+    QUANTIZED_MODEL_LOADED, //< Qunatized model is loaded
+    COMPILED_MODEL_LOADED   //< Compiled model is loaded
+  };
+
 public:
   /**
    * @brief Factory method. It creates and initialize nnfw_session
@@ -141,6 +148,14 @@ public:
   NNFW_STATUS register_custom_operation(const std::string &id, nnfw_custom_eval eval_func);
   NNFW_STATUS input_tensorindex(const char *tensorname, uint32_t *index);
   NNFW_STATUS output_tensorindex(const char *tensorname, uint32_t *index);
+
+  // Run inference with auto compilation
+  NNFW_STATUS run_with_auto_compilation(const char *target, NNFW_CODEGEN_PREF pref);
+  // Set odc parameter: minmax_records_count for quantization in auto compilation mode
+  NNFW_STATUS set_odc_param_minmax_records_count(int minmax_records_count);
+  // delete MinMax File of on-device compiler
+  NNFW_STATUS delete_odc_minmax_file();
+
   /**
    * @brief   Set backends with string-encoded mapping from operation index to backend type
    *          (cpu, acl_cl)
@@ -203,6 +218,7 @@ private:
   std::unique_ptr<onert::ir::train::TrainingInfo> _train_info;
   std::unique_ptr<onert::odc::QuantizeManager> _quant_manager;
   std::unique_ptr<onert::odc::CodegenManager> _codegen_manager;
+  AutoCompilationState _autoCompilationState = AutoCompilationState::INITIAL_STATE;
   // Remember path to loaded original model
   // It may be used for on-device compiler / on-device training.
   //


### PR DESCRIPTION
This PR for `odc:auto-compilation` introduces `nnfw_run_with_auto_compilation`,`nnfw_odc_delete_minmax_file` and `nnfw_set_odc_param_minmax_records_count` methods to NNFW API. 

For [Issue]( https://github.com/Samsung/ONE/issues/13288). 
From [Draft](https://github.com/Samsung/ONE/pull/13530).

ONE-DCO-1.0-Signed-off-by: Evgenii Maltsev e.maltsev@samsung.com