### PR TITLE
[onert-micro] Remove .FORMATDENY file

### DIFF
--- a/onert-micro/externals/.clang-format
+++ b/onert-micro/externals/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION
This commit removes .FORMATDENY file and replaces it to .clang-format's DisableFormat.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #14556 