### PR TITLE
[onert/test] Use file loading API for test

### DIFF
--- a/tests/nnfw_api/src/OdcAutoCompilation.test.cc
+++ b/tests/nnfw_api/src/OdcAutoCompilation.test.cc
@@ -60,7 +60,7 @@ TEST(TestOdcAutoCompilation, AutoCompilation_test)
   nnfw_session *session = nullptr;
   nnfw_create_session(&session);
 
-  nnfw_load_model_from_modelfile(session, (model_path + ".circle").c_str());
+  nnfw_load_model_from_file(session, (model_path + ".circle").c_str());
   nnfw_set_available_backends(session, "cpu");
   nnfw_prepare(session);
 
@@ -171,7 +171,7 @@ TEST(TestOdcAutoCompilation, neg_autoCompilation_no_export_path)
   nnfw_session *session = nullptr;
   nnfw_create_session(&session);
 
-  nnfw_load_model_from_modelfile(session, (model_path + ".circle").c_str());
+  nnfw_load_model_from_file(session, (model_path + ".circle").c_str());
   nnfw_set_available_backends(session, "cpu");
   nnfw_prepare(session);
 

--- a/tests/tools/onert_run/src/onert_run.cc
+++ b/tests/tools/onert_run/src/onert_run.cc
@@ -131,8 +131,7 @@ int main(const int argc, char **argv)
     // ModelLoad
     phases.run("MODEL_LOAD", [&](const benchmark::Phase &, uint32_t) {
       if (args.useSingleModel())
-        NNPR_ENSURE_STATUS(
-          nnfw_load_model_from_modelfile(session, args.getModelFilename().c_str()));
+        NNPR_ENSURE_STATUS(nnfw_load_model_from_file(session, args.getModelFilename().c_str()));
       else
         NNPR_ENSURE_STATUS(nnfw_load_model_from_file(session, args.getPackageFilename().c_str()));
     });

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -67,8 +67,7 @@ int main(const int argc, char **argv)
     // ModelLoad
     measure.run(PhaseType::MODEL_LOAD, [&]() {
       if (args.useSingleModel())
-        NNPR_ENSURE_STATUS(
-          nnfw_load_model_from_modelfile(session, args.getModelFilename().c_str()));
+        NNPR_ENSURE_STATUS(nnfw_load_model_from_file(session, args.getModelFilename().c_str()));
       else
         NNPR_ENSURE_STATUS(nnfw_load_model_from_file(session, args.getPackageFilename().c_str()));
     });

--- a/tests/tools/tflite_comparator/src/tflite_comparator.cc
+++ b/tests/tools/tflite_comparator/src/tflite_comparator.cc
@@ -236,7 +236,7 @@ int main(const int argc, char **argv)
     exit(-1);
   }
 
-  NNFW_ASSERT_FAIL(nnfw_load_model_from_modelfile(onert_session, tflite_file.c_str()),
+  NNFW_ASSERT_FAIL(nnfw_load_model_from_file(onert_session, tflite_file.c_str()),
                    "[ ERROR ] Failure during model load");
 
   uint32_t num_inputs;


### PR DESCRIPTION
This commit updates test code to use nnfw_load_model_from_file API instead of nnfw_load_model_from_modelfile internal API.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>