### PR TITLE
[circle-mlir/tools] Use inline variables in SingleRun

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/src/driverDebug.cpp
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/src/driverDebug.cpp
@@ -123,12 +123,9 @@ public:
   }
 
 private:
-  static int _lock_fd;
-  static const char *const _lock_file;
+  inline static int _lock_fd = -1;
+  inline static const char *const _lock_file = "/tmp/onnx2cirlce_run_single.lock";
 };
-
-int SingleRun::_lock_fd = -1;
-const char *const SingleRun::_lock_file = "/tmp/onnx2cirlce_run_single.lock";
 
 void onexit() { SingleRun::Release(); }
 


### PR DESCRIPTION
This commits changes SingleRun's member variables to inline variables.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>