### PR TITLE
[luci-pass-value-py-test] Add tests for expand_broadcast_const option

### DIFF
--- a/compiler/luci-pass-value-py-test/test.lst
+++ b/compiler/luci-pass-value-py-test/test.lst
@@ -7,6 +7,10 @@
 
 # eval(Net_Preactivation_BN_000 fuse_preactivation_batchnorm) : value diff exist
 # --> https://github.com/Samsung/ONE/issues/5782
+eval(Add_003 expand_broadcast_const)
+eval(Add_004 expand_broadcast_const)
+eval(Add_005 expand_broadcast_const)
+eval(Add_006 expand_broadcast_const)
 eval(FullyConnected_007 replace_non_const_fc_with_batch_matmul)
 eval(HardSwish_001 decompose_hardswish)
 eval(Net_Add_FloorMod_Gather_000 remove_gather_guard)


### PR DESCRIPTION
Let's add tests for expand_broadcast_const option.

ONE-DCO-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

---

DRAFT: https://github.com/Samsung/ONE/pull/14555
FOR: https://github.com/Samsung/ONE/issues/14554