### PR TITLE
[tools/mec] Fix noxfile.py correctly

### DIFF
--- a/tools/model_explorer_circle/noxfile.py
+++ b/tools/model_explorer_circle/noxfile.py
@@ -16,7 +16,7 @@ import os
 import nox
 
 # Define the minimal nox version required to run
-nox.options.needs_version = ">= 2024.3.2"
+nox.needs_version = ">= 2024.3.2"
 
 
 @nox.session


### PR DESCRIPTION
The 'needs_version' object is belong to Nox module not NoxOptions.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>