### PR TITLE
[tools/onnx-subgraph] Add onnx subgraph python code by given nodes

### DIFF
--- a/tools/onnx_subgraph/CMakeLists.txt
+++ b/tools/onnx_subgraph/CMakeLists.txt
@@ -16,6 +16,8 @@ include_directories(${Python3_INCLUDE_DIRS})
 
 set(ONNX_SUBGRAPH_FILES                                                 
     test_model_download.sh
+    extract_onnx.py
+    subgraphs_ios.txt
 )
 foreach(ONNX_SUBGRAPH IN ITEMS ${ONNX_SUBGRAPH_FILES})
     set(ONNX_SUBGRAPH_FILE ${ONNX_SUBGRAPH})

--- a/tools/onnx_subgraph/extract_onnx.py
+++ b/tools/onnx_subgraph/extract_onnx.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import onnx
+import re
+import os
+
+
+def split_subgraph_ios(iofile):
+    iolist = re.split('--input-name |;--output-name ', iofile)
+    in_ = iolist[1].split(';')
+    out_ = iolist[2].split(';')
+    del out_[-1]
+    type = iolist[0].split('subgraph')[0]
+    return in_, out_, type
+
+
+def split_onnx_ios(instrfile,
+                   input_path='net/generation_model_simplify.onnx',
+                   out_folder='subgraphs/'):
+    if not os.path.exists(input_path):
+        print(input_path + " not exist")
+        return
+
+    model = onnx.load(input_path)
+    onnx.checker.check_model(input_path)
+    for output in model.graph.output:
+        model.graph.value_info.append(output)
+    onnx.save(model, input_path)
+    f1 = open(instrfile, "r")
+    lines = f1.readlines()
+    cpu_count = 0
+    npu_count = 0
+    count = 0
+    if not os.path.exists(out_folder):
+        os.makedirs(out_folder)
+    for line in lines:
+        input_names, output_names, type = split_subgraph_ios(line)
+        if (type == 'CPU'):
+            count = cpu_count
+            cpu_count = cpu_count + 1
+        else:
+            count = npu_count
+            npu_count = npu_count + 1
+        output_path_folder = out_folder
+        if not os.path.exists(output_path_folder):
+            os.makedirs(output_path_folder)
+        output_path = output_path_folder + type + 'subgraph' + str(count) + '.onnx'
+        if ((input_names != ['']) and (output_names != [''])):
+            onnx.utils.extract_model(input_path, output_path, input_names, output_names)
+            print("succeed", count)
+            count = count + 1
+    f1.close()
+
+
+if __name__ == "__main__":
+    split_onnx_ios('./scripts/subgraphs_ios.txt', './resnet-test.onnx')

--- a/tools/onnx_subgraph/extract_onnx.py
+++ b/tools/onnx_subgraph/extract_onnx.py
@@ -42,9 +42,6 @@ def split_onnx_ios(instrfile, input_path, out_folder='subgraphs/'):
     npu_count = 0
     count = 0
 
-    if not os.path.exists(out_folder):
-        os.makedirs(out_folder)
-
     for line in lines:
         input_names, output_names, type = split_subgraph_ios(line)
         if (type == 'CPU'):

--- a/tools/onnx_subgraph/subgraphs_ios.txt
+++ b/tools/onnx_subgraph/subgraphs_ios.txt
@@ -1,0 +1,4 @@
+NPUsubgraph0: order0--input-name x;--output-name /stem/conv3/bn/act/Mul_output_0;
+NPUsubgraph1: order2--input-name /stem/pool/MaxPool_output_0;--output-name /stages/stages.3/stages.3.1/act/Mul_output_0;
+CPUsubgraph0: order1--input-name /stem/conv3/bn/act/Mul_output_0;--output-name /stem/pool/MaxPool_output_0;
+CPUsubgraph1: order3--input-name /stages/stages.3/stages.3.1/act/Mul_output_0;--output-name 316;


### PR DESCRIPTION
related issue: https://github.com/Samsung/ONE/issues/14534
historical full changes PR: https://github.com/Samsung/ONE/pull/14613

1. subgraphs_ios.txt is node position information for onnx model splitting, it will be generated by future code,  it is used for smoking test now, and will be removed until can be generated auto
2. extract_onnx.py can split the onnx model to sub models

ONE-DCO-1.0-Signed-off-by: Youxin Chen <yx113.chen@samsung.com>