### PR TITLE
[luci] Remove redundant exception

### DIFF
--- a/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
+++ b/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
@@ -98,9 +98,6 @@ void overwrite_quantparam(const luci::CircleNode *source, luci::CircleNode *targ
     auto quantparam = std::make_unique<luci::CircleQuantParam>();
     target->quantparam(std::move(quantparam));
     target_qparam = target->quantparam();
-
-    if (target_qparam == nullptr)
-      throw std::runtime_error("Creating new quant param failed");
   }
   target_qparam->min = source_qparam->min;
   target_qparam->max = source_qparam->max;


### PR DESCRIPTION
This removes a redundant exception.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/14503