### PR TITLE
[circle-mlir/tools] Enable options to onnx2circle tool

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/CMakeLists.txt
@@ -18,5 +18,8 @@ target_link_libraries(onnx2circle PUBLIC cirmlir_dialect)
 target_link_libraries(onnx2circle PUBLIC cirmlir_pass)
 target_link_libraries(onnx2circle PUBLIC cirmlir_export)
 target_link_libraries(onnx2circle PUBLIC cirmlir_coverage)
+if(RELEASE_BUILD)
+  target_link_libraries(onnx2circle PUBLIC arser)
+endif()
 
 install(TARGETS onnx2circle DESTINATION bin)

--- a/circle-mlir/circle-mlir/tools/onnx2circle/src/cmdOptions.h
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/src/cmdOptions.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CMD_OPTIONS_H__
+#define __CMD_OPTIONS_H__
+
+namespace opts
+{
+
+inline const char *__opt_save_ops = "Save operators list instead of .circle ";
+inline const char *__opt_unroll_rnn_d = "Unroll RNN Op if exist";
+inline const char *__opt_unroll_lstm_d = "Unroll LSTM Op if exist";
+inline const char *__opt_edbuf_d = "Tensorflow experimental_disable_batchmatmul_unfold";
+inline const char *__opt_keep_io_order_d = "Rename I/O to match order (obsolete)";
+inline const char *__opt_save_int_d = "Save intermediate files (obsolete)";
+inline const char *__opt_check_shapeinf = "Validate shape inference";
+inline const char *__opt_check_dynshapeinf = "Validate dynamic shape inference";
+
+} // namespace opts
+
+#endif // __CMD_OPTIONS_H__

--- a/circle-mlir/circle-mlir/tools/onnx2circle/src/driverRelease.cpp
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/src/driverRelease.cpp
@@ -15,13 +15,108 @@
  */
 
 #include "onnx2circle.h"
+#include "cmdOptions.h"
+
+#include <arser/arser.h>
 
 #include <iostream>
 
+using namespace opts;
+
+std::string get_copyright(void)
+{
+  std::string str;
+  str = "Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved\r\n";
+  str += "Licensed under the Apache License, Version 2.0\r\n";
+  str += "https://github.com/Samsung/ONE";
+  return str;
+}
+
+void print_version(void)
+{
+  std::cout << "onnx2circle version " << __version << std::endl;
+  std::cout << get_copyright() << std::endl;
+}
+
+void print_version_only(void) { std::cout << __version; }
+
 int safe_main(int argc, char *argv[])
 {
-  // TODO parse arguments
+  arser::Arser arser;
+
+  arser::Helper::add_version(arser, print_version);
+
+  arser.add_argument("--version_only")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("Show version number only and exit")
+    .exit_with(print_version_only);
+
+  arser.add_argument("--save_ops")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help(__opt_save_ops);
+
+  arser.add_argument("--unroll_rnn")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help(__opt_unroll_rnn_d);
+
+  arser.add_argument("--unroll_lstm")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help(__opt_unroll_lstm_d);
+
+  arser.add_argument("--experimental_disable_batchmatmul_unfold")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help(__opt_edbuf_d);
+
+  // ignored obsolete options
+  arser.add_argument("--keep_io_order")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help(__opt_keep_io_order_d);
+
+  arser.add_argument("--save_intermediate")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help(__opt_save_int_d);
+
+  arser.add_argument("--check_shapeinf")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help(__opt_check_shapeinf);
+
+  arser.add_argument("--check_dynshapeinf")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help(__opt_check_dynshapeinf);
+
+  // two positional arguments
+  arser.add_argument("onnx").help("Input ONNX file");
+  arser.add_argument("circle").help("Output Circle file");
+
+  arser.parse(argc, argv);
+
   O2Cparam param;
+  param.sourcefile = arser.get<std::string>("onnx");
+  param.targetfile = arser.get<std::string>("circle");
+  param.save_ops = arser.get<bool>("--save_ops");
+  param.unroll_rnn = arser.get<bool>("--unroll_rnn");
+  param.unroll_lstm = arser.get<bool>("--unroll_lstm");
+  param.unfold_batchmatmul = !arser.get<bool>("--experimental_disable_batchmatmul_unfold");
+  param.check_shapeinf = arser.get<bool>("--check_shapeinf");
+  param.check_dynshapeinf = arser.get<bool>("--check_dynshapeinf");
 
   return entry(param);
 }


### PR DESCRIPTION
This will enable options to onnx2circle tool.
- debug uses llvm:cl:opt
- release uses arser, not expose MLIR/ONNX-MLIR options