### PR TITLE
[tools/mec] Check if a scale of quantization is None

### DIFF
--- a/tools/model_explorer_circle/src/model_explorer_circle/main.py
+++ b/tools/model_explorer_circle/src/model_explorer_circle/main.py
@@ -148,7 +148,7 @@ class CircleAdapter(Adapter):
         )
 
         # Quantization parameter (if exists)
-        if tensor.quantization:
+        if tensor.quantization and tensor.quantization.scale is not None:
             quantparam = '['
             for i, scale in enumerate(tensor.quantization.scale):
                 if i != 0:


### PR DESCRIPTION
It adds sanitizer code for a model which have quantization parmeters but scale is not intialized.
