### PR TITLE
[onert] Remove modelfile loading internal API

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_internal.h
+++ b/runtime/onert/api/nnfw/include/nnfw_internal.h
@@ -36,15 +36,6 @@ NNFW_STATUS nnfw_get_config(nnfw_session *session, const char *key, char *value,
 NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer, size_t size);
 
 /**
- * @brief Load a tflite/circle model from file.
- *
- * @param[in] session   session
- * @param[in] file_path Path to model file. Model type(tflite/circle) is decided by file extension
- * @return    NFNFW_STATUS
- */
-NNFW_STATUS nnfw_load_model_from_modelfile(nnfw_session *session, const char *file_path);
-
-/**
  * @brief Export circle+ model
  * @note  This function should be called on training mode
  *        This function should be called before or after {@link nnfw_train}

--- a/runtime/onert/api/nnfw/src/nnfw_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_internal.cc
@@ -45,12 +45,6 @@ NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer,
   return session->load_circle_from_buffer(buffer, size);
 }
 
-NNFW_STATUS nnfw_load_model_from_modelfile(nnfw_session *session, const char *file_path)
-{
-  NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->load_model_from_path(file_path);
-}
-
 NNFW_STATUS nnfw_train_export_circleplus(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);


### PR DESCRIPTION
This commit removes model file loading internal API. 
Official API includes this functionality.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>