### PR TITLE
[circle-mlir] Local gitignore

### DIFF
--- a/circle-mlir/.gitignore
+++ b/circle-mlir/.gitignore
@@ -1,0 +1,2 @@
+Makefile
+build


### PR DESCRIPTION
This will introduce circle-mlir project local gitignore
to ignore local build folder and personal Makefile.
