### PR TITLE
[tools] Add subdirectoy manually for tools cmake

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,1 +1,2 @@
-add_subdirectories()
+add_subdirectory(kbenchmark)
+add_subdirectory(opencl_tool)


### PR DESCRIPTION
This commit changes adding tools directory manually in cmake instead of using macro. 
It will help to divide build process for each tool from runtime build.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>