### PR TITLE
[circle-mlir] Pass CIRCLE_MLIR_LOCALINST

### DIFF
--- a/circle-mlir/CMakeLists.txt
+++ b/circle-mlir/CMakeLists.txt
@@ -30,4 +30,13 @@ include(CTest)
 include(GTestHelper)
 include(GoogleTest)
 
+# to override submodules install
+if(DEFINED ENV{CIRCLE_MLIR_LOCALINST})
+  set(CIRCLE_MLIR_LOCALINST $ENV{CIRCLE_MLIR_LOCALINST})
+endif()
+
+if(CIRCLE_MLIR_LOCALINST)
+  message(STATUS "CIRCLE_MLIR_LOCALINST=${CIRCLE_MLIR_LOCALINST}")
+endif()
+
 add_subdirectory(circle-mlir)


### PR DESCRIPTION
This will pass CIRCLE_MLIR_LOCALINST environmet variable to CMake CIRCLE_MLIR_LOCALINST.
