### PR TITLE
[onert/python] Introduce LossRegistry

### DIFF
--- a/runtime/onert/api/python/package/experimental/train/losses/registry.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/registry.py
@@ -1,3 +1,4 @@
+from onert.native.libnnfw_api_pybind import loss as loss_type
 from .cce import CategoricalCrossentropy
 from .mse import MeanSquaredError
 
@@ -37,8 +38,8 @@ class LossRegistry:
         """
         # Loss to Enum mapping
         loss_to_enum = {
-            CategoricalCrossentropy: "CATEGORICAL_CROSSENTROPY",
-            MeanSquaredError: "MEAN_SQUARED_ERROR",
+            CategoricalCrossentropy: loss_type.CATEGORICAL_CROSSENTROPY,
+            MeanSquaredError: loss_type.MEAN_SQUARED_ERROR
         }
         for loss_class, enum_value in loss_to_enum.items():
             if isinstance(loss_instance, loss_class):

--- a/runtime/onert/api/python/package/experimental/train/losses/registry.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/registry.py
@@ -4,11 +4,11 @@ from .mse import MeanSquaredError
 
 class LossRegistry:
     """
-    Registry for creating losses by name.
+    Registry for creating and mapping losses by name or instance.
     """
     _losses = {
         "categorical_crossentropy": CategoricalCrossentropy,
-        "mean_squred_error": MeanSquaredError
+        "mean_squared_error": MeanSquaredError
     }
 
     @staticmethod
@@ -23,3 +23,26 @@ class LossRegistry:
         if name not in LossRegistry._losses:
             raise ValueError(f"Unknown Loss: {name}. Custom loss is not supported yet")
         return LossRegistry._losses[name]()
+
+    @staticmethod
+    def map_loss_function_to_enum(loss_instance):
+        """
+        Maps a LossFunction instance to the appropriate enum value.
+        Args:
+            loss_instance (BaseLoss): An instance of a loss function.
+        Returns:
+            loss_type: Corresponding enum value for the loss function.
+        Raises:
+            TypeError: If the loss_instance is not a recognized LossFunction type.
+        """
+        # Loss to Enum mapping
+        loss_to_enum = {
+            CategoricalCrossentropy: "CATEGORICAL_CROSSENTROPY",
+            MeanSquaredError: "MEAN_SQUARED_ERROR",
+        }
+        for loss_class, enum_value in loss_to_enum.items():
+            if isinstance(loss_instance, loss_class):
+                return enum_value
+        raise TypeError(
+            f"Unsupported loss function type: {type(loss_instance).__name__}. "
+            f"Supported types are: {list(loss_to_enum.keys())}.")

--- a/runtime/onert/api/python/package/experimental/train/losses/registry.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/registry.py
@@ -1,0 +1,25 @@
+from .cce import CategoricalCrossentropy
+from .mse import MeanSquaredError
+
+
+class LossRegistry:
+    """
+    Registry for creating losses by name.
+    """
+    _losses = {
+        "categorical_crossentropy": CategoricalCrossentropy,
+        "mean_squred_error": MeanSquaredError
+    }
+
+    @staticmethod
+    def create_loss(name):
+        """
+        Create a loss instance by name.
+        Args:
+            name (str): Name of the loss.
+        Returns:
+            BaseLoss: Loss instance.
+        """
+        if name not in LossRegistry._losses:
+            raise ValueError(f"Unknown Loss: {name}. Custom loss is not supported yet")
+        return LossRegistry._losses[name]()


### PR DESCRIPTION
This commit introduces LossRegistries.
  - create_loss : Create a loss instance by name
  - map_loss_function_to_enum : Map a loss instance to the appropriate enum value.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>