### PR TITLE
[infra/nncc] Fix strict build fail by overloaded-virtual

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -116,8 +116,8 @@ include("cmake/ApplyCompileFlags.cmake")
 ###
 add_library(nncc_common INTERFACE)
 if(ENABLE_STRICT_BUILD)
-  # TODO Remove -Wno-reoder
-  target_compile_options(nncc_common INTERFACE -Werror -Wall -Wextra -Wno-reorder)
+  # TODO Remove -Wno-reoder and -Wno-overloaded-virtual
+  target_compile_options(nncc_common INTERFACE -Werror -Wall -Wextra -Wno-reorder -Wno-overloaded-virtual)
 endif(ENABLE_STRICT_BUILD)
 
 add_library(nncc_coverage INTERFACE)


### PR DESCRIPTION
This commit adds '-Wno-overloaded-virtual' to the strict build for workaround in gcc 13.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>