### PR TITLE
[onert/test] Apply strict build to tflite_comparator

### DIFF
--- a/tests/tools/tflite_comparator/CMakeLists.txt
+++ b/tests/tools/tflite_comparator/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND SOURCES "src/args.cc")
 
 add_executable(tflite_comparator ${SOURCES})
 
+target_link_libraries(tflite_comparator nnfw_common)
 target_link_libraries(tflite_comparator nnfw-dev)
 target_link_libraries(tflite_comparator nnfw_lib_tflite nnfw_lib_misc)
 target_link_libraries(tflite_comparator arser)

--- a/tests/tools/tflite_comparator/src/tflite_comparator.cc
+++ b/tests/tools/tflite_comparator/src/tflite_comparator.cc
@@ -89,7 +89,7 @@ void randomBoolData(benchmark::RandomGenerator &randgen, std::vector<uint8_t> &d
 inline uint64_t num_elems(const nnfw_tensorinfo *ti)
 {
   uint64_t n = 1;
-  for (uint32_t i = 0; i < ti->rank; ++i)
+  for (int32_t i = 0; i < ti->rank; ++i)
   {
     n *= ti->dims[i];
   }
@@ -172,7 +172,7 @@ template <>
 bool isClose(const uint8_t *ref_buf, const std::vector<uint8_t> &act_buf, uint32_t index)
 {
   // TODO better way for handling quant error?
-  auto tolerance = static_cast<uint64_t>(nnfw::misc::EnvVar("TOLERANCE").asInt(0));
+  auto tolerance = nnfw::misc::EnvVar("TOLERANCE").asInt(0);
   bool match = true;
 
   for (uint32_t e = 0; e < act_buf.size() / sizeof(uint8_t); e++)
@@ -294,6 +294,7 @@ int main(const int argc, char **argv)
           break;
         case NNFW_TYPE_TENSOR_QUANT16_SYMM_SIGNED:
           randomData<int16_t>(randgen, inputs[i]);
+          break;
         case NNFW_TYPE_TENSOR_FLOAT32:
           randomData<float>(randgen, inputs[i]);
           break;


### PR DESCRIPTION
This commit applies strict build to tflite_comparator.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related: https://github.com/Samsung/ONE/pull/14440