### PR TITLE
[infra/github] Cancel running workflow on PR update

### DIFF
--- a/.github/workflows/build-dev-docker.yml
+++ b/.github/workflows/build-dev-docker.yml
@@ -15,6 +15,11 @@ on:
       - '.github/workflows/build-dev-docker.yml'
       - 'infra/docker/**'
 
+# Cancel previous running jobs when pull request is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Build on docker CLI for PR test without login
   build-pr-test:

--- a/.github/workflows/generate-rootfs.yml
+++ b/.github/workflows/generate-rootfs.yml
@@ -21,6 +21,11 @@ on:
     - cron: '0 15 1 * *'
   workflow_dispatch:
 
+# Cancel previous running jobs when pull request is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gen-rootfs:
     if: github.repository_owner == 'Samsung'

--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -34,6 +34,11 @@ defaults:
   run:
     shell: bash
 
+# Cancel previous running jobs when pull request is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   onecc-test:
     if: github.repository_owner == 'Samsung'

--- a/.github/workflows/run-onert-android-build.yml
+++ b/.github/workflows/run-onert-android-build.yml
@@ -38,6 +38,11 @@ defaults:
   run:
     shell: bash
 
+# Cancel previous running jobs when pull request is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/run-onert-build.yml
+++ b/.github/workflows/run-onert-build.yml
@@ -38,6 +38,11 @@ defaults:
   run:
     shell: bash
 
+# Cancel previous running jobs when pull request is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.repository_owner == 'Samsung'

--- a/.github/workflows/run-onert-gbs-build.yml
+++ b/.github/workflows/run-onert-gbs-build.yml
@@ -42,6 +42,11 @@ defaults:
   run:
     shell: bash
 
+# Cancel previous running jobs when pull request is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/run-onert-micro-unit-tests.yml
+++ b/.github/workflows/run-onert-micro-unit-tests.yml
@@ -25,6 +25,11 @@ defaults:
   run:
     shell: bash
 
+# Cancel previous running jobs when pull request is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   run-onert-micro-unit-tests:
     name: Run onert-micro Unit tests


### PR DESCRIPTION
This commit updates workflows to cancel running workflows including heavy overhead when a PR is update.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>