### PR TITLE
[mir] Adapt to the Protobuf API changes

### DIFF
--- a/compiler/mir/src/mir_caffe2_importer/caffe2_importer.cpp
+++ b/compiler/mir/src/mir_caffe2_importer/caffe2_importer.cpp
@@ -124,7 +124,7 @@ static void loadModelFile(const std::string &filename, caffe2::NetDef *net)
   file_stream.SetCloseOnDelete(true);
 
   google::protobuf::io::CodedInputStream coded_stream(&file_stream);
-  coded_stream.SetTotalBytesLimit(INT_MAX, INT_MAX);
+  coded_stream.SetTotalBytesLimit(INT_MAX);
 
   if (!net->ParseFromCodedStream(&coded_stream))
     throw std::runtime_error("Couldn't parse file \"" + filename + "\".");

--- a/compiler/mir/src/mir_caffe_importer/caffe_importer.cpp
+++ b/compiler/mir/src/mir_caffe_importer/caffe_importer.cpp
@@ -106,7 +106,7 @@ void loadModelFromBinaryFile(const std::string &filename, caffe::NetParameter *n
   file_stream.SetCloseOnDelete(true);
 
   google::protobuf::io::CodedInputStream coded_stream(&file_stream);
-  coded_stream.SetTotalBytesLimit(INT_MAX, INT_MAX);
+  coded_stream.SetTotalBytesLimit(INT_MAX);
 
   if (!net->ParseFromCodedStream(&coded_stream))
     throw std::runtime_error("Couldn't parse file \"" + filename + "\".");

--- a/compiler/mir/src/mir_onnx_importer/ONNXImporterImpl.cpp
+++ b/compiler/mir/src/mir_onnx_importer/ONNXImporterImpl.cpp
@@ -77,7 +77,7 @@ void loadModelFromBinaryFile(const std::string &filename, onnx::ModelProto *mode
   file_stream.SetCloseOnDelete(true);
 
   google::protobuf::io::CodedInputStream coded_stream(&file_stream);
-  coded_stream.SetTotalBytesLimit(INT_MAX, INT_MAX);
+  coded_stream.SetTotalBytesLimit(INT_MAX);
 
   if (!model->ParseFromCodedStream(&coded_stream))
     throw std::runtime_error("Couldn't parse file \"" + filename + "\".");


### PR DESCRIPTION
This commit adapts the code in mir to the changes in the Protobuf API.

ONE-DCO-1.0-Signed-off-by: Tomasz Dolbniak <t.dolbniak@partner.samsung.com>

Related: https://github.com/Samsung/ONE/pull/14535