### PR TITLE
[ann-ref] Remove .FORMATDENY file

### DIFF
--- a/compiler/ann-ref/.clang-format
+++ b/compiler/ann-ref/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION
This commit removes .FORMATDENY file and replaces it to .clang-format's DisableFormat.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/14556