### PR TITLE
[circle-mlir/tools] Introduce unit tests for loadONNX

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/CMakeLists.txt
@@ -23,3 +23,21 @@ if(RELEASE_BUILD)
 endif()
 
 install(TARGETS onnx2circle DESTINATION bin)
+
+if(NOT ENABLE_TEST)
+  return()
+endif()
+
+set(SRC_TEST
+  src/onnx2circle.cpp
+  src/onnx2circle.test.cpp
+)
+
+GTest_AddTest_Public(onnx2circle_test ${SRC_TEST})
+cir_mlir_static_flags(onnx2circle_test)
+cir_onnx_static_flags(onnx2circle_test)
+cir_onnx_tools_flags(onnx2circle_test)
+target_link_libraries(onnx2circle_test PUBLIC cirmlir_dialect)
+target_link_libraries(onnx2circle_test PUBLIC cirmlir_pass)
+target_link_libraries(onnx2circle_test PUBLIC cirmlir_export)
+target_link_libraries(onnx2circle_test PUBLIC cirmlir_coverage)

--- a/circle-mlir/circle-mlir/tools/onnx2circle/src/onnx2circle.test.cpp
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/src/onnx2circle.test.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/BuiltinOps.h>
+
+#include <string>
+
+// delcare methods of onnx2circle.cpp to test
+namespace onnx2circle
+{
+
+int loadONNX(const std::string &onnx_path, mlir::MLIRContext &context,
+             mlir::OwningOpRef<mlir::ModuleOp> &module);
+
+} // namespace onnx2circle
+
+#include <gtest/gtest.h>
+
+TEST(LoadONNXTest, NonExistFile_NEG)
+{
+  mlir::MLIRContext context;
+  mlir::OwningOpRef<mlir::ModuleOp> module;
+
+  std::string invalid_filename = "/no_such_folder/no_such_file_in_storage.mlir";
+  auto result = onnx2circle::loadONNX(invalid_filename, context, module);
+  ASSERT_NE(0, result);
+
+  invalid_filename = "/no_such_folder/no_such_file_in_storage.onnx";
+  result = onnx2circle::loadONNX(invalid_filename, context, module);
+  ASSERT_NE(0, result);
+}
+
+TEST(LoadONNXTest, NotSupportedExtension_NEG)
+{
+  std::string invalid_filename = "somefile.blabla";
+
+  mlir::MLIRContext context;
+  mlir::OwningOpRef<mlir::ModuleOp> module;
+
+  auto result = onnx2circle::loadONNX(invalid_filename, context, module);
+  ASSERT_NE(0, result);
+}


### PR DESCRIPTION
This will introduce two negative unit tests for loadONNX method.
