### PR TITLE
[luci-interpreter] Relax StrideSlice rank limitations

### DIFF
--- a/compiler/luci-interpreter/src/kernels/StridedSlice.cpp
+++ b/compiler/luci-interpreter/src/kernels/StridedSlice.cpp
@@ -44,7 +44,7 @@ void StridedSlice::configure()
   assert(begin()->element_type() == DataType::S32);
   assert(end()->element_type() == DataType::S32);
   assert(strides()->element_type() == DataType::S32);
-  assert(input()->shape().num_dims() <= 4);
+  assert(input()->shape().num_dims() <= 5);
   if (params().ellipsis_mask != 0)
   {
     throw std::runtime_error("ellipsis_mask is not implemented yet.");


### PR DESCRIPTION
This commit removes assert that limit StrideSlice rank to 4. TF 2.8 allows to inference this operator with rank 5.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Issue: https://github.com/Samsung/ONE/issues/14165