### PR TITLE
Fix docs for cross-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 
 # Makefile
 /Makefile
+
+# Python virtualenv
+/.venv

--- a/docs/howto/how-to-build-runtime.md
+++ b/docs/howto/how-to-build-runtime.md
@@ -36,40 +36,83 @@ scons \
 software-properties-common \
 unzip \
 wget
-
-$ pip3 install yapf==0.40.2 numpy
-
 ```
 
-## Build from source code, for Ubuntu
+## Get ONE source code
 
-In a typical linux development environment, including Ubuntu, you can build the runtime with a simple command like this:
+Getting code is as simple as
 
 ```
 $ git clone https://github.com/Samsung/ONE.git one
 $ cd one
-$ ./nnfw configure
-$ ./nnfw build
-$ ./nnfw install
+```
+
+## Install python packages
+
+Python package `numpy` is needed for build. It's recommended to always install python packages in virtualenv.
+To do this, at first you need to install python venv package:
+
+```
+$ sudo apt-get install python3-venv
+```
+Next, create virtualenv in `.venv` directory (make sure that you are in ONE directory):
+
+```
+$ python3 -m venv .venv
+```
+
+and activate it (please keep in mind that you will have to activate it always before build)
+
+```
+$ source .venv/bin/activate
+```
+
+Next, just in case upgrade pip package:
+
+```
+(.venv)$ pip install -U pip
+```
+
+and finally install `numpy`:
+
+```
+(.venv)$ pip install numpy
+```
+
+Additionally, package `yapf` is needed in specific version:
+
+```
+(.venv)$ pip install yapf==0.40.2
+```
+
+## Build from source code, for Ubuntu
+
+In a typical linux development environment, including Ubuntu, you can build the runtime with a simple command like this (make sure that you are in ONE directory):
+
+```
+$ source .venv/bin/activate
+(.venv)$ ./nnfw configure
+(.venv)$ ./nnfw build
+(.venv)$ ./nnfw install
 ```
 
 For easy build process, we provides `Makefile.template` makefile.
 
 ```
-$ make -f Makefile.template
+(.venv)$ make -f Makefile.template
 ```
 
 To release build the runtime, add the environment variable `BUILD_TYPE=release` to the build command as follows.
 
 ```
-$ export BUILD_TYPE=release
-$ make -f Makefile.template
+(.venv)$ export BUILD_TYPE=release
+(.venv)$ make -f Makefile.template
 ```
 
 Or you can simply do something like this:
 
 ```
-$ BUILD_TYPE=release make -f Makefile.template
+(.venv)$ BUILD_TYPE=release make -f Makefile.template
 ```
 
 The build method described here is a `native build` in which the build environment and execution environment are same. So, this command creates a runtime binary targeting the current build architecture, probably x86_64, as the execution environment. You can find the build output in the ./Product folder as follows:

--- a/docs/howto/how-to-cross-build-runtime-for-arm.md
+++ b/docs/howto/how-to-cross-build-runtime-for-arm.md
@@ -25,7 +25,7 @@ RootFS will be prepared at `tools/cross/rootfs/arm` or `tools/cross/rootfs/aarch
 
 ***\* CAUTION: The OS version of rootfs must match the OS version of execution target device. On the other hand, you need to match the Ubuntu version of the development PC with the Ubuntu version of rootfs to be used for cross-build. Otherwise, unexpected build errors may occur.***
 
-If you are using Ubuntu 20.04 LTS, select `focal`, if you are using Ubuntu 22.04 LTS, select `jammy`. You can check your Ubuntu code name in the following way.
+If you are using Ubuntu 20.04 LTS, select `focal`, if you are using Ubuntu 22.04 LTS, select `jammy`, for Ubuntu 24.04 LTS, select `noble`. You can check your Ubuntu code name in the following way.
 
 ```
 $ cat /etc/lsb-release
@@ -81,7 +81,7 @@ If you select specific version, update symbolic link for build toolchain.
 Otherwise, you should set your custom cmake crossbuild toolchain. You can find cmake toolchain files in `infra/nnfw/cmake/buildtool/cross/`.
 
 ```
-$ update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-10 80 \
+$ sudo update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-10 80 \
     --slave /usr/bin/arm-linux-gnueabihf-g++ arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-10 \
     --slave /usr/bin/arm-linux-gnueabihf-gcov arm-linux-gnueabihf-gcov /usr/bin/arm-linux-gnueabihf-gcov-10
 ```
@@ -104,17 +104,27 @@ ACL source will be automatically installed in `externals/ARMCOMPUTE` when you bu
 
 You can check ACL source information in `infra/cmake/packages/ARMComputeSourceConfig.cmake`
 
+## Install numpy
+
+Python package `numpy` is needed for build. Please use [this guide](how-to-build-runtime.md##install-python-packages) to install it.
+
 ## Cross build for ARM by using Makefile.template
 
 Give `TARGET_ARCH` variable to set the target architecture.
 
 If you used `ROOTFS_DIR` to prepare in alternative folder, you should also give this to makefile.
 
+Remember to activate venv if you didn't activate it already:
+
 ```
-$ CROSS_BUILD=1 TARGET_ARCH=armv7l make -f Makefile.template
+$ source .venv/bin/activate
+```
+
+```
+(.venv)$ CROSS_BUILD=1 TARGET_ARCH=armv7l make -f Makefile.template
 
 # If ROOTFS_DIR is in alternative folder
-$ ROOTFS_DIR=/path/to/your/rootfs/arm \
+(.venv)$ ROOTFS_DIR=/path/to/your/rootfs/arm \
 CROSS_BUILD=1 TARGET_ARCH=armv7l make
 ```
 
@@ -124,10 +134,10 @@ the `TARGET_ARCH` are differs from the hostarchitecture, the make script automat
 normal build and cross build as follows.
 
 ```
-$ export ROOTFS_DIR=xxx
+(.venv)$ export ROOTFS_DIR=xxx
 ...
-$ make -f Makefile.template                     # do normal build
-$ TARGET_ARCH=armv7l make -f Makefile.template  # do cross build
+(.venv)$ make -f Makefile.template                     # do normal build
+(.venv)$ TARGET_ARCH=armv7l make -f Makefile.template  # do cross build
 ```
 
 Makefile.template will pass crossbuild toolchain setting to cmake automatically by parsing variables.


### PR DESCRIPTION
Small fixes to documentation, based on trying to cross-build to armv7l on Ubuntu 24.04 LTS.

Additionally, as python virtual env is nice to have option, add `.venv` to `.gitignore` file.

ONE-DCO-1.0-Signed-off-by: Marcin Słowiński <m.slowinski2@samsung.com>
