### PR TITLE
Disable XNNPack backend on Tizen

### DIFF
--- a/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
@@ -7,3 +7,5 @@ option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
+
+option(BUILD_XNNPACK "Build XNNPACK" OFF)

--- a/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
@@ -7,3 +7,5 @@ option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
+
+option(BUILD_XNNPACK "Build XNNPACK" OFF)

--- a/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
@@ -7,3 +7,5 @@ option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
+
+option(BUILD_XNNPACK "Build XNNPACK" OFF)


### PR DESCRIPTION
This commit disables XNNPack backend build on Tizen.

missing pr for https://review.tizen.org/gerrit/gitweb?p=platform/core/ml/nnfw.git;a=commit;h=a47a504ac8ce5ea212074087dee9ee90748b7979