### PR TITLE
[circle-mlir] Fix Dockerfile

### DIFF
--- a/circle-mlir/infra/docker/u2204/Dockerfile
+++ b/circle-mlir/infra/docker/u2204/Dockerfile
@@ -9,7 +9,13 @@ RUN apt-get update \
 # Build tool
 RUN apt-get update \
  && apt-get -qqy install build-essential cmake git fakeroot autoconf automake libtool unzip wget \
-                         devscripts debmake debhelper lcov clang-format-16
+                         devscripts debmake debhelper lcov
+
+# Install clang-format
+RUN apt-get install -qqy gnupg2
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+RUN apt-get update && apt-get install -qqy clang-format-16
 
 # additonal tools
 RUN apt-get update \

--- a/circle-mlir/infra/docker/u2204/Dockerfile
+++ b/circle-mlir/infra/docker/u2204/Dockerfile
@@ -12,10 +12,12 @@ RUN apt-get update \
                          devscripts debmake debhelper lcov
 
 # Install clang-format
-RUN apt-get install -qqy gnupg2
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
-RUN apt-get update && apt-get install -qqy clang-format-16
+RUN apt-get update \
+ && apt-get install -qqy gnupg2 \
+ && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+ && add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" \
+ && apt-get update \
+ && apt-get install -qqy clang-format-16
 
 # additonal tools
 RUN apt-get update \


### PR DESCRIPTION
This will fix installing `clang-format-16`.
To install this format, the LLVM repository must be set up in advance.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>

---

for #14627, https://github.com/Samsung/ONE/issues/14607