### PR TITLE
[onert] Relocate API functions

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-#include "nnfw_api_internal.h"
+#include "nnfw.h"
+#include "nnfw_experimental.h"
 #include "nnfw_version.h"
+
+#include "nnfw_session.h"
 
 // Double-check enum value changes
 
@@ -334,18 +337,6 @@ NNFW_STATUS nnfw_query_info_u32(nnfw_session *session, NNFW_INFO_ID id, uint32_t
   return NNFW_STATUS_ERROR;
 }
 
-NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer, size_t size)
-{
-  NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->load_circle_from_buffer(buffer, size);
-}
-
-NNFW_STATUS nnfw_load_model_from_modelfile(nnfw_session *session, const char *file_path)
-{
-  NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->load_model_from_modelfile(file_path);
-}
-
 NNFW_STATUS nnfw_input_tensorindex(nnfw_session *session, const char *tensorname, uint32_t *index)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
@@ -456,12 +447,6 @@ NNFW_STATUS nnfw_train_export_circle(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->train_export_circle(path);
-}
-
-NNFW_STATUS nnfw_train_export_circleplus(nnfw_session *session, const char *path)
-{
-  NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_export_circleplus(path);
 }
 
 NNFW_STATUS nnfw_train_import_checkpoint(nnfw_session *session, const char *path)

--- a/runtime/onert/api/nnfw/src/nnfw_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_internal.cc
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-#include "nnfw_api_internal.h"
+#include "nnfw_internal.h"
+
+#include "nnfw_session.h"
 
 #include <util/ConfigSource.h>
 
@@ -35,4 +37,22 @@ NNFW_STATUS nnfw_get_config(nnfw_session *session, const char *key, char *value,
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->get_config(key, value, value_size);
+}
+
+NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer, size_t size)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->load_circle_from_buffer(buffer, size);
+}
+
+NNFW_STATUS nnfw_load_model_from_modelfile(nnfw_session *session, const char *file_path)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->load_model_from_modelfile(file_path);
+}
+
+NNFW_STATUS nnfw_train_export_circleplus(nnfw_session *session, const char *path)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->train_export_circleplus(path);
 }

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "nnfw_api_internal.h"
+#include "nnfw_session.h"
 
 #include "compiler/CompilerFactory.h"
 #include "exporter/CircleExporter.h"

--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-#ifndef __API_NNFW_API_INTERNAL_H__
-#define __API_NNFW_API_INTERNAL_H__
+#ifndef __API_NNFW_SESSION_H__
+#define __API_NNFW_SESSION_H__
 
 #include "nnfw.h"
-#include "nnfw_experimental.h"
 
 #include "CustomKernelRegistry.h"
 #include "compiler/CompilerOptions.h"
@@ -231,4 +230,4 @@ private:
   std::filesystem::path _model_path;
 };
 
-#endif // __API_NNFW_API_INTERNAL_H__
+#endif // __API_NNFW_SESSION_H__


### PR DESCRIPTION
This commit relocates API functions
- Rename internal API implementation file from nnfw_debug.cc to nnfw_internal.cc
- Move some internal API implementation to src/nnfw_internal.cc
- Rename nnfw_api_internal.h/cc to nnfw_session.h/cc

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>