### PR TITLE
[circle-mlir] Revise converter-gen CMakeLists

### DIFF
--- a/circle-mlir/circle-mlir/lib/tools/converter-gen/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/lib/tools/converter-gen/CMakeLists.txt
@@ -3,7 +3,6 @@ set(SRC
 )
 
 add_executable(converter-gen ${SRC})
-llvm_update_compile_flags(converter-gen)
 cir_mlir_tablegen_flags(converter-gen)
 
 # below function is from llvm-project/llvm/cmake/modules/TableGen.cmake


### PR DESCRIPTION
This will revise converter-gen CMakeLists with llvm_update_compile_flags() removed
as cir_mlir_tablegen_flags() includes calling it.