### PR TITLE
[onert/infra] Fix coverage test failure

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -228,7 +228,7 @@ coverage_suite_internal: install_all_internal
 	@echo "packaging test-coverage suite"
 	@rm -rf $(INSTALL_PATH)/coverage-suite.tar.gz
 	@find Product -name "*.gcno" > include_lists.txt
-	@pwd | grep -o '/' | wc -l > tests/scripts/build_path_depth.txt
+	@pwd | grep -o '/' | wc -l > runtime/tests/scripts/build_path_depth.txt
 	@tar -zcf coverage-suite.tar.gz tests/scripts infra Product/out --dereference -T include_lists.txt
-	@rm -rf include_lists.txt tests/scripts/build_path_depth.txt
+	@rm -rf include_lists.txt runtime/tests/scripts/build_path_depth.txt
 	@mv coverage-suite.tar.gz $(INSTALL_PATH)/.

--- a/infra/scripts/test_coverage.sh
+++ b/infra/scripts/test_coverage.sh
@@ -18,11 +18,11 @@ tar -zxf ${ARCHIVE_PATH}/coverage-suite.tar.gz -C ./
 
 CheckTestPrepared
 
-if [[ ! -e $ROOT_PATH/tests/scripts/build_path_depth.txt ]]; then
+if [[ ! -e $ROOT_PATH/runtime/tests/scripts/build_path_depth.txt ]]; then
   echo "Cannot find prefix strip file"
   exit 1
 fi
-export GCOV_PREFIX_STRIP=`cat $ROOT_PATH/tests/scripts/build_path_depth.txt`
+export GCOV_PREFIX_STRIP=`cat $ROOT_PATH/runtime/tests/scripts/build_path_depth.txt`
 
 TENSOR_LOGGING=trace_log.txt ./infra/scripts/test_ubuntu_runtime.sh --backend acl_cl --nnapi-frontend
 ./infra/scripts/test_ubuntu_runtime.sh --backend acl_neon

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -212,7 +212,7 @@ cp -r %{nncc_workspace}/overlay/include/flatbuffers %{overlay_path}/include
 
 %if %{test_build} == 1
 %if %{coverage_build} == 1
-pwd > tests/scripts/build_path.txt
+pwd > runtime/tests/scripts/build_path.txt
 %endif # coverage_build
 tar -zcf test-suite.tar.gz infra/scripts
 %endif # test_build
@@ -276,7 +276,7 @@ tar -zxf test-suite.tar.gz -C %{buildroot}%{test_install_home}
 %if %{coverage_build} == 1
 mkdir -p %{buildroot}%{test_install_home}/gcov
 find %{nnfw_workspace} -name "*.gcno" -exec xargs cp {} %{buildroot}%{test_install_home}/gcov/. \;
-install -m 0644 ./tests/scripts/build_path.txt %{buildroot}%{test_install_dir}/test/build_path.txt
+install -m 0644 ./runtime/tests/scripts/build_path.txt %{buildroot}%{test_install_dir}/test/build_path.txt
 %endif # coverage_build
 %endif # test_build
 


### PR DESCRIPTION
This commit fixes coverage test failure by teset directory relocation.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>