### PR TITLE
[tools/mec] Add value attribute only when available

### DIFF
--- a/tools/model_explorer_circle/src/model_explorer_circle/main.py
+++ b/tools/model_explorer_circle/src/model_explorer_circle/main.py
@@ -122,6 +122,8 @@ class CircleAdapter(Adapter):
         """Prints a tensor with the specified number of elements"""
         tensor = self.model.subgraphs[0].tensors[tensor_id]
         buffer = self.model.buffers[tensor.buffer].data
+        if buffer is None:
+            return
         dtype = self.dict_tensor_type_to_string[tensor.type].lower()
         # Convert buffer into numpy array with the correct datatype
         if dtype in ['int4', 'uint4']:


### PR DESCRIPTION
The tensor buffer can be empty for immature model, so it needs to check if the buffer is available when it tries to fill value attribute.

