### PR TITLE
[tools/onnx-subgraph] Add test model downloading scripts

### DIFF
--- a/tools/onnx_subgraph/CMakeLists.txt
+++ b/tools/onnx_subgraph/CMakeLists.txt
@@ -14,28 +14,25 @@ find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${Python3_INCLUDE_DIRS})
 
-set(ONNX_SUGRAPH_FILES                                                          
+set(ONNX_SUBGRAPH_FILES                                                 
     test_model_download.sh
- )                                                                            
-                                                                              
- foreach(ONNX_SUGRAPH IN ITEMS ${ONNX_SUGRAPH_FILES})                                                                                                        
-   set(ONNX_SUGRAPH_FILE ${ONNX_SUGRAPH})                                           
-   set(ONNX_SUGRAPH_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${ONNX_SUGRAPH_FILE}")         
-   set(ONNX_SUGRAPH_BIN "${CMAKE_CURRENT_BINARY_DIR}/scripts/${ONNX_SUGRAPH_FILE}")         
-   set(ONNX_SUGRAPH_TARGET "${ONNX_SUGRAPH}_target")                                
-                                                                              
-   add_custom_command(OUTPUT ${ONNX_SUGRAPH_BIN}                                 
-     COMMAND ${CMAKE_COMMAND} -E copy "${ONNX_SUGRAPH_SRC}" "${ONNX_SUGRAPH_BIN}"   
-     DEPENDS ${ONNX_SUGRAPH_SRC}                                                 
-     COMMENT "Generate ${ONNX_SUGRAPH_BIN}"                                      
-   )                                                                          
-                                                                              
-   add_custom_target(${ONNX_SUGRAPH_TARGET} ALL DEPENDS ${ONNX_SUGRAPH_BIN})        
-                                                                              
-   install(FILES ${ONNX_SUGRAPH_BIN}                                             
-           PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE                   
-                       GROUP_READ GROUP_EXECUTE                               
-                       WORLD_READ WORLD_EXECUTE                               
-           DESTINATION bin)                                                   
-                                                                              
- endforeach(ONNX_SUGRAPH) 
+)
+foreach(ONNX_SUBGRAPH IN ITEMS ${ONNX_SUBGRAPH_FILES})
+    set(ONNX_SUBGRAPH_FILE ${ONNX_SUBGRAPH})
+    set(ONNX_SUBGRAPH_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${ONNX_SUBGRAPH_FILE}")
+    set(ONNX_SUBGRAPH_BIN "${CMAKE_CURRENT_BINARY_DIR}/scripts/${ONNX_SUBGRAPH_FILE}")
+    set(ONNX_SUBGRAPH_TARGET "${ONNX_SUBGRAPH}_target")
+
+    add_custom_command(OUTPUT ${ONNX_SUBGRAPH_BIN}
+        COMMAND ${CMAKE_COMMAND} -E copy "${ONNX_SUBGRAPH_SRC}" "${ONNX_SUBGRAPH_BIN}"
+        DEPENDS ${ONNX_SUBGRAPH_SRC}
+        COMMENT "Generate ${ONNX_SUBGRAPH_BIN}"
+    )
+    add_custom_target(${ONNX_SUBGRAPH_TARGET} ALL DEPENDS ${ONNX_SUBGRAPH_BIN})
+    install(FILES ${ONNX_SUBGRAPH_BIN}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
+        DESTINATION bin
+    )
+endforeach(ONNX_SUBGRAPH)

--- a/tools/onnx_subgraph/CMakeLists.txt
+++ b/tools/onnx_subgraph/CMakeLists.txt
@@ -13,3 +13,29 @@ find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${Python3_INCLUDE_DIRS})
+
+set(ONNX_SUGRAPH_FILES                                                          
+    test_model_download.sh
+ )                                                                            
+                                                                              
+ foreach(ONNX_SUGRAPH IN ITEMS ${ONNX_SUGRAPH_FILES})                                                                                                        
+   set(ONNX_SUGRAPH_FILE ${ONNX_SUGRAPH})                                           
+   set(ONNX_SUGRAPH_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${ONNX_SUGRAPH_FILE}")         
+   set(ONNX_SUGRAPH_BIN "${CMAKE_CURRENT_BINARY_DIR}/scripts/${ONNX_SUGRAPH_FILE}")         
+   set(ONNX_SUGRAPH_TARGET "${ONNX_SUGRAPH}_target")                                
+                                                                              
+   add_custom_command(OUTPUT ${ONNX_SUGRAPH_BIN}                                 
+     COMMAND ${CMAKE_COMMAND} -E copy "${ONNX_SUGRAPH_SRC}" "${ONNX_SUGRAPH_BIN}"   
+     DEPENDS ${ONNX_SUGRAPH_SRC}                                                 
+     COMMENT "Generate ${ONNX_SUGRAPH_BIN}"                                      
+   )                                                                          
+                                                                              
+   add_custom_target(${ONNX_SUGRAPH_TARGET} ALL DEPENDS ${ONNX_SUGRAPH_BIN})        
+                                                                              
+   install(FILES ${ONNX_SUGRAPH_BIN}                                             
+           PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE                   
+                       GROUP_READ GROUP_EXECUTE                               
+                       WORLD_READ WORLD_EXECUTE                               
+           DESTINATION bin)                                                   
+                                                                              
+ endforeach(ONNX_SUGRAPH) 

--- a/tools/onnx_subgraph/test_model_download.sh
+++ b/tools/onnx_subgraph/test_model_download.sh
@@ -1,15 +1,10 @@
-pip install onnx onnxsim
+#!/bin/bash
 
-if [ ! -d "./models/" ];then
-  mkdir ./models/
-  else
-  echo "./models path existing"
-fi
+pip install --user onnx onnxsim
+
+mkdir -p models
 
 cd ./models
 wget https://media.githubusercontent.com/media/onnx/models/refs/heads/main/Computer_Vision/resnext26ts_Opset16_timm/resnext26ts_Opset16.onnx --no-check-certificate
-#wget https://media.githubusercontent.com/media/onnx/models/refs/heads/main/Natural_Language_Processing/xmod_Opset16_transformers/xmod_Opset16.onnx --no-check-certificate
 
 onnxsim resnext26ts_Opset16.onnx ../resnet-test.onnx
-#onnxsim xmod_Opset16.onnx ../xmod-transformer-test.onnx
-

--- a/tools/onnx_subgraph/test_model_download.sh
+++ b/tools/onnx_subgraph/test_model_download.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-pip install --user onnx onnxsim
-
 mkdir -p models
 
 cd ./models

--- a/tools/onnx_subgraph/test_model_download.sh
+++ b/tools/onnx_subgraph/test_model_download.sh
@@ -1,0 +1,15 @@
+pip install onnx onnxsim
+
+if [ ! -d "./models/" ];then
+  mkdir ./models/
+  else
+  echo "./models path existing"
+fi
+
+cd ./models
+wget https://media.githubusercontent.com/media/onnx/models/refs/heads/main/Computer_Vision/resnext26ts_Opset16_timm/resnext26ts_Opset16.onnx --no-check-certificate
+#wget https://media.githubusercontent.com/media/onnx/models/refs/heads/main/Natural_Language_Processing/xmod_Opset16_transformers/xmod_Opset16.onnx --no-check-certificate
+
+onnxsim resnext26ts_Opset16.onnx ../resnet-test.onnx
+#onnxsim xmod_Opset16.onnx ../xmod-transformer-test.onnx
+


### PR DESCRIPTION
related issue: https://github.com/Samsung/ONE/issues/14534
historical PR:
https://github.com/Samsung/ONE/pull/14654
https://github.com/Samsung/ONE/pull/14613

Add test onnx models downloading scripts for future smoking test, downloading will happen in installing path, will not effect git status.

ONE-DCO-1.0-Signed-off-by: Youxin Chen <yx113.chen@samsung.com>