### PR TITLE
[release/1.28.1] Disable python format checking

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -18,6 +18,8 @@ jobs:
   check-format:
     name: Check format
     runs-on: ubuntu-20.04
+    env:
+      CHECK_PYTHON: 0 # Disable python format check for now
 
     steps:
       - name: Checkout


### PR DESCRIPTION
It disables python format checking because it is not working on yapf 0.22.0.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Relataed issue: #14596