### PR TITLE
[circle-mlir/pass] Execute RuntimeVerifyPass

### DIFF
--- a/circle-mlir/circle-mlir/lib/pass/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/lib/pass/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SRC
   src/ConvertHelper.cpp
   src/RewriteONNXPass.cpp
   src/DumpCircleOpsPass.cpp
+  src/RuntimeVerifyPass.cpp
 )
 
 add_library(cirmlir_pass STATIC ${SRC})

--- a/circle-mlir/circle-mlir/lib/pass/src/CirclePass.cpp
+++ b/circle-mlir/circle-mlir/lib/pass/src/CirclePass.cpp
@@ -19,6 +19,7 @@
 #include "ConvertONNXToCirclePass.h"
 #include "RewriteONNXPass.h"
 #include "DumpCircleOpsPass.h"
+#include "RuntimeVerifyPass.h"
 
 #include <mlir/Pass/PassManager.h>
 #include <mlir/Transforms/Passes.h>
@@ -100,6 +101,7 @@ int convertToCircle(mlir::MLIRContext &context, mlir::OwningOpRef<mlir::ModuleOp
 
   int result = 0;
   pm.addPass(createConvertONNXToCirclePass());
+  pm.addPass(CreateRuntimeVerifyPass());
   pm.addPass(mlir::createCanonicalizerPass());
   auto runres = pm.run(*module);
   if (mlir::failed(runres))

--- a/circle-mlir/circle-mlir/lib/pass/src/RuntimeVerifyPass.cpp
+++ b/circle-mlir/circle-mlir/lib/pass/src/RuntimeVerifyPass.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// from tensorflow/compiler/mlir/lite/transforms/runtime_verify.cc
+
+#include "RuntimeVerifyPass.h"
+
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/OperationSupport.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+
+#include <circle-mlir/dialect/CircleDialect.h>
+
+namespace mlir
+{
+namespace Circle
+{
+
+struct RuntimeVerifyPass
+  : public mlir::PassWrapper<RuntimeVerifyPass, mlir::OperationPass<mlir::func::FuncOp>>
+{
+  RuntimeVerifyPass() = default;
+  RuntimeVerifyPass(const RuntimeVerifyPass &pass)
+    : mlir::PassWrapper<RuntimeVerifyPass, OperationPass<mlir::func::FuncOp>>()
+  {
+    // Do nothing
+  }
+
+  llvm::StringRef getArgument() const override { return "circle-runtime-verify"; }
+  llvm::StringRef getDescription() const override { return "Circle Runtime Verify"; }
+
+  void runOnOperation(void) final;
+};
+
+void RuntimeVerifyPass::runOnOperation(void)
+{
+  getOperation().walk([&](CirRuntimeVerifyOpInterface op) {
+    if (mlir::failed(op.VerifyCirRuntimeConstraints(op.getOperation(), true)))
+      signalPassFailure();
+  });
+}
+
+// Verifies circle runtime constraints.
+std::unique_ptr<mlir::Pass> CreateRuntimeVerifyPass(void)
+{
+  return std::make_unique<RuntimeVerifyPass>();
+}
+
+} // namespace Circle
+} // namespace mlir

--- a/circle-mlir/circle-mlir/lib/pass/src/RuntimeVerifyPass.h
+++ b/circle-mlir/circle-mlir/lib/pass/src/RuntimeVerifyPass.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// from tensorflow/compiler/mlir/lite/transforms/passes.h
+
+#ifndef __CIRCLE_MLIR_PASS_RUNTIME_VERIFY_PASS_H__
+#define __CIRCLE_MLIR_PASS_RUNTIME_VERIFY_PASS_H__
+
+#include <mlir/Pass/Pass.h>
+
+namespace mlir
+{
+namespace Circle
+{
+
+std::unique_ptr<mlir::Pass> CreateRuntimeVerifyPass(void);
+
+} // namespace Circle
+} // namespace mlir
+
+#endif // __CIRCLE_MLIR_PASS_RUNTIME_VERIFY_PASS_H__


### PR DESCRIPTION
This will introduce and execute RuntimeVerifyPass for onnx to circle conversion.
RuntimeVerifyPass will check runtime constraints for each ops, if exist.
