### PR TITLE
[onert] Apply inline variable to OperandNode

### DIFF
--- a/runtime/onert/core/src/dumper/dot/OperandNode.cc
+++ b/runtime/onert/core/src/dumper/dot/OperandNode.cc
@@ -22,11 +22,6 @@
 namespace onert::dumper::dot
 {
 
-const std::string Operand::INPUT_SHAPE = "doublecircle";
-const std::string Operand::OUTPUT_SHAPE = "doublecircle";
-const std::string Operand::OPERAND_SHAPE = "ellipse";
-const std::string Operand::BG_COLOR_SCHEME = "set18";
-
 Operand::Operand(const ir::OperandIndex &index, Type type)
   : Node{"operand" + std::to_string(index.value())}
 {

--- a/runtime/onert/core/src/dumper/dot/OperandNode.h
+++ b/runtime/onert/core/src/dumper/dot/OperandNode.h
@@ -49,10 +49,10 @@ public:
   };
 
 public:
-  static const std::string INPUT_SHAPE;
-  static const std::string OUTPUT_SHAPE;
-  static const std::string OPERAND_SHAPE;
-  static const std::string BG_COLOR_SCHEME;
+  static inline const std::string INPUT_SHAPE = "doublecircle";
+  static inline const std::string OUTPUT_SHAPE = "doublecircle";
+  static inline const std::string OPERAND_SHAPE = "ellipse";
+  static inline const std::string BG_COLOR_SCHEME = "set18";
 
 public:
   /**


### PR DESCRIPTION
This commit applies inline variable to class OperandNode.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>