### PR TITLE
[luci] Introduce the parent class method to luci::Pass

### DIFF
--- a/compiler/luci/pass/include/luci/ModulePass.h
+++ b/compiler/luci/pass/include/luci/ModulePass.h
@@ -28,6 +28,8 @@ namespace luci
 class Pass : public logo::Pass
 {
 public:
+  // This directive prevents emitting a compiler erro triggered by -Werror=overloaded-virtual
+  using logo::Pass::run;
   // Run module pass and return false if there was nothing changed
   virtual bool run(luci::Module *) = 0;
 };


### PR DESCRIPTION
This directive fixes a build break caused by a compiler error emitted when compiling with -Werror=overloaded-virtual flag switched on. The error is about the logo::Pass::run method being hidden by luci::Pass::run.

ONE-DCO-1.0-Signed-off-by: Tomasz Dolbniak <t.dolbniak@partner.samsung.com>

Related issue `NPU_Compiler/issues/19901`