### PR TITLE
[onert/python] Allow calling compilation by infer session

### DIFF
--- a/runtime/onert/api/python/package/common/basesession.py
+++ b/runtime/onert/api/python/package/common/basesession.py
@@ -59,6 +59,10 @@ class BaseSession:
             size (int): Number of input tensors.
             inputs_array (list): List of numpy arrays for the input data.
         """
+        if self.session is None:
+            raise ValueError(
+                "Session is not initialized with a model. Please compile with a model before setting inputs."
+            )
         for i in range(size):
             input_tensorinfo = self.session.input_tensorinfo(i)
 
@@ -80,6 +84,10 @@ class BaseSession:
         Args:
             size (int): Number of output tensors.
         """
+        if self.session is None:
+            raise ValueError(
+                "Session is not initialized with a model. Please compile a model before setting outputs."
+            )
         for i in range(size):
             output_tensorinfo = self.session.output_tensorinfo(i)
             output_array = np.zeros((num_elems(output_tensorinfo)),

--- a/runtime/onert/api/python/package/common/basesession.py
+++ b/runtime/onert/api/python/package/common/basesession.py
@@ -15,7 +15,7 @@ class BaseSession:
     """
     Base class providing common functionality for inference and training sessions.
     """
-    def __init__(self, backend_session):
+    def __init__(self, backend_session=None):
         """
         Initialize the BaseSession with a backend session.
         Args:
@@ -33,7 +33,24 @@ class BaseSession:
         Returns:
             The attribute or method from the bound NNFW_SESSION instance.
         """
-        return getattr(self.session, name)
+        if name in self.__dict__:
+            # First, try to get the attribute from the instance's own dictionary
+            return self.__dict__[name]
+        elif hasattr(self.session, name):
+            # If not found, delegate to the session object
+            return getattr(self.session, name)
+        else:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'")
+
+    def _recreate_session(self, backend_session):
+        """
+        Protected method to recreate the session.
+        Subclasses can override this method to provide custom session recreation logic.
+        """
+        if self.session is not None:
+            del self.session  # Clean up the existing session
+        self.session = backend_session
 
     def set_inputs(self, size, inputs_array=[]):
         """

--- a/runtime/onert/api/python/package/infer/session.py
+++ b/runtime/onert/api/python/package/infer/session.py
@@ -6,14 +6,35 @@ class session(BaseSession):
     """
     Class for inference using nnfw_session.
     """
-    def __init__(self, nnpackage_path, backends="cpu"):
+    def __init__(self, nnpackage_path: str = None, backends: str = "cpu"):
         """
         Initialize the inference session.
         Args:
             nnpackage_path (str): Path to the nnpackage file or directory.
             backends (str): Backends to use, default is "cpu".
         """
-        super().__init__(libnnfw_api_pybind.infer.nnfw_session(nnpackage_path, backends))
+        if nnpackage_path is not None:
+            super().__init__(
+                libnnfw_api_pybind.infer.nnfw_session(nnpackage_path, backends))
+            self.session.prepare()
+            self.set_outputs(self.session.output_size())
+        else:
+            super().__init__()
+
+    def compile(self, nnpackage_path: str, backends: str = "cpu"):
+        """
+        Prepare the session by recreating it with new parameters.
+        Args:
+            nnpackage_path (str): Path to the nnpackage file or directory. Defaults to the existing path.
+            backends (str): Backends to use. Defaults to the existing backends.
+        """
+        # Update parameters if provided
+        if nnpackage_path is None:
+            raise ValueError("nnpackage_path must not be None.")
+        # Recreate the session with updated parameters
+        self._recreate_session(
+            libnnfw_api_pybind.infer.nnfw_session(nnpackage_path, backends))
+        # Prepare the new session
         self.session.prepare()
         self.set_outputs(self.session.output_size())
 

--- a/runtime/onert/api/python/package/infer/session.py
+++ b/runtime/onert/api/python/package/infer/session.py
@@ -6,34 +6,32 @@ class session(BaseSession):
     """
     Class for inference using nnfw_session.
     """
-    def __init__(self, nnpackage_path: str = None, backends: str = "cpu"):
+    def __init__(self, path: str = None, backends: str = "cpu"):
         """
         Initialize the inference session.
         Args:
-            nnpackage_path (str): Path to the nnpackage file or directory.
+            path (str): Path to the model file or nnpackage directory.
             backends (str): Backends to use, default is "cpu".
         """
-        if nnpackage_path is not None:
-            super().__init__(
-                libnnfw_api_pybind.infer.nnfw_session(nnpackage_path, backends))
+        if path is not None:
+            super().__init__(libnnfw_api_pybind.infer.nnfw_session(path, backends))
             self.session.prepare()
             self.set_outputs(self.session.output_size())
         else:
             super().__init__()
 
-    def compile(self, nnpackage_path: str, backends: str = "cpu"):
+    def compile(self, path: str, backends: str = "cpu"):
         """
         Prepare the session by recreating it with new parameters.
         Args:
-            nnpackage_path (str): Path to the nnpackage file or directory. Defaults to the existing path.
+            path (str): Path to the model file or nnpackage directory. Defaults to the existing path.
             backends (str): Backends to use. Defaults to the existing backends.
         """
         # Update parameters if provided
-        if nnpackage_path is None:
-            raise ValueError("nnpackage_path must not be None.")
+        if path is None:
+            raise ValueError("path must not be None.")
         # Recreate the session with updated parameters
-        self._recreate_session(
-            libnnfw_api_pybind.infer.nnfw_session(nnpackage_path, backends))
+        self._recreate_session(libnnfw_api_pybind.infer.nnfw_session(path, backends))
         # Prepare the new session
         self.session.prepare()
         self.set_outputs(self.session.output_size())


### PR DESCRIPTION
This commit allows calling compilation(prepare) by infer session.
  - Introduce recreating internal session(nnfw_session) into BaseSession
  - Introduce compile function that can recreate internal session
  - Modify __getattr__ of BaseSession strictly

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>