### PR TITLE
[circle-mlir] Fix Dockerfile warning

### DIFF
--- a/circle-mlir/infra/docker/u2204/Dockerfile
+++ b/circle-mlir/infra/docker/u2204/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04 AS build
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install 'add-apt-repository'
 RUN apt-get update \


### PR DESCRIPTION
This will fix Dockerfile warning not to use white space separator.
