### PR TITLE
[onnx_subgraph] Fix Dockerfile warning

### DIFF
--- a/tools/onnx_subgraph/docker/Dockerfile.u2204
+++ b/tools/onnx_subgraph/docker/Dockerfile.u2204
@@ -14,7 +14,7 @@
 
 FROM ubuntu:22.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install 'add-apt-repository'
 RUN apt-get update \


### PR DESCRIPTION
This will fix Dockerfile warning not to use white space separator.