### PR TITLE
[circle-mlir/tools] Enable onnx2circle conversion and export

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/CMakeLists.txt
@@ -28,6 +28,8 @@ if(NOT ENABLE_TEST)
   return()
 endif()
 
+include(TestModels.cmake)
+
 set(SRC_TEST
   src/onnx2circle.cpp
   src/onnx2circle.test.cpp

--- a/circle-mlir/circle-mlir/tools/onnx2circle/TestModels.cmake
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/TestModels.cmake
@@ -1,0 +1,33 @@
+set(FILE_DEPS )
+
+# ConvertUnitModel used in test.lst
+set(TEST_MODELS )
+macro(ConvertUnitModel MLIR_FNAME)
+  # copy to build folder
+  set(TEST_MLIR_MODEL_SRC "${CMAKE_SOURCE_DIR}/models/mlir/${MLIR_FNAME}")
+  set(TEST_MLIR_MODEL_DST "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MLIR_FNAME}")
+  add_custom_command(
+    OUTPUT ${TEST_MLIR_MODEL_DST}
+    COMMAND ${CMAKE_COMMAND} -E copy "${TEST_MLIR_MODEL_SRC}" "${TEST_MLIR_MODEL_DST}"
+    DEPENDS ${TEST_MLIR_MODEL_SRC}
+    COMMENT "tools/onnx2circle: prepare mlir/${MLIR_FNAME}"
+  )
+  list(APPEND TEST_MODELS "${MLIR_FNAME}")
+  list(APPEND FILE_DEPS "${TEST_MLIR_MODEL_DST}")
+endmacro(ConvertUnitModel)
+
+# Read "test.lst"
+include("test.lst")
+
+add_custom_target(onnx2circle_deps ALL DEPENDS ${FILE_DEPS})
+
+foreach(MODEL IN ITEMS ${TEST_MODELS})
+  set(MLIR_MODEL_PATH "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MODEL}")
+  set(CIRCLE_MODEL_PATH "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MODEL}.circle")
+  add_test(
+    NAME onnx2circle_test_${MODEL}
+    COMMAND "$<TARGET_FILE:onnx2circle>"
+      "${MLIR_MODEL_PATH}"
+      "${CIRCLE_MODEL_PATH}"
+  )
+endforeach()

--- a/circle-mlir/circle-mlir/tools/onnx2circle/src/onnx2circle.cpp
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/src/onnx2circle.cpp
@@ -145,6 +145,10 @@ int convertToCircle(const O2Cparam &param)
   if (result != 0)
     return result;
 
+  result = mlir::Circle::convertToCircle(context, module);
+  if (result != 0)
+    return result;
+
   std::string error_msg;
   if (param.save_ops)
   {
@@ -162,7 +166,13 @@ int convertToCircle(const O2Cparam &param)
     return result;
   }
 
-  // TODO add processing
+  std::string serialized_flatbuffer;
+  if (!mlir::Circle::MlirToFlatBufferTranslateFunction(module.get(), &serialized_flatbuffer))
+    return -1;
+  auto output = mlir::openOutputFile(targetfile, &error_msg);
+  // TODO error handle
+  output->os() << serialized_flatbuffer;
+  output->keep();
 
   return 0;
 }

--- a/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
@@ -1,0 +1,6 @@
+## EXAMPLE
+#
+# ConvertUnitModel(test_mode.mlir)
+#
+
+ConvertUnitModel(Add_F32.onnx.mlir)


### PR DESCRIPTION
This will enable onnx2circle tool conversion from onnx to circle and export to circle model file.
Test is also added with AddOp.
