### PR TITLE
[circle-mlir/pass] Introduce dumpCircleOps

### DIFF
--- a/circle-mlir/circle-mlir/lib/pass/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/lib/pass/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SRC
   src/CirclePass.cpp
   src/ConvertONNXToCirclePass.cpp
   src/ConvertHelper.cpp
+  src/DumpCircleOpsPass.cpp
 )
 
 add_library(cirmlir_pass STATIC ${SRC})

--- a/circle-mlir/circle-mlir/lib/pass/src/DumpCircleOpsPass.cpp
+++ b/circle-mlir/circle-mlir/lib/pass/src/DumpCircleOpsPass.cpp
@@ -14,23 +14,35 @@
  * limitations under the License.
  */
 
-#ifndef __CIRCLE_MLIR_PASS_CIRCLE_PASS_H__
-#define __CIRCLE_MLIR_PASS_CIRCLE_PASS_H__
+#include "DumpCircleOpsPass.h"
 
-#include <mlir/IR/BuiltinOps.h>
-#include <mlir/IR/Dialect.h>
-#include <mlir/IR/MLIRContext.h>
+#include <circle-mlir/dialect/CircleDialect.h>
+
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/PatternMatch.h>
 
 namespace mlir
 {
 namespace Circle
 {
 
-int convertToCircle(mlir::MLIRContext &context, mlir::OwningOpRef<mlir::ModuleOp> &module);
-int dumpCircleOps(llvm::raw_fd_ostream &os, mlir::MLIRContext &context,
-                  mlir::OwningOpRef<mlir::ModuleOp> &module);
+void DumpCircleOpsPass::runOnOperation()
+{
+  mlir::func::FuncOp func = getOperation();
+
+  for (auto &region : func->getRegions())
+    dumpRegion(region);
+}
+
+void DumpCircleOpsPass::dumpRegion(mlir::Region &region)
+{
+  region.walk([&](mlir::Operation *op) { ostream() << op->getName() << "\n"; });
+
+  region.walk([&](mlir::Operation *op) {
+    for (auto &region : op->getRegions())
+      dumpRegion(region);
+  });
+}
 
 } // namespace Circle
 } // namespace mlir
-
-#endif // __CIRCLE_MLIR_PASS_CIRCLE_PASS_H__

--- a/circle-mlir/circle-mlir/lib/pass/src/DumpCircleOpsPass.h
+++ b/circle-mlir/circle-mlir/lib/pass/src/DumpCircleOpsPass.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLE_MLIR_PASS_DUMP_CIRCLE_OPS_PASS_H__
+#define __CIRCLE_MLIR_PASS_DUMP_CIRCLE_OPS_PASS_H__
+
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Func/Transforms/Passes.h>
+
+#include <functional>
+
+namespace mlir
+{
+namespace Circle
+{
+
+struct DumpCircleOpsPass
+  : public mlir::PassWrapper<DumpCircleOpsPass, mlir::OperationPass<mlir::func::FuncOp>>
+{
+  DumpCircleOpsPass() = default;
+  DumpCircleOpsPass(const DumpCircleOpsPass &pass)
+    : mlir::PassWrapper<DumpCircleOpsPass, OperationPass<mlir::func::FuncOp>>()
+  {
+    _getOStream = pass._getOStream;
+  }
+
+  llvm::StringRef getArgument() const override { return "circle-dump-ops"; }
+
+  llvm::StringRef getDescription() const override { return "Dump Circle ops"; }
+
+  Option<std::string> target{*this, "target", ::llvm::cl::desc("Dump Circle operators"),
+                             ::llvm::cl::init("")};
+
+  void runOnOperation() final;
+
+protected:
+  void dumpRegion(mlir::Region &region);
+
+public:
+  using GetOStream_t = std::function<llvm::raw_fd_ostream &(void)>;
+
+  void ostream(GetOStream_t os) { _getOStream = os; }
+  llvm::raw_fd_ostream &ostream(void) { return _getOStream(); }
+
+protected:
+  GetOStream_t _getOStream = nullptr;
+};
+
+} // namespace Circle
+} // namespace mlir
+
+#endif // __CIRCLE_MLIR_PASS_DUMP_CIRCLE_OPS_PASS_H__


### PR DESCRIPTION
This will introduce dumpCircleOps method with DumpCircleOpsPass class
to dump Circle Ops for test and validation.
