### PR TITLE
[onert/python] Separate prepare from session constructor

### DIFF
--- a/runtime/onert/api/python/include/nnfw_api_wrapper.h
+++ b/runtime/onert/api/python/include/nnfw_api_wrapper.h
@@ -131,6 +131,7 @@ public:
 
   void close_session();
   void set_input_tensorinfo(uint32_t index, const tensorinfo *tensor_info);
+  void prepare();
   void run();
   void run_async();
   void wait();

--- a/runtime/onert/api/python/src/nnfw_api_wrapper.cc
+++ b/runtime/onert/api/python/src/nnfw_api_wrapper.cc
@@ -173,7 +173,6 @@ NNFW_SESSION::NNFW_SESSION(const char *package_file_path, const char *backends)
   ensure_status(nnfw_create_session(&(this->session)));
   ensure_status(nnfw_load_model_from_file(this->session, package_file_path));
   ensure_status(nnfw_set_available_backends(this->session, backends));
-  ensure_status(nnfw_prepare(this->session));
 }
 NNFW_SESSION::~NNFW_SESSION()
 {
@@ -199,6 +198,7 @@ void NNFW_SESSION::set_input_tensorinfo(uint32_t index, const tensorinfo *tensor
   }
   ensure_status(nnfw_set_input_tensorinfo(session, index, &ti));
 }
+void NNFW_SESSION::prepare() { ensure_status(nnfw_prepare(session)); }
 void NNFW_SESSION::run() { ensure_status(nnfw_run(session)); }
 void NNFW_SESSION::run_async() { ensure_status(nnfw_run_async(session)); }
 void NNFW_SESSION::wait() { ensure_status(nnfw_await(session)); }


### PR DESCRIPTION
This commit separates prepare function from initializing session instance.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>