### PR TITLE
Throw instead of logging in ImporterEx::importVerifyModule

### DIFF
--- a/compiler/circle-interpreter/src/CircleInterpreter.cpp
+++ b/compiler/circle-interpreter/src/CircleInterpreter.cpp
@@ -104,8 +104,7 @@ int entry(int argc, char **argv)
   const auto output_prefix = arser.get<std::string>("output_prefix");
 
   // Load model from the file
-  luci::ImporterEx importer;
-  std::unique_ptr<luci::Module> module = importer.importVerifyModule(filename);
+  std::unique_ptr<luci::Module> module = luci::importVerifyModule(filename);
   if (module == nullptr)
   {
     std::cerr << "ERROR: Failed to load '" << filename << "'" << std::endl;

--- a/compiler/luci/import/include/luci/ImporterEx.h
+++ b/compiler/luci/import/include/luci/ImporterEx.h
@@ -56,6 +56,10 @@ private:
   const GraphBuilderSource *_source = nullptr;
 };
 
+// Imports a model from a given file. In case of an error this function logs to std::cerr
+// and returns a nullptr as a result.
+std::unique_ptr<Module> importVerifyModule(const std::string &input_path);
+
 } // namespace luci
 
 #endif // __LUCI_IMPORTER_EX_H__

--- a/compiler/luci/import/src/ImporterEx.cpp
+++ b/compiler/luci/import/src/ImporterEx.cpp
@@ -38,15 +38,7 @@ std::unique_ptr<Module> ImporterEx::importVerifyModule(const std::string &input_
   foder::FileLoader file_loader{input_path};
   std::vector<char> model_data;
 
-  try
-  {
-    model_data = file_loader.load();
-  }
-  catch (const std::runtime_error &err)
-  {
-    std::cerr << err.what() << std::endl;
-    return nullptr;
-  }
+  model_data = file_loader.load();
 
   auto data_data = reinterpret_cast<uint8_t *>(model_data.data());
   auto data_size = model_data.size();
@@ -72,6 +64,21 @@ std::unique_ptr<Module> ImporterEx::importModule(const std::vector<char> &model_
 
   Importer importer(_source);
   return importer.importModule(data_data, data_size);
+}
+
+std::unique_ptr<Module> importVerifyModule(const std::string &input_path)
+{
+  ImporterEx importer;
+  std::unique_ptr<Module> model;
+  try
+  {
+    model = importer.importVerifyModule(input_path);
+  }
+  catch (const std::runtime_error &err)
+  {
+    std::cerr << err.what() << std::endl;
+  }
+  return model;
 }
 
 } // namespace luci


### PR DESCRIPTION
Submitting a new PR instead of https://github.com/Samsung/ONE/pull/14724



This is a proposal of a change of the underlying behavior of the ImporterEx::importVerifyModule method.

It's related to the comments in the NPU_Compiler/pull/20425 pull request where the switch to the current version of this method has been rejected.

The proposal changes the error handling of importVerifyModule from writing directly to std::cerr to throwing an exception instead. This way different users of this method can decide how they want to handle the error.

At the same time this PR contains a helper function which maintains the behavior in this repository - the verifier error, if occurs, will be logged to std::cerr. The code adaptation in this repository is also minimal with this approach.

Related issue: NPU_Compiler/issues/20383
Related PR: NPU_Compiler/pull/20425
