### PR TITLE
[arser] Reorder name field

### DIFF
--- a/compiler/arser/include/arser/arser.h
+++ b/compiler/arser/include/arser/arser.h
@@ -309,7 +309,7 @@ public:
 
 private:
   // The '_names' vector contains all of the options specified by the user.
-  // And among them, '_long_name' and '_short_name' are selected.
+  // And among them, '_short_name' and '_long_name' are selected.
   std::string _short_name;
   std::string _long_name;
   std::vector<std::string> _names;

--- a/compiler/arser/include/arser/arser.h
+++ b/compiler/arser/include/arser/arser.h
@@ -310,8 +310,8 @@ public:
 private:
   // The '_names' vector contains all of the options specified by the user.
   // And among them, '_long_name' and '_short_name' are selected.
-  std::string _long_name;
   std::string _short_name;
+  std::string _long_name;
   std::vector<std::string> _names;
   std::string _type = "string";
   std::vector<std::string> _help_message;


### PR DESCRIPTION
This commit reorders the name field to follow constructor initialization order.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #14450 #14440