### PR TITLE
[infra/docker] Install libtsan_preinit.o manually

### DIFF
--- a/infra/docker/focal/Dockerfile
+++ b/infra/docker/focal/Dockerfile
@@ -42,6 +42,12 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
 RUN apt-get update && apt-get install -qqy clang-format-16
 
+# Install libtsan_preinit.o manually (workaround for missing package in focal)
+RUN apt-get download libgcc-10-dev
+RUN dpkg -x libgcc-10-dev_*_amd64.deb libgcc/
+RUN cp -f libgcc/usr/lib/gcc/x86_64-linux-gnu/10/libtsan_preinit.o /usr/lib/gcc/x86_64-linux-gnu/9/
+RUN rm -rf libgcc-10-dev_*_amd64.deb libgcc/
+
 # Install gbs
 RUN echo 'deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_20.04/ /' | cat >> /etc/apt/sources.list
 RUN apt-get update && apt-get -qqy install gbs


### PR DESCRIPTION
This commit adds a manual installation of libtsan_preinit.o in ubuntu 20.04 docker image. 
It is workaround for the build failure due to missing libtsan_preinit.o in libtsan0 package.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #11202