### PR TITLE
[infra/onert] Remove BUILD_TFLITE_ACCURACY

### DIFF
--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -48,12 +48,13 @@ option(BUILD_TENSORFLOW_LITE_GPU "Build TensorFlow Lite GPU delegate from the do
 option(BUILD_NPUD "Build NPU daemon" OFF)
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
 option(BUILD_LOGGING "Build logging runtime" OFF)
+
 #
 # Default build configuration for tools
 #
 option(BUILD_KBENCHMARK "Build kernel benchmark tool" OFF)
 option(BUILD_OPENCL_TOOL "Build OpenCL tool" OFF)
-option(BUILD_TFLITE_ACCURACY "Build tflite accuracy tool" OFF)
+
 #
 # Default external libraries source download and build configuration
 #


### PR DESCRIPTION
This commit removes BUILD_TFLITE_ACCURACY option.
It is not used anymore.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>