### PR TITLE
[onert-micro] fix wrong namespace use in import ns

### DIFF
--- a/onert-micro/onert-micro/src/import/kernels/Abs.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Abs.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleAbs(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleAbs(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Add.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Add.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleAdd(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleAdd(const OMConfigureArgs &config_args)
 {
   return import::helpers::configure_TISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/AddN.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/AddN.cpp
@@ -30,7 +30,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleAddN(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleAddN(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -79,3 +84,6 @@ OMStatus onert_micro::import::configure_kernel_CircleAddN(const OMConfigureArgs 
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/ArgMax.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/ArgMax.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleArgMax(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleArgMax(const OMConfigureArgs &config_args)
 {
   return helpers::configure_arg_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/ArgMin.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/ArgMin.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleArgMin(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleArgMin(const OMConfigureArgs &config_args)
 {
   return helpers::configure_arg_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/AveragePool2D.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/AveragePool2D.cpp
@@ -19,8 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus
-onert_micro::import::configure_kernel_CircleAveragePool2D(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleAveragePool2D(const OMConfigureArgs &config_args)
 {
   return import::helpers::configure_pooling_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/BatchToSpaceND.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/BatchToSpaceND.cpp
@@ -19,8 +19,16 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleBatchToSpaceND(
-  const onert_micro::import::OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus
+configure_kernel_CircleBatchToSpaceND(const onert_micro::import::OMConfigureArgs &config_args)
 {
   return helpers::configure_spaces_batches_nd_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Cast.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Cast.cpp
@@ -30,7 +30,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleCast(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleCast(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -57,3 +62,6 @@ OMStatus onert_micro::import::configure_kernel_CircleCast(const OMConfigureArgs 
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Ceil.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Ceil.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleCeil(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleCeil(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Concatenation.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Concatenation.cpp
@@ -24,8 +24,12 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus
-onert_micro::import::configure_kernel_CircleConcatenation(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleConcatenation(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -92,3 +96,6 @@ onert_micro::import::configure_kernel_CircleConcatenation(const OMConfigureArgs 
 
   return Ok;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Conv2D.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Conv2D.cpp
@@ -38,7 +38,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleConv2D(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleConv2D(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -114,3 +119,6 @@ OMStatus onert_micro::import::configure_kernel_CircleConv2D(const OMConfigureArg
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Cos.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Cos.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleCos(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleCos(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/DepthwiseConv2D.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/DepthwiseConv2D.cpp
@@ -38,8 +38,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus
-onert_micro::import::configure_kernel_CircleDepthwiseConv2D(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleDepthwiseConv2D(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -135,3 +139,6 @@ onert_micro::import::configure_kernel_CircleDepthwiseConv2D(const OMConfigureArg
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Dequantize.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Dequantize.cpp
@@ -30,7 +30,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleDequantize(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleDequantize(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -71,3 +76,6 @@ OMStatus onert_micro::import::configure_kernel_CircleDequantize(const OMConfigur
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Div.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Div.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleDiv(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleDiv(const OMConfigureArgs &config_args)
 {
   return import::helpers::configure_TISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Elu.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Elu.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleElu(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleElu(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Equal.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Equal.cpp
@@ -34,7 +34,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleEqual(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleEqual(const OMConfigureArgs &config_args)
 {
   const circle::Tensor *input1;
   const circle::Tensor *input2;
@@ -54,3 +59,6 @@ OMStatus onert_micro::import::configure_kernel_CircleEqual(const OMConfigureArgs
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Exp.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Exp.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleExp(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleExp(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/ExpandDims.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/ExpandDims.cpp
@@ -32,7 +32,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleExpandDims(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleExpandDims(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -97,3 +102,6 @@ OMStatus onert_micro::import::configure_kernel_CircleExpandDims(const OMConfigur
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Fill.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Fill.cpp
@@ -32,7 +32,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleFill(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleFill(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -65,3 +70,6 @@ OMStatus onert_micro::import::configure_kernel_CircleFill(const OMConfigureArgs 
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Floor.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Floor.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleFloor(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleFloor(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/FloorDiv.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/FloorDiv.cpp
@@ -28,7 +28,15 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleFloorDiv(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleFloorDiv(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_floor_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/FloorMod.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/FloorMod.cpp
@@ -28,7 +28,15 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleFloorMod(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleFloorMod(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_floor_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/FullyConnected.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/FullyConnected.cpp
@@ -37,8 +37,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus
-onert_micro::import::configure_kernel_CircleFullyConnected(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleFullyConnected(const OMConfigureArgs &config_args)
 {
 
   OMRuntimeContext &runtime_context = config_args.runtime_context;
@@ -171,3 +175,6 @@ onert_micro::import::configure_kernel_CircleFullyConnected(const OMConfigureArgs
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/GRU.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/GRU.cpp
@@ -40,7 +40,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleGRU(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleGRU(const OMConfigureArgs &config_args)
 {
   core::OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -102,3 +107,6 @@ OMStatus onert_micro::import::configure_kernel_CircleGRU(const OMConfigureArgs &
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Gather.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Gather.cpp
@@ -32,7 +32,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleGather(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleGather(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -122,3 +127,6 @@ OMStatus onert_micro::import::configure_kernel_CircleGather(const OMConfigureArg
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/GatherND.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/GatherND.cpp
@@ -35,7 +35,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleGatherND(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleGatherND(const OMConfigureArgs &config_args)
 {
 
   OMRuntimeContext &runtime_context = config_args.runtime_context;
@@ -95,3 +100,6 @@ OMStatus onert_micro::import::configure_kernel_CircleGatherND(const OMConfigureA
 
   return Ok;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Greater.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Greater.cpp
@@ -33,7 +33,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleGreater(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleGreater(const OMConfigureArgs &config_args)
 {
   const circle::Tensor *input1;
   const circle::Tensor *input2;
@@ -53,3 +58,6 @@ OMStatus onert_micro::import::configure_kernel_CircleGreater(const OMConfigureAr
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/GreaterEqual.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/GreaterEqual.cpp
@@ -33,8 +33,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus
-onert_micro::import::configure_kernel_CircleGreaterEqual(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleGreaterEqual(const OMConfigureArgs &config_args)
 {
   const circle::Tensor *input1;
   const circle::Tensor *input2;
@@ -54,3 +58,6 @@ onert_micro::import::configure_kernel_CircleGreaterEqual(const OMConfigureArgs &
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/L2Normalize.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/L2Normalize.cpp
@@ -31,9 +31,17 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleL2Normalize(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleL2Normalize(const OMConfigureArgs &config_args)
 {
   OMStatus status = onert_micro::import::helpers::configure_SISO_kernel(config_args);
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/L2Pool2D.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/L2Pool2D.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleL2Pool2D(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleL2Pool2D(const OMConfigureArgs &config_args)
 {
   return helpers::configure_pooling_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/LeakyRelu.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/LeakyRelu.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleLeakyRelu(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleLeakyRelu(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Less.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Less.cpp
@@ -33,7 +33,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleLess(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleLess(const OMConfigureArgs &config_args)
 {
   const circle::Tensor *input1;
   const circle::Tensor *input2;
@@ -53,3 +58,6 @@ OMStatus onert_micro::import::configure_kernel_CircleLess(const OMConfigureArgs 
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/LessEqual.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/LessEqual.cpp
@@ -33,7 +33,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleLessEqual(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleLessEqual(const OMConfigureArgs &config_args)
 {
   const circle::Tensor *input1;
   const circle::Tensor *input2;
@@ -53,3 +58,6 @@ OMStatus onert_micro::import::configure_kernel_CircleLessEqual(const OMConfigure
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Log.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Log.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleLog(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleLog(const OMConfigureArgs &config_args)
 {
   return import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/LogSoftmax.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/LogSoftmax.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleLogSoftmax(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleLogSoftmax(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Logistic.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Logistic.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleLogistic(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleLogistic(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/MaxPool2D.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/MaxPool2D.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleMaxPool2D(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleMaxPool2D(const OMConfigureArgs &config_args)
 {
   return helpers::configure_pooling_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Maximum.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Maximum.cpp
@@ -31,7 +31,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleMaximum(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleMaximum(const OMConfigureArgs &config_args)
 {
 
   OMRuntimeContext &runtime_context = config_args.runtime_context;
@@ -61,3 +66,6 @@ OMStatus onert_micro::import::configure_kernel_CircleMaximum(const OMConfigureAr
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Minimum.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Minimum.cpp
@@ -31,7 +31,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleMinimum(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleMinimum(const OMConfigureArgs &config_args)
 {
 
   OMRuntimeContext &runtime_context = config_args.runtime_context;
@@ -61,3 +66,6 @@ OMStatus onert_micro::import::configure_kernel_CircleMinimum(const OMConfigureAr
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Mul.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Mul.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleMul(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleMul(const OMConfigureArgs &config_args)
 {
   return import::helpers::configure_TISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Neg.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Neg.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleNeg(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleNeg(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/NotEqual.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/NotEqual.cpp
@@ -34,7 +34,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleNotEqual(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleNotEqual(const OMConfigureArgs &config_args)
 {
   const circle::Tensor *input1;
   const circle::Tensor *input2;
@@ -54,3 +59,6 @@ OMStatus onert_micro::import::configure_kernel_CircleNotEqual(const OMConfigureA
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Pack.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Pack.cpp
@@ -25,7 +25,12 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CirclePack(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CirclePack(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -63,3 +68,6 @@ OMStatus onert_micro::import::configure_kernel_CirclePack(const OMConfigureArgs 
 
   return Ok;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Pad.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Pad.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CirclePad(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CirclePad(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_pad_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Quantize.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Quantize.cpp
@@ -30,7 +30,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleQuantize(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleQuantize(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -71,3 +76,6 @@ OMStatus onert_micro::import::configure_kernel_CircleQuantize(const OMConfigureA
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Relu.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Relu.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleRelu(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleRelu(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Relu6.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Relu6.cpp
@@ -19,8 +19,16 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleRelu6(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleRelu6(const OMConfigureArgs &config_args)
 {
 
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Reshape.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Reshape.cpp
@@ -32,7 +32,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleReshape(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleReshape(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -95,3 +100,6 @@ OMStatus onert_micro::import::configure_kernel_CircleReshape(const OMConfigureAr
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Round.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Round.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleRound(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleRound(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Rsqrt.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Rsqrt.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleRsqrt(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleRsqrt(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/SVDF.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/SVDF.cpp
@@ -40,7 +40,12 @@ constexpr int outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleSVDF(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSVDF(const OMConfigureArgs &config_args)
 {
   // Validate Tensor Inputs (dtype depends on quantization):
   // [0] = Input, {2, batch_size, input_size}
@@ -152,3 +157,6 @@ OMStatus onert_micro::import::configure_kernel_CircleSVDF(const OMConfigureArgs 
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Shape.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Shape.cpp
@@ -31,7 +31,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleShape(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleShape(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -50,3 +55,6 @@ OMStatus onert_micro::import::configure_kernel_CircleShape(const OMConfigureArgs
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Sin.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Sin.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleSin(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSin(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Slice.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Slice.cpp
@@ -38,7 +38,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleSlice(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSlice(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -79,3 +84,6 @@ OMStatus onert_micro::import::configure_kernel_CircleSlice(const OMConfigureArgs
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Softmax.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Softmax.cpp
@@ -34,7 +34,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleSoftmax(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSoftmax(const OMConfigureArgs &config_args)
 {
   const circle::Tensor *input;
   const circle::Tensor *output;
@@ -81,3 +86,6 @@ OMStatus onert_micro::import::configure_kernel_CircleSoftmax(const OMConfigureAr
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/SpaceToBatchND.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/SpaceToBatchND.cpp
@@ -19,8 +19,16 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleSpaceToBatchND(
-  const onert_micro::import::OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus
+configure_kernel_CircleSpaceToBatchND(const onert_micro::import::OMConfigureArgs &config_args)
 {
   return helpers::configure_spaces_batches_nd_kernel_common(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/SpaceToDepth.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/SpaceToDepth.cpp
@@ -30,8 +30,13 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleSpaceToDepth(
-  const onert_micro::import::OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus
+configure_kernel_CircleSpaceToDepth(const onert_micro::import::OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -79,3 +84,6 @@ OMStatus onert_micro::import::configure_kernel_CircleSpaceToDepth(
     return status;
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Split.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Split.cpp
@@ -32,7 +32,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleSplit(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSplit(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   OMRuntimeStorage &runtime_storage = config_args.runtime_storage;
@@ -86,3 +91,6 @@ OMStatus onert_micro::import::configure_kernel_CircleSplit(const OMConfigureArgs
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/SplitV.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/SplitV.cpp
@@ -33,7 +33,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleSplitV(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSplitV(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   OMRuntimeStorage &runtime_storage = config_args.runtime_storage;
@@ -104,3 +109,6 @@ OMStatus onert_micro::import::configure_kernel_CircleSplitV(const OMConfigureArg
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Sqrt.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Sqrt.cpp
@@ -18,7 +18,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleSqrt(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSqrt(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Square.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Square.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleSquare(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSquare(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/SquaredDifference.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/SquaredDifference.cpp
@@ -19,8 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus
-onert_micro::import::configure_kernel_CircleSquaredDifference(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSquaredDifference(const OMConfigureArgs &config_args)
 {
   return import::helpers::configure_TISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/StridedSlice.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/StridedSlice.cpp
@@ -38,8 +38,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus
-onert_micro::import::configure_kernel_CircleStridedSlice(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleStridedSlice(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -74,3 +78,6 @@ onert_micro::import::configure_kernel_CircleStridedSlice(const OMConfigureArgs &
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Sub.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Sub.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleSub(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleSub(const OMConfigureArgs &config_args)
 {
   return import::helpers::configure_TISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Tanh.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Tanh.cpp
@@ -19,7 +19,15 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleTanh(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleTanh(const OMConfigureArgs &config_args)
 {
   return onert_micro::import::helpers::configure_SISO_kernel(config_args);
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Transpose.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Transpose.cpp
@@ -35,7 +35,12 @@ constexpr int kOutputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleTranspose(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleTranspose(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -70,3 +75,6 @@ OMStatus onert_micro::import::configure_kernel_CircleTranspose(const OMConfigure
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/TransposeConv.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/TransposeConv.cpp
@@ -42,8 +42,12 @@ constexpr int kOutputTensorIdx = 0;
 
 } // namespace
 
-OMStatus
-onert_micro::import::configure_kernel_CircleTransposeConv(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleTransposeConv(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   uint16_t op_index = config_args.kernel_index;
@@ -83,3 +87,6 @@ onert_micro::import::configure_kernel_CircleTransposeConv(const OMConfigureArgs 
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/Unpack.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/Unpack.cpp
@@ -31,7 +31,12 @@ constexpr uint32_t outputTensorIdx = 0;
 
 } // namespace
 
-OMStatus onert_micro::import::configure_kernel_CircleUnpack(const OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleUnpack(const OMConfigureArgs &config_args)
 {
   OMRuntimeContext &runtime_context = config_args.runtime_context;
   OMRuntimeStorage &runtime_storage = config_args.runtime_storage;
@@ -98,3 +103,6 @@ OMStatus onert_micro::import::configure_kernel_CircleUnpack(const OMConfigureArg
 
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro

--- a/onert-micro/onert-micro/src/import/kernels/While.cpp
+++ b/onert-micro/onert-micro/src/import/kernels/While.cpp
@@ -22,8 +22,12 @@
 using namespace onert_micro;
 using namespace onert_micro::core;
 
-OMStatus onert_micro::import::configure_kernel_CircleWhile(
-  const onert_micro::import::OMConfigureArgs &config_args)
+namespace onert_micro
+{
+namespace import
+{
+
+OMStatus configure_kernel_CircleWhile(const onert_micro::import::OMConfigureArgs &config_args)
 {
   OMRuntimeModule &runtime_module = config_args.runtime_module;
   OMRuntimeContext &runtime_context = config_args.runtime_context;
@@ -78,3 +82,6 @@ OMStatus onert_micro::import::configure_kernel_CircleWhile(
                           body_runtime_graph->getNumberOfOutputs() == runtime_kernel.outputs_num);
   return status;
 }
+
+} // namespace import
+} // namespace onert_micro


### PR DESCRIPTION
Fix strange namespace use in onert_micro::import ns

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>