### PR TITLE
[circle-mlir] Introduce CMake test option flags

### DIFF
--- a/circle-mlir/CMakeLists.txt
+++ b/circle-mlir/CMakeLists.txt
@@ -13,7 +13,12 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_compile_options("-fexceptions")
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/infra/cmake")
+
 # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)
 endif()
+
+# configuration flags
+include(CfgOptionFlags)

--- a/circle-mlir/infra/cmake/CfgOptionFlags.cmake
+++ b/circle-mlir/infra/cmake/CfgOptionFlags.cmake
@@ -1,0 +1,9 @@
+#
+# configuration options
+#
+option(ENABLE_TEST "Enable module unit test and intrgration test" ON)
+option(ENABLE_COVERAGE "Enable build for coverage test" OFF)
+
+if(${ENABLE_COVERAGE} AND NOT ${ENABLE_TEST})
+  message(FATAL_ERROR "Test should be enabled to measure test coverage")
+endif()

--- a/circle-mlir/infra/cmake/CfgOptionFlags.cmake
+++ b/circle-mlir/infra/cmake/CfgOptionFlags.cmake
@@ -1,7 +1,7 @@
 #
 # configuration options
 #
-option(ENABLE_TEST "Enable module unit test and intrgration test" ON)
+option(ENABLE_TEST "Enable module unit test and integration test" ON)
 option(ENABLE_COVERAGE "Enable build for coverage test" OFF)
 
 if(${ENABLE_COVERAGE} AND NOT ${ENABLE_TEST})


### PR DESCRIPTION
This will introduce CMake configure option flags
- ENABLE_TEST to enable/disable test
- ENABLE_COVERAGE to enable/disable test coverage