### PR TITLE
[infra/cmake] Introduce DISABLE_EXTERNAL_WARNING option

### DIFF
--- a/infra/cmake/modules/ExternalProjectTools.cmake
+++ b/infra/cmake/modules/ExternalProjectTools.cmake
@@ -1,5 +1,11 @@
 macro(add_extdirectory DIR TAG)
   cmake_parse_arguments(ARG "EXCLUDE_FROM_ALL" "" "" ${ARGN})
+
+  # Disable warning messages from external source code
+  if(DISABLE_EXTERNAL_WARNING)
+    add_compile_options(-w)
+  endif(DISABLE_EXTERNAL_WARNING)
+
   if(ARG_EXCLUDE_FROM_ALL)
     add_subdirectory(${DIR} "${CMAKE_BINARY_DIR}/externals/${TAG}" EXCLUDE_FROM_ALL)
   else(ARG_EXCLUDE_FROM_ALL)


### PR DESCRIPTION
This commit introduces DISABLE_EXTERNAL_WARNING option. 
It is used to disable warnings from external library build.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>