### PR TITLE
[infra/onert] Change minimal app build condition

### DIFF
--- a/infra/debian/runtime/rules
+++ b/infra/debian/runtime/rules
@@ -18,7 +18,7 @@ override_dh_auto_build:
 	mkdir -p $(NNFW_WORKSPACE)
 	./nnfw configure -DCMAKE_BUILD_TYPE=Release -DEXTERNALS_BUILD_THREADS=$(NPROC) \
 	  -DDOWNLOAD_GTEST=OFF -DENABLE_TEST=OFF \
-		-DBUILD_PYTHON_BINDING=OFF
+		-DBUILD_PYTHON_BINDING=OFF -DBUILD_MINIMAL_SAMPLE=OFF
 	./nnfw build -j$(NPROC)
 override_dh_auto_install:
 	./nnfw install --prefix $(NNFW_INSTALL_PREFIX) --strip

--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -94,4 +94,4 @@ option(HDF5_USE_STATIC_LIBRARIES "Determine whether or not static linking for HD
 #
 ## Default sample build configuration
 #
-option(BUILD_MINIMAL_SAMPLE "Build minimal app" OFF)
+option(BUILD_MINIMAL_SAMPLE "Build minimal app" ON)

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -87,12 +87,6 @@ Summary: NNFW On-Device Compilation Package
 NNFW package for on-device compilation
 %endif # odc_build
 
-%package minimal-app
-Summary: Minimal test binary for VD manual test
-
-%description minimal-app
-Minimal test binary for VD manual test
-
 %if %{test_build} == 1
 %package test
 Summary: NNFW Test
@@ -157,7 +151,7 @@ If you want to get coverage info, you should install runtime package which is bu
 %endif # coverage_build
 
 %define build_options -DCMAKE_BUILD_TYPE=%{build_type} -DTARGET_ARCH=%{target_arch} -DTARGET_OS=tizen \\\
-        -DEXTERNALS_BUILD_THREAD=%{nproc} -DBUILD_MINIMAL_SAMPLE=ON -DNNFW_OVERLAY_DIR=$(pwd)/%{overlay_path} \\\
+        -DEXTERNALS_BUILD_THREAD=%{nproc} -DBUILD_MINIMAL_SAMPLE=OFF -DNNFW_OVERLAY_DIR=$(pwd)/%{overlay_path} \\\
         %{option_test} %{option_coverage} %{option_config} %{extra_option}
 
 %define strip_options %{nil}
@@ -235,7 +229,6 @@ install -m 644 build/out/lib/*.so %{buildroot}%{_libdir}
 install -m 644 build/out/lib/nnfw/*.so %{buildroot}%{_libdir}/nnfw/
 install -m 644 build/out/lib/nnfw/backend/*.so %{buildroot}%{_libdir}/nnfw/backend
 install -m 644 build/out/lib/nnfw/loader/*.so %{buildroot}%{_libdir}/nnfw/loader
-install -m 755 build/out/bin/onert-minimal-app %{buildroot}%{_bindir}
 cp -r build/out/include/* %{buildroot}%{_includedir}/
 
 # For developer
@@ -323,13 +316,6 @@ install -m 644 build/out/lib/nnfw/odc/*.so %{buildroot}%{_libdir}/nnfw/odc
 %{_includedir}/onert/*
 %{_libdir}/pkgconfig/nnfw-plugin.pc
 %{_libdir}/pkgconfig/onert-plugin.pc
-%endif
-
-%ifarch arm armv7l armv7hl aarch64 x86_64 %ix86 riscv64
-%files minimal-app
-%manifest %{name}.manifest
-%defattr(-,root,root,-)
-%{_bindir}/onert-minimal-app
 %endif
 
 %if %{test_build} == 1

--- a/runtime/onert/sample/minimal/CMakeLists.txt
+++ b/runtime/onert/sample/minimal/CMakeLists.txt
@@ -5,6 +5,6 @@ endif(NOT BUILD_MINIMAL_SAMPLE)
 list(APPEND MINIMAL_SRCS "src/minimal.cc")
 
 add_executable(onert-minimal-app ${MINIMAL_SRCS})
-target_link_libraries(onert-minimal-app nnfw-dev pthread dl)
+target_link_libraries(onert-minimal-app nnfw-dev)
 
 install(TARGETS onert-minimal-app DESTINATION bin)


### PR DESCRIPTION
This commit change minimal app build condition
- Enable build as default to check build error in CI
- Disable build on debian/rpm packaging

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>