### PR TITLE
[infra/onert] Add tizen arm build fp16 flag

### DIFF
--- a/infra/nnfw/cmake/buildtool/config/config_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7hl-tizen.cmake
@@ -20,4 +20,5 @@ set(FLAGS_COMMON ${FLAGS_COMMON}
     "-mfpu=neon-vfpv4"
     "-funsafe-math-optimizations"
     "-ftree-vectorize"
+    "-mfp16-format=ieee"
     )

--- a/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
@@ -20,4 +20,5 @@ set(FLAGS_COMMON ${FLAGS_COMMON}
     "-mfpu=neon-vfpv4"
     "-funsafe-math-optimizations"
     "-ftree-vectorize"
+    "-mfp16-format=ieee"
     )


### PR DESCRIPTION
This commit adds 'mfp16-format=ieee' for tizen arm build.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>