### PR TITLE
[onert] Modify ChromeTracingWriter to generate traceEvents only once

### DIFF
--- a/runtime/onert/core/src/util/ChromeTracingEventWriter.cc
+++ b/runtime/onert/core/src/util/ChromeTracingEventWriter.cc
@@ -163,19 +163,25 @@ std::string getTid(const DurationEvent &evt)
 
 } // namespace
 
-void ChromeTracingWriter::flush(const std::vector<std::unique_ptr<EventRecorder>> &recorders)
+ChromeTracingWriter::ChromeTracingWriter(const std::string &filepath) : EventFormatWriter(filepath)
 {
   _os << "{\n";
   _os << "  " << quote("traceEvents") << ": [\n";
+}
 
+ChromeTracingWriter::~ChromeTracingWriter()
+{
+  _os << "    { }\n";
+  _os << "  ]\n";
+  _os << "}\n";
+}
+
+void ChromeTracingWriter::flush(const std::vector<std::unique_ptr<EventRecorder>> &recorders)
+{
   for (const auto &recorder : recorders)
   {
     flushOneRecord(*recorder);
   }
-
-  _os << "    { }\n";
-  _os << "  ]\n";
-  _os << "}\n";
 }
 
 void ChromeTracingWriter::flushOneRecord(const EventRecorder &recorder)

--- a/runtime/onert/core/src/util/EventWriter.cc
+++ b/runtime/onert/core/src/util/EventWriter.cc
@@ -38,6 +38,8 @@ void EventWriter::readyToFlush(std::unique_ptr<EventRecorder> &&recorder)
   flush(WriteFormat::SNPE_BENCHMARK);
   flush(WriteFormat::CHROME_TRACING);
   flush(WriteFormat::MD_TABLE);
+
+  _recorders.clear();
 }
 
 void EventWriter::flush(WriteFormat write_format)

--- a/runtime/onert/core/src/util/EventWriter.h
+++ b/runtime/onert/core/src/util/EventWriter.h
@@ -53,10 +53,8 @@ public:
 class ChromeTracingWriter : public EventFormatWriter
 {
 public:
-  ChromeTracingWriter(const std::string &filepath) : EventFormatWriter(filepath)
-  { /* empty */
-  }
-  ~ChromeTracingWriter() {}
+  ChromeTracingWriter(const std::string &filepath);
+  ~ChromeTracingWriter();
 
   void flush(const std::vector<std::unique_ptr<EventRecorder>> &) override;
 


### PR DESCRIPTION
This commit ensures that `traceEvents` is generated only once and prevents the error of generating multiple `traceEvents` when using multiple nnfw sessions.

ONE-DCO-1.0-Signed-off-by: youngsik kim <ys44.kim@samsung.com>