### PR TITLE
[onert] Add todo comments about std::string_view

### DIFF
--- a/runtime/onert/api/nnfw/src/CustomKernelRegistry.h
+++ b/runtime/onert/api/nnfw/src/CustomKernelRegistry.h
@@ -39,6 +39,8 @@ public:
   std::unique_ptr<CustomKernel> buildKernelForOp(const std::string &id);
 
 private:
+  // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+  //       to use `std::string_view` with lookup functions in unordered containers
   std::unordered_map<std::string, nnfw_custom_eval> _storage;
 };
 

--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -121,6 +121,8 @@ private:
   Operands _operands;
   OperandIndexSequence _inputs;
   OperandIndexSequence _outputs;
+  // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+  //       to use `std::string_view` with lookup functions in unordered containers
   std::unordered_map<std::string, IOIndex> _name_to_input;
   std::unordered_map<std::string, IOIndex> _name_to_output;
 };

--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -193,6 +193,8 @@ public:
   }
 
 private:
+  // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+  //       to use `std::string_view` with lookup functions in unordered containers
   std::unordered_map<std::string, std::unique_ptr<const ir::Data>> _metadatas;
 };
 } // namespace onert::ir

--- a/runtime/onert/core/include/util/ConfigSource.h
+++ b/runtime/onert/core/include/util/ConfigSource.h
@@ -23,6 +23,8 @@
 namespace onert::util
 {
 
+// TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+//       to use `std::string_view` with lookup functions in unordered containers
 using CfgKeyValues = std::unordered_map<std::string, std::string>;
 
 void setConfigKeyValues(const CfgKeyValues &keyValues);

--- a/runtime/onert/core/src/compiler/HEScheduler.h
+++ b/runtime/onert/core/src/compiler/HEScheduler.h
@@ -165,6 +165,8 @@ private:
   // whether it should assign these backends to these nodes:
   // * It stores false for unsupported nodes
   // * During rank calculation with enabled profiling mode it stores true for supported nodes
+  // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+  //       to use `std::string_view` with lookup functions in unordered containers
   std::unordered_map<const backend::Backend *, std::unordered_map<std::string, bool>> _is_supported;
   // Finishing and starting time of each backend
   std::unordered_map<const backend::Backend *, std::map<int64_t, int64_t>> _backends_avail_time;

--- a/runtime/onert/core/src/dumper/dot/Node.h
+++ b/runtime/onert/core/src/dumper/dot/Node.h
@@ -113,6 +113,8 @@ public:
 
 private:
   std::string _id;
+  // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+  //       to use `std::string_view` with lookup functions in unordered containers
   std::unordered_map<std::string, std::string> _attributes;
   std::vector<Node *> _out_edges;
 };

--- a/runtime/onert/core/src/exec/JSONExecTime.h
+++ b/runtime/onert/core/src/exec/JSONExecTime.h
@@ -27,6 +27,8 @@
 namespace onert::exec
 {
 
+// TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+//       to use `std::string_view` with lookup functions in unordered containers
 /**
  * @brief table, that contains execution time of an operation on some backend for different input
  * sizes and transfer time from one backend to another for various input sizes (permutation time)
@@ -59,6 +61,8 @@ public:
 private:
   ///@brief file containing measurements
   std::string _measurement_file;
+  // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+  //       to use `std::string_view` with lookup functions in unordered containers
   std::unordered_map<std::string, const backend::Backend *> _backends;
   MeasurementData &_measurements;
 

--- a/runtime/onert/core/src/ir/OpCode.cc
+++ b/runtime/onert/core/src/ir/OpCode.cc
@@ -33,6 +33,8 @@ const char *toString(OpCode opcode)
 
 OpCode toOpCode(const std::string str)
 {
+  // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+  //       to use `std::string_view` with lookup functions in unordered containers
   static const std::unordered_map<std::string, OpCode> map{
 #define OP(Name) {#Name, OpCode::Name},
 #include "ir/Operations.lst"

--- a/runtime/onert/core/src/util/ConfigSource.cc
+++ b/runtime/onert/core/src/util/ConfigSource.cc
@@ -66,6 +66,8 @@ static IConfigSource *config_source()
 
 static std::string getConfigOrDefault(const std::string &key)
 {
+  // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+  //       to use `std::string_view` with lookup functions in unordered containers
   static std::unordered_map<std::string, std::string> defaults;
   if (defaults.empty())
   {

--- a/runtime/onert/core/src/util/SNPEEventWriter.cc
+++ b/runtime/onert/core/src/util/SNPEEventWriter.cc
@@ -127,6 +127,8 @@ void SNPEWriter::flush(const std::vector<std::unique_ptr<EventRecorder>> &record
   {
     // NOTE This assumes _duration_events is sorted by "ts" ascending
 
+    // TODO: Apply Heterogeneous lookup for unordered containers (transparent hashing) since C++20
+    //       to use `std::string_view` with lookup functions in unordered containers
     // 2D keys : stats[tid][name]
     std::unordered_map<std::string, std::unordered_map<std::string, Stat>> stats;
     std::unordered_map<std::string, std::unordered_map<std::string, uint64_t>> begin_timestamps;


### PR DESCRIPTION
This commit adds todo comments about std::string_view. To use std::string_view with unordered associative containers that have std::string keys, heterogeneous lookup support is required. But, Heterogeneous lookup for unordered associative containers is supported since C++20.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>