### PR TITLE
[luci] Support Transpose in InsertQuantizeOpOnDTypeMismatch

### DIFF
--- a/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.h
+++ b/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.h
@@ -32,6 +32,7 @@ private:
   void visit(luci::CircleFullyConnected *node);
   void visit(luci::CircleMul *node);
   void visit(luci::CircleBatchMatMul *node);
+  void visit(luci::CircleTranspose *node);
 
   // TODO Support more operators
 };


### PR DESCRIPTION
This supports Transpose Op in InsertQuantizeOpOnDTypeMismatch.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>