### PR TITLE
[infra] Remove custom arch flag for tizen build

### DIFF
--- a/infra/nnfw/cmake/buildtool/config/config_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7hl-tizen.cmake
@@ -14,9 +14,6 @@ include("cmake/buildtool/config/config_linux.cmake")
 
 # addition for arm-linux
 set(FLAGS_COMMON ${FLAGS_COMMON}
-    "-march=armv7-a"
-    "-mtune=cortex-a15.cortex-a7"
-    "-mfloat-abi=hard"
     "-mfpu=neon-vfpv4"
     "-funsafe-math-optimizations"
     "-ftree-vectorize"

--- a/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
@@ -14,9 +14,6 @@ include("cmake/buildtool/config/config_linux.cmake")
 
 # addition for arm-linux
 set(FLAGS_COMMON ${FLAGS_COMMON}
-    "-march=armv7-a"
-    "-mtune=cortex-a15.cortex-a7"
-    "-mfloat-abi=softfp"
     "-mfpu=neon-vfpv4"
     "-funsafe-math-optimizations"
     "-ftree-vectorize"


### PR DESCRIPTION
This commit removes compiler architecture flag on armv7l and armv7hl platforms. It will use default setting on gbs build.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>