### PR TITLE
[onert] Use the shape signature in baseloader

### DIFF
--- a/runtime/onert/core/src/loader/BaseLoader.h
+++ b/runtime/onert/core/src/loader/BaseLoader.h
@@ -364,7 +364,8 @@ ir::OperandIndex BaseLoader<LoaderDomain>::loadOperand(const Tensor *tensor, ir:
 {
   ir::Shape shape;
   // Shape
-  const auto *tensor_shape = tensor->shape();
+  const auto *tensor_shape =
+    tensor->shape_signature() ? tensor->shape_signature() : tensor->shape();
   if (tensor_shape != nullptr)
   {
     for (const auto &dim : *tensor_shape)


### PR DESCRIPTION
This commit use the shape signature in base loader. 
if there is an unknown shape in the circle, maintain the unknown shape

ONE-DCO-1.0-Signed-off-by: youngsik kim <ys44.kim@samsung.com>