### PR TITLE
[infra/onert] Cleanup cmake option for onert project

### DIFF
--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -12,22 +12,25 @@ include("cmake/options/options_${TARGET_PLATFORM}.cmake")
 #
 option(ENABLE_STRICT_BUILD "Treat warning as error" ON)
 option(ENABLE_COVERAGE "Build for coverage test" OFF)
-option(BUILD_EXT_MULTITHREAD "Build external build using multi thread" ON)
-option(BUILD_ONERT "Build onert" ON)
+
+#
+# Default build configuration for runtime
+#
+option(BUILD_TRIX_LOADER "Build trix loader" ON)
+option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" ON)
+
+#
+# Default build configuration for tests
+#
 option(BUILD_RUNTIME_NNAPI_TEST "Build Runtime NN API Generated Test" ON)
 option(BUILD_RUNTIME_NNFW_API_TEST "Build Runtime NNFW API Tests" ON)
-option(BUILD_TFLITE_RUN "Build tflite-run" ON)
-option(BUILD_TFLITE_VANILLA_RUN "Build tflite-vanilla-run" OFF)
-option(BUILD_ONERT_RUN "Build onert_run" ON)
-option(BUILD_ONERT_TRAIN "Build onert_train" ON)
-option(BUILD_TFLITE_LOADER "Build TensorFlow Lite loader" ON)
-option(BUILD_CIRCLE_LOADER "Build circle loader" ON)
-option(BUILD_TRIX_LOADER "Build trix loader" ON)
-option(BUILD_TFLITE_COMPARATOR_TEST_TOOL "Build tflite loader testing tool" ON)
+option(BUILD_TFLITE_RUN "Build tflite_run test driver" ON)
+option(BUILD_ONERT_RUN "Build onert_run test driver" ON)
+option(BUILD_ONERT_TRAIN "Build onert_train test driver" ON)
+option(BUILD_TFLITE_COMPARATOR_TEST_TOOL "Build testing tool to compare runtime result with TFLite" ON)
 option(BUILD_WITH_HDF5 "Build test tool with HDF5 library" ON)
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" ON)
-option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" ON)
-option(INSTALL_TEST_SCRIPTS "Install test scripts" ON)
+
 #
 # Default build configuration for contrib
 #

--- a/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
+++ b/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
@@ -134,7 +134,7 @@ function(_ARMCompute_Build ARMComputeInstall_DIR)
     ProcessorCount(N)
   endif(DEFINED EXTERNALS_BUILD_THREADS)
 
-  if((NOT N EQUAL 0) AND BUILD_EXT_MULTITHREAD)
+  if(NOT N EQUAL 0)
     list(APPEND SCONS_OPTIONS -j${N})
   endif()
   if(DEFINED BUILD_ARCH)

--- a/runtime/onert/CMakeLists.txt
+++ b/runtime/onert/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(NOT BUILD_ONERT)
-  return()
-endif(NOT BUILD_ONERT)
-
 add_subdirectory(api)
 add_subdirectory(backend)
 add_subdirectory(core)

--- a/tests/custom_op/CMakeLists.txt
+++ b/tests/custom_op/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(NOT BUILD_ONERT)
-  return()
-endif(NOT BUILD_ONERT)
-
 nnfw_find_package(FlatBuffers EXACT 23.5.26 QUIET)
 if(NOT FlatBuffers_FOUND)
   message(STATUS "Skip build custom operation test: cannot find flatbuffers")

--- a/tests/nnapi/CMakeLists.txt
+++ b/tests/nnapi/CMakeLists.txt
@@ -2,11 +2,6 @@ if (NOT BUILD_RUNTIME_NNAPI_TEST)
   return()
 endif(NOT BUILD_RUNTIME_NNAPI_TEST)
 
-if (NOT BUILD_ONERT)
-  message(STATUS "Skip build NNAPI test: no runtime build")
-  return()
-endif(NOT BUILD_ONERT)
-
 nnfw_find_package(GTest)
 
 set(GENERATED_CPPS "${CMAKE_CURRENT_SOURCE_DIR}/src/generated/all_generated_V1_2_cts_tests.cpp"

--- a/tests/nnfw_api/CMakeLists.txt
+++ b/tests/nnfw_api/CMakeLists.txt
@@ -2,11 +2,6 @@ if (NOT BUILD_RUNTIME_NNFW_API_TEST)
   return()
 endif(NOT BUILD_RUNTIME_NNFW_API_TEST)
 
-if (NOT BUILD_ONERT)
-  message(STATUS "Skip build NNFW API test: no runtime build")
-  return()
-endif(NOT BUILD_ONERT)
-
 nnfw_find_package(GTest)
 
 set(RUNTIME_NNFW_API_TEST nnfw_api_gtest)

--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(NOT INSTALL_TEST_SCRIPTS)
-  return()
-endif(NOT INSTALL_TEST_SCRIPTS)
-
 # Install test driver
 file(GLOB TEST_DRIVER_SCRIPT onert-test)
 install(PROGRAMS ${TEST_DRIVER_SCRIPT} DESTINATION test)

--- a/tests/tools/onert_run/CMakeLists.txt
+++ b/tests/tools/onert_run/CMakeLists.txt
@@ -2,10 +2,6 @@ if(NOT BUILD_ONERT_RUN)
   return()
 endif(NOT BUILD_ONERT_RUN)
 
-if(NOT BUILD_ONERT)
-  return()
-endif(NOT BUILD_ONERT)
-
 list(APPEND ONERT_RUN_SRCS "src/onert_run.cc")
 list(APPEND ONERT_RUN_SRCS "src/args.cc")
 list(APPEND ONERT_RUN_SRCS "src/nnfw_util.cc")

--- a/tests/tools/onert_train/CMakeLists.txt
+++ b/tests/tools/onert_train/CMakeLists.txt
@@ -2,10 +2,6 @@ if(NOT BUILD_ONERT_TRAIN)
   return()
 endif(NOT BUILD_ONERT_TRAIN)
 
-if(NOT BUILD_ONERT)
-  return()
-endif(NOT BUILD_ONERT)
-
 list(APPEND ONERT_TRAIN_SRCS "src/onert_train.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/args.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/nnfw_util.cc")

--- a/tests/tools/tflite_comparator/CMakeLists.txt
+++ b/tests/tools/tflite_comparator/CMakeLists.txt
@@ -3,11 +3,6 @@ if(NOT BUILD_TFLITE_COMPARATOR_TEST_TOOL)
   return()
 endif(NOT BUILD_TFLITE_COMPARATOR_TEST_TOOL)
 
-if(NOT BUILD_ONERT)
-  message("skipping tflite comparator tool build: onert is not built")
-  return()
-endif(NOT BUILD_ONERT)
-
 list(APPEND SOURCES "src/tflite_comparator.cc")
 list(APPEND SOURCES "src/args.cc")
 


### PR DESCRIPTION
- Split category: project -> project, runtime, test
- Remove unused option: BUILD_TFLITE_VANILLA_RUN, BUILD_TFLITE_LOADER, BUILD_CIRCLE_LOADER
- Remove BUILD_EXT_MULTITHREAD
  - Use multithread if EXTERNALS_BUILD_THREADS is set and value is not 1
- Remove INSTALL_TEST_SCRIPTS: always install test scripts
- Fix help text

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>