### PR TITLE
[infra] Update python format checker

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -30,10 +30,10 @@ jobs:
           python-version: '3.x'
 
       # C format: clang-format-16 (already installed)
-      # Python format: yapf==0.40.2
+      # Python format: yapf==0.43.0
       - name: Install packages
         run: |
-          pip install yapf==0.40.2
+          pip install yapf==0.43.0
 
       - name: Check
         run: ./nnas format

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,3 @@
+runtime/3rdparty/**/*
+tests/nnapi/nnapi_test_generator/**/*
+tests/nnapi/specs/**/*

--- a/infra/command/format
+++ b/infra/command/format
@@ -166,11 +166,6 @@ function check_python_files() {
   # Exceptional case: fm-equalize doesn't have '.py' extension.
   FILES_TO_CHECK_PYTHON+=(`echo "$FILES_TO_CHECK" | tr ' ' '\n' | egrep '^compiler/fm-equalize/fm-equalize$'`)
 
-  for s in ${DIRECTORIES_NOT_TO_BE_TESTED[@]}; do
-    skip=${s#'.'/}/
-    FILES_TO_CHECK_PYTHON=(${FILES_TO_CHECK_PYTHON[*]/$skip*/})
-  done
-
   if [[ ${#FILES_TO_CHECK_PYTHON} -ne 0 ]]; then
     yapf -i ${FILES_TO_CHECK_PYTHON[@]}
     EXIT_CODE=$?


### PR DESCRIPTION
This commit updates format checker for python
- Use .yapfignore file in root directory instead of .FORMATDENY in each directory to ignore files from yapf
- Update yapf version to 0.43.0: update package dependency

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #14556 