### PR TITLE
[tools/mec] Rename the shape in output metadata

### DIFF
--- a/tools/model_explorer_circle/src/model_explorer_circle/main.py
+++ b/tools/model_explorer_circle/src/model_explorer_circle/main.py
@@ -141,7 +141,7 @@ class CircleAdapter(Adapter):
         metadata = graph_builder.MetadataItem(
             id=f'{output_id}',
             attrs=[
-                graph_builder.KeyValue(key='shape', value=tensor_shape),
+                graph_builder.KeyValue(key='tensor_shape', value=tensor_shape),
                 graph_builder.KeyValue(key='tensor_index', value=f'{tensor_id}'),
                 graph_builder.KeyValue(key='tensor_name', value=tensor_name)
             ],


### PR DESCRIPTION
It changes the name of shape key in output metadata to 'tensor_shape' following the tensorflow's.
