### PR TITLE
[luci/service] Remove useless null check

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleAdd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAdd.cpp
@@ -29,8 +29,7 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleAdd *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleAdd>();
-  if (cloned != nullptr)
-    cloned->fusedActivationFunction(node->fusedActivationFunction());
+  cloned->fusedActivationFunction(node->fusedActivationFunction());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleArgMax.cpp
+++ b/compiler/luci/service/src/Nodes/CircleArgMax.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleArgMax *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleArgMax>();
-  if (cloned != nullptr)
-    cloned->output_type(node->output_type());
+  cloned->output_type(node->output_type());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleArgMin.cpp
+++ b/compiler/luci/service/src/Nodes/CircleArgMin.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleArgMin *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleArgMin>();
-  if (cloned != nullptr)
-    cloned->output_type(node->output_type());
+  cloned->output_type(node->output_type());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleAveragePool2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAveragePool2D.cpp
@@ -27,7 +27,6 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleAveragePool2D *
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleAveragePool2D>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->padding(node->padding());

--- a/compiler/luci/service/src/Nodes/CircleBCQFullyConnected.cpp
+++ b/compiler/luci/service/src/Nodes/CircleBCQFullyConnected.cpp
@@ -25,7 +25,6 @@ luci::CircleNode *CloneNode::visit(const luci::CircleBCQFullyConnected *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleBCQFullyConnected>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->weights_hidden_size(node->weights_hidden_size());

--- a/compiler/luci/service/src/Nodes/CircleBCQGather.cpp
+++ b/compiler/luci/service/src/Nodes/CircleBCQGather.cpp
@@ -22,7 +22,6 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleBCQGather *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleBCQGather>();
-  if (cloned != nullptr)
   {
     cloned->axis(node->axis());
     cloned->input_hidden_size(node->input_hidden_size());

--- a/compiler/luci/service/src/Nodes/CircleBatchMatMul.cpp
+++ b/compiler/luci/service/src/Nodes/CircleBatchMatMul.cpp
@@ -68,7 +68,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleBatchMatMul *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleBatchMatMul>();
-  if (cloned != nullptr)
   {
     cloned->adj_x(node->adj_x());
     cloned->adj_y(node->adj_y());

--- a/compiler/luci/service/src/Nodes/CircleCast.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCast.cpp
@@ -22,7 +22,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleCast *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleCast>();
-  if (cloned != nullptr)
   {
     cloned->in_data_type(node->in_data_type());
     cloned->out_data_type(node->out_data_type());

--- a/compiler/luci/service/src/Nodes/CircleConcatenation.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConcatenation.cpp
@@ -29,7 +29,6 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleConcatenation *
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleConcatenation>(node->numValues());
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->axis(node->axis());

--- a/compiler/luci/service/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConst.cpp
@@ -46,7 +46,6 @@ luci::CircleConst *clone_circleconst(const luci::CircleConst *node, loco::Graph 
 {
   auto cloned = graph->nodes()->create<luci::CircleConst>();
 
-  if (cloned != nullptr)
   {
     // dtype/shape
     cloned->dtype(node->dtype());

--- a/compiler/luci/service/src/Nodes/CircleConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConv2D.cpp
@@ -27,7 +27,6 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleConv2D *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleConv2D>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->padding(node->padding());

--- a/compiler/luci/service/src/Nodes/CircleCustom.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCustom.cpp
@@ -24,7 +24,6 @@ luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleCustom *node)
   uint32_t num_in = node->numInputs();
   uint32_t num_out = node->numOutputs();
   auto *cloned = _graph->nodes()->create<luci::CircleCustom>(num_in, num_out);
-  if (cloned != nullptr)
   {
     cloned->custom_options(node->custom_options());
     cloned->custom_code(node->custom_code());

--- a/compiler/luci/service/src/Nodes/CircleCustomOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCustomOut.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleCustomOut *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleCustomOut>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleDepthToSpace.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDepthToSpace.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDepthToSpace *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleDepthToSpace>();
-  if (cloned != nullptr)
-    cloned->block_size(node->block_size());
+  cloned->block_size(node->block_size());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.cpp
@@ -27,7 +27,6 @@ luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDepthwiseConv2D
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleDepthwiseConv2D>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->padding(node->padding());

--- a/compiler/luci/service/src/Nodes/CircleDiv.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDiv.cpp
@@ -29,8 +29,7 @@ luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDiv *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleDiv>();
-  if (cloned != nullptr)
-    cloned->fusedActivationFunction(node->fusedActivationFunction());
+  cloned->fusedActivationFunction(node->fusedActivationFunction());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleFakeQuant.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFakeQuant.cpp
@@ -22,7 +22,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFakeQuant *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleFakeQuant>();
-  if (cloned != nullptr)
   {
     cloned->min(node->min());
     cloned->max(node->max());

--- a/compiler/luci/service/src/Nodes/CircleFullyConnected.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFullyConnected.cpp
@@ -31,7 +31,6 @@ luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFullyConnected 
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleFullyConnected>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->weights_format(node->weights_format());

--- a/compiler/luci/service/src/Nodes/CircleGRU.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGRU.cpp
@@ -25,7 +25,6 @@ luci::CircleNode *CloneNode::visit(const luci::CircleGRU *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleGRU>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->returnSequences(node->returnSequences());

--- a/compiler/luci/service/src/Nodes/CircleGather.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGather.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::GHIJ>::visit(const luci::CircleGather *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleGather>();
-  if (cloned != nullptr)
-    cloned->axis(node->axis());
+  cloned->axis(node->axis());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleGelu.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGelu.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::GHIJ>::visit(const luci::CircleGelu *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleGelu>();
-  if (cloned != nullptr)
-    cloned->approximate(node->approximate());
+  cloned->approximate(node->approximate());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleIfOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleIfOut.cpp
@@ -100,8 +100,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleIfOut *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleIfOut>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleL2Normalize.cpp
+++ b/compiler/luci/service/src/Nodes/CircleL2Normalize.cpp
@@ -25,8 +25,7 @@ luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleL2Normalize *n
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleL2Normalize>();
-  if (cloned != nullptr)
-    cloned->fusedActivationFunction(node->fusedActivationFunction());
+  cloned->fusedActivationFunction(node->fusedActivationFunction());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleL2Pool2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleL2Pool2D.cpp
@@ -27,7 +27,6 @@ luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleL2Pool2D *node
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleL2Pool2D>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->padding(node->padding());

--- a/compiler/luci/service/src/Nodes/CircleLeakyRelu.cpp
+++ b/compiler/luci/service/src/Nodes/CircleLeakyRelu.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleLeakyRelu *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleLeakyRelu>();
-  if (cloned != nullptr)
-    cloned->alpha(node->alpha());
+  cloned->alpha(node->alpha());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleLocalResponseNormalization.cpp
+++ b/compiler/luci/service/src/Nodes/CircleLocalResponseNormalization.cpp
@@ -22,7 +22,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleLocalResponseNormalization *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleLocalResponseNormalization>();
-  if (cloned != nullptr)
   {
     cloned->radius(node->radius());
     cloned->bias(node->bias());

--- a/compiler/luci/service/src/Nodes/CircleMaxPool2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleMaxPool2D.cpp
@@ -27,7 +27,6 @@ luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleMaxPool2D *nod
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleMaxPool2D>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->padding(node->padding());

--- a/compiler/luci/service/src/Nodes/CircleMean.cpp
+++ b/compiler/luci/service/src/Nodes/CircleMean.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleMean *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleMean>();
-  if (cloned != nullptr)
-    cloned->keep_dims(node->keep_dims());
+  cloned->keep_dims(node->keep_dims());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleMirrorPad.cpp
+++ b/compiler/luci/service/src/Nodes/CircleMirrorPad.cpp
@@ -25,8 +25,7 @@ luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleMirrorPad *nod
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleMirrorPad>();
-  if (cloned != nullptr)
-    cloned->mode(node->mode());
+  cloned->mode(node->mode());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleMul.cpp
+++ b/compiler/luci/service/src/Nodes/CircleMul.cpp
@@ -28,8 +28,7 @@ luci::CircleNode *CloneNodeLet<CN::KLMN>::visit(const luci::CircleMul *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleMul>();
-  if (cloned != nullptr)
-    cloned->fusedActivationFunction(node->fusedActivationFunction());
+  cloned->fusedActivationFunction(node->fusedActivationFunction());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV4Out.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV4Out.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleNonMaxSuppressionV4Out *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleNonMaxSuppressionV4Out>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV5Out.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV5Out.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleNonMaxSuppressionV5Out *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleNonMaxSuppressionV5Out>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleOneHot.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOneHot.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleOneHot *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleOneHot>();
-  if (cloned != nullptr)
-    cloned->axis(node->axis());
+  cloned->axis(node->axis());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CirclePack.cpp
+++ b/compiler/luci/service/src/Nodes/CirclePack.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CirclePack *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CirclePack>(node->values_count());
-  if (cloned != nullptr)
-    cloned->axis(node->axis());
+  cloned->axis(node->axis());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReduceAny.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceAny.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleReduceAny *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleReduceAny>();
-  if (cloned != nullptr)
-    cloned->keep_dims(node->keep_dims());
+  cloned->keep_dims(node->keep_dims());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReduceMax.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceMax.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleReduceMax *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleReduceMax>();
-  if (cloned != nullptr)
-    cloned->keep_dims(node->keep_dims());
+  cloned->keep_dims(node->keep_dims());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReduceMin.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceMin.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleReduceMin *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleReduceMin>();
-  if (cloned != nullptr)
-    cloned->keep_dims(node->keep_dims());
+  cloned->keep_dims(node->keep_dims());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReduceProd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceProd.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleReduceProd *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleReduceProd>();
-  if (cloned != nullptr)
-    cloned->keep_dims(node->keep_dims());
+  cloned->keep_dims(node->keep_dims());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -52,7 +52,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleReshape *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleReshape>();
-  if (cloned != nullptr)
   {
     uint32_t rank = node->newShape()->rank();
     cloned->newShape()->rank(rank);

--- a/compiler/luci/service/src/Nodes/CircleResizeBilinear.cpp
+++ b/compiler/luci/service/src/Nodes/CircleResizeBilinear.cpp
@@ -22,7 +22,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleResizeBilinear *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleResizeBilinear>();
-  if (cloned != nullptr)
   {
     cloned->align_corners(node->align_corners());
     cloned->half_pixel_centers(node->half_pixel_centers());

--- a/compiler/luci/service/src/Nodes/CircleResizeNearestNeighbor.cpp
+++ b/compiler/luci/service/src/Nodes/CircleResizeNearestNeighbor.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleResizeNearestNeighbor *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleResizeNearestNeighbor>();
-  if (cloned != nullptr)
-    cloned->align_corners(node->align_corners());
+  cloned->align_corners(node->align_corners());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReverseSequence.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReverseSequence.cpp
@@ -22,7 +22,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::OPQR>::visit(const luci::CircleReverseSequence *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleReverseSequence>();
-  if (cloned != nullptr)
   {
     cloned->seq_axis(node->seq_axis());
     cloned->batch_axis(node->batch_axis());

--- a/compiler/luci/service/src/Nodes/CircleRmsNorm.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRmsNorm.cpp
@@ -22,7 +22,6 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleRmsNorm *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleRmsNorm>();
-  if (cloned != nullptr)
   {
     cloned->epsilon(node->epsilon());
   }

--- a/compiler/luci/service/src/Nodes/CircleSVDF.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSVDF.cpp
@@ -25,7 +25,6 @@ luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSVDF *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleSVDF>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->asymmetric_quantize_inputs(node->asymmetric_quantize_inputs());

--- a/compiler/luci/service/src/Nodes/CircleShape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleShape.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleShape *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleShape>();
-  if (cloned != nullptr)
-    cloned->out_type(node->out_type());
+  cloned->out_type(node->out_type());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSoftmax.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSoftmax.cpp
@@ -25,8 +25,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSoftmax *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSoftmax>();
-  if (cloned != nullptr)
-    cloned->beta(node->beta());
+  cloned->beta(node->beta());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSpaceToDepth.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSpaceToDepth.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSpaceToDepth *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSpaceToDepth>();
-  if (cloned != nullptr)
-    cloned->block_size(node->block_size());
+  cloned->block_size(node->block_size());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSparseToDense.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSparseToDense.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSparseToDense *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSparseToDense>();
-  if (cloned != nullptr)
-    cloned->validate_indices(node->validate_indices());
+  cloned->validate_indices(node->validate_indices());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSplit.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplit.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSplit *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSplit>();
-  if (cloned != nullptr)
-    cloned->num_split(node->num_split());
+  cloned->num_split(node->num_split());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSplitOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplitOut.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleSplitOut *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSplitOut>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSplitV.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplitV.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSplitV *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSplitV>();
-  if (cloned != nullptr)
-    cloned->num_split(node->num_split());
+  cloned->num_split(node->num_split());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSplitVOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplitVOut.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleSplitVOut *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSplitVOut>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSqueeze.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSqueeze.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSqueeze *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSqueeze>();
-  if (cloned != nullptr)
-    cloned->squeeze_dims(node->squeeze_dims());
+  cloned->squeeze_dims(node->squeeze_dims());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
+++ b/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
@@ -36,7 +36,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleStridedSlice *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleStridedSlice>();
-  if (cloned != nullptr)
   {
     cloned->begin_mask(node->begin_mask());
     cloned->end_mask(node->end_mask());

--- a/compiler/luci/service/src/Nodes/CircleSub.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSub.cpp
@@ -25,8 +25,7 @@ luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSub *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleSub>();
-  if (cloned != nullptr)
-    cloned->fusedActivationFunction(node->fusedActivationFunction());
+  cloned->fusedActivationFunction(node->fusedActivationFunction());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSum.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSum.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSum *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSum>();
-  if (cloned != nullptr)
-    cloned->keep_dims(node->keep_dims());
+  cloned->keep_dims(node->keep_dims());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleTopKV2Out.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTopKV2Out.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleTopKV2Out *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleTopKV2Out>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleTransposeConv.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTransposeConv.cpp
@@ -25,7 +25,6 @@ luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleTransposeConv 
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleTransposeConv>();
-  if (cloned != nullptr)
   {
     cloned->padding(node->padding());
     cloned->stride()->h(node->stride()->h());

--- a/compiler/luci/service/src/Nodes/CircleUnidirectionalSequenceLSTM.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnidirectionalSequenceLSTM.cpp
@@ -25,7 +25,6 @@ luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleUnidirectional
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleUnidirectionalSequenceLSTM>();
-  if (cloned != nullptr)
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->cell_clip(node->cell_clip());

--- a/compiler/luci/service/src/Nodes/CircleUnique.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnique.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleUnique *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleUnique>();
-  if (cloned != nullptr)
-    cloned->idx_out_type(node->idx_out_type());
+  cloned->idx_out_type(node->idx_out_type());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleUniqueOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUniqueOut.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleUniqueOut *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleUniqueOut>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleUnpack.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnpack.cpp
@@ -22,7 +22,6 @@ namespace luci
 luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleUnpack *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleUnpack>();
-  if (cloned != nullptr)
   {
     cloned->num(node->num());
     cloned->axis(node->axis());

--- a/compiler/luci/service/src/Nodes/CircleUnpackOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnpackOut.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleUnpackOut *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleUnpackOut>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleWhileOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleWhileOut.cpp
@@ -22,8 +22,7 @@ namespace luci
 luci::CircleNode *CloneNode::visit(const luci::CircleWhileOut *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleWhileOut>();
-  if (cloned != nullptr)
-    cloned->index(node->index());
+  cloned->index(node->index());
   return cloned;
 }
 


### PR DESCRIPTION
This commit removes null check created by loco::NodePool::create(). 
When node creation fails, it throws an exception instead of returning nullptr.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related: https://github.com/Samsung/ONE/issues/14503#issuecomment-2567253925