### PR TITLE
[infra/onert] Turn off warning from external

### DIFF
--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -11,6 +11,7 @@ include("cmake/options/options_${TARGET_PLATFORM}.cmake" OPTIONAL)
 # Default build configuration for project
 #
 option(ENABLE_STRICT_BUILD "Treat warning as error" ON)
+option(DISABLE_EXTERNAL_WARNING "Disable warnings from external libraries compile" ON)
 option(ENABLE_COVERAGE "Build for coverage test" OFF)
 
 #


### PR DESCRIPTION
This commit set cmake option "DISABLE_EXTERNAL_WARNING" to turn off warning from external.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #14440 