### PR TITLE
[circle-mlir] Enable td generation

### DIFF
--- a/circle-mlir/circle-mlir/lib/dialect/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/lib/dialect/CMakeLists.txt
@@ -9,3 +9,5 @@ cir_mlir_static_flags(cirmlir_dialect)
 target_include_directories(cirmlir_dialect PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_include_directories(cirmlir_dialect PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(cirmlir_dialect PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+# use generated files
+add_dependencies(cirmlir_dialect circle_mlir_gen_inc)

--- a/circle-mlir/circle-mlir/lib/dialect/mlir/TableGen.cmake
+++ b/circle-mlir/circle-mlir/lib/dialect/mlir/TableGen.cmake
@@ -8,3 +8,5 @@ mlir_tablegen(mlir/CircleOpInterface.h.inc -gen-op-interface-decls)
 mlir_tablegen(mlir/CircleOpInterface.cc.inc -gen-op-interface-defs)
 mlir_tablegen(mlir/CircleOpsDialect.h.inc -gen-dialect-decls)
 mlir_tablegen(mlir/CircleOpsDialect.cc.inc -gen-dialect-defs)
+
+add_public_tablegen_target(circle_mlir_gen_inc)


### PR DESCRIPTION
This will add circle_mlir_gen_inc target and by adding depencency, include files are actually generated.
