### PR TITLE
[github] Introduce build-docker-onnx-subgr

### DIFF
--- a/.github/workflows/build-docker-onnx-subgr.yml
+++ b/.github/workflows/build-docker-onnx-subgr.yml
@@ -1,0 +1,28 @@
+name: Build docker image for tools/onnx_subgraph CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-docker-image:
+    if: github.repository_owner == 'Samsung'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ 'u2204' ]
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Install Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./onnx_subgraph/docker/Dockerfile.${{ matrix.version }}
+          push: true
+          tags: nnfw/onnx-subgraph-build-${{ matrix.version }}


### PR DESCRIPTION
This will introduce build-docker-onnx-subgr Workflow
to generate Docker image for tools/onnx-subgraph build/test.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>