### PR TITLE
[circle-mlir] Introduce cirmlir_coverage interface

### DIFF
--- a/circle-mlir/CMakeLists.txt
+++ b/circle-mlir/CMakeLists.txt
@@ -23,6 +23,9 @@ endif()
 # configuration flags
 include(CfgOptionFlags)
 
+# enable test coverage
+include(TestCoverage)
+
 # enable ctest
 include(CTest)
 

--- a/circle-mlir/infra/cmake/TestCoverage.cmake
+++ b/circle-mlir/infra/cmake/TestCoverage.cmake
@@ -1,0 +1,5 @@
+add_library(cirmlir_coverage INTERFACE)
+if(ENABLE_COVERAGE)
+  target_compile_options(cirmlir_coverage INTERFACE -g -O0 -fprofile-arcs -ftest-coverage)
+  target_link_libraries(cirmlir_coverage INTERFACE gcov)
+endif()


### PR DESCRIPTION
This will introduce cirmlir_coverage CMake interface for test coverage report generation.