### PR TITLE
[circle-mlir/infra] Introduce ONNX2CIRCLE_TEST_MODELS_SINGLE

### DIFF
--- a/circle-mlir/infra/cmake/CfgOptionFlags.cmake
+++ b/circle-mlir/infra/cmake/CfgOptionFlags.cmake
@@ -1,6 +1,8 @@
 #
 # configuration options
 #
+option(ONNX2CIRCLE_TEST_MODELS_SINGLE "Run onnx2cirle-models test with one at a time" OFF)
+
 option(ENABLE_TEST "Enable module unit test and integration test" ON)
 option(ENABLE_COVERAGE "Enable build for coverage test" OFF)
 


### PR DESCRIPTION
This will introduce ONNX2CIRCLE_TEST_MODELS_SINGLE option
to test one model at a time, not to mix logs for better readability
as test runs in parallel.
