### PR TITLE
[circle-mlir/infra] Revise numpy package version

### DIFF
--- a/circle-mlir/infra/docker/u2204/Dockerfile
+++ b/circle-mlir/infra/docker/u2204/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
 RUN apt-get update \
  && apt-get -qqy install python3 python3-pip python3-venv python3-dev python3-all dh-python
 RUN python3 -m pip install --upgrade pip setuptools
-RUN python3 -m pip install yapf==0.43.0 numpy h5py==3.8.0 einops
+RUN python3 -m pip install yapf==0.43.0 numpy==1.26.4 h5py==3.8.0 einops
 
 # TODO upgrade
 ARG VER_TORCH=2.1.0

--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -62,3 +62,4 @@ ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnx==${VER_ONNX}
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnxruntime==${VER_ONNXRUNTIME}
 
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install h5py einops
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install numpy==1.26.4


### PR DESCRIPTION
This will revise numpy package install with version
to prevent version incompatible error using numpy==2.x.y.