### PR TITLE
[onert/ggml] Don't specify arch on armv7l linux build

### DIFF
--- a/runtime/3rdparty/ggml/src/CMakeLists.txt
+++ b/runtime/3rdparty/ggml/src/CMakeLists.txt
@@ -1097,8 +1097,10 @@ if (CMAKE_OSX_ARCHITECTURES      STREQUAL "arm64" OR
                 # Android armeabi-v7a
                 list(APPEND ARCH_FLAGS -mfpu=neon-vfpv4 -mno-unaligned-access -funsafe-math-optimizations)
             else()
-                # Raspberry Pi 2
+                # [FIX] remove the assumption of RPI2 here
+                # That is, `-mfpu=neon-fp-armv8` is removed.
                 list(APPEND ARCH_FLAGS -mno-unaligned-access -funsafe-math-optimizations)
+                # end of [FIX]
             endif()
         endif()
         if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv8")

--- a/runtime/3rdparty/ggml/src/CMakeLists.txt
+++ b/runtime/3rdparty/ggml/src/CMakeLists.txt
@@ -1098,7 +1098,7 @@ if (CMAKE_OSX_ARCHITECTURES      STREQUAL "arm64" OR
                 list(APPEND ARCH_FLAGS -mfpu=neon-vfpv4 -mno-unaligned-access -funsafe-math-optimizations)
             else()
                 # Raspberry Pi 2
-                list(APPEND ARCH_FLAGS -mfpu=neon-fp-armv8 -mno-unaligned-access -funsafe-math-optimizations)
+                list(APPEND ARCH_FLAGS -mno-unaligned-access -funsafe-math-optimizations)
             endif()
         endif()
         if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv8")


### PR DESCRIPTION
It removes the specific arch on ggml cross armv7l linux build. Previously, ggml specifies -mfpu=neon-fp-armv8, which may cause illegal instruction signal during running ggml_quantize_row_q8_0, especially compiled with gcc-13 -On, where n = 1,2,3 on odroid xu4. (ARMv7 Cortex-A15).

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #14391 