### PR TITLE
[infra] Adjust the Caffe 1.0 code to the new Protobuf API

### DIFF
--- a/infra/cmake/packages/CaffeSource.patch
+++ b/infra/cmake/packages/CaffeSource.patch
@@ -1,0 +1,13 @@
+diff --git a/src/caffe/util/io.cpp b/src/caffe/util/io.cpp
+index 5295d9dd..f71553c9 100644
+--- a/src/caffe/util/io.cpp
++++ b/src/caffe/util/io.cpp
+@@ -54,7 +54,7 @@ bool ReadProtoFromBinaryFile(const char* filename, Message* proto) {
+   CHECK_NE(fd, -1) << "File not found: " << filename;
+   ZeroCopyInputStream* raw_input = new FileInputStream(fd);
+   CodedInputStream* coded_input = new CodedInputStream(raw_input);
+-  coded_input->SetTotalBytesLimit(kProtoReadBytesLimit, 536870912);
++  coded_input->SetTotalBytesLimit(kProtoReadBytesLimit);
+ 
+   bool success = proto->ParseFromCodedStream(coded_input);
+ 

--- a/infra/cmake/packages/CaffeSourceConfig.cmake
+++ b/infra/cmake/packages/CaffeSourceConfig.cmake
@@ -10,7 +10,7 @@ function(_CaffeSource_import)
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(CAFFE_URL ${EXTERNAL_DOWNLOAD_SERVER}/BVLC/caffe/archive/1.0.tar.gz)
 
-  ExternalSource_Download(CAFFE ${CAFFE_URL})
+  ExternalSource_Download(CAFFE ${CAFFE_URL} PATCH ${CMAKE_CURRENT_LIST_DIR}/CaffeSource.patch)
 
   set(CaffeSource_DIR ${CAFFE_SOURCE_DIR} PARENT_SCOPE)
   set(CaffeSource_FOUND ${DOWNLOAD_CAFFE} PARENT_SCOPE)


### PR DESCRIPTION
This commit patches the sources of Caffe 1.0 upon the download in order to resolve a compilation error coming from the changes of Protobuf's API.

ONE-DCO-1.0-Signed-off-by: Tomasz Dolbniak <t.dolbniak@partner.samsung.com>

Related issue: https://github.com/Samsung/ONE/issues/14620