### PR TITLE
[circle-mlir/tools-test] Add exec_circle and make_circle_input

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/CMakeLists.txt
@@ -18,6 +18,8 @@ endmacro(COPY_SCRIPT)
 # copy test scripts
 COPY_SCRIPT(run_value_test.sh)
 COPY_SCRIPT(exec_onnx.py)
+COPY_SCRIPT(exec_circle.py)
+COPY_SCRIPT(make_circle_input.py)
 COPY_SCRIPT(util_h5_file.py)
 
 add_custom_target(

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/exec_circle.py
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/exec_circle.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+from pathlib import Path
+
+
+def exec_model(circle_model):
+    # Execute circle-interpreter
+    one_compiler_root = os.getenv('ONE_COMPILER_ROOT')
+    if not one_compiler_root:
+        one_compiler_root = '/usr/share/one'
+    driver = one_compiler_root + '/bin/circle-interpreter'
+    input_data = circle_model + '.input'
+    output_res_data = circle_model + '.output'
+    return subprocess.run([driver, circle_model, input_data, output_res_data], check=True)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        filepath = Path(sys.argv[0])
+        sys.exit('Usage: ' + filepath.name + ' [model.cirle]')
+
+    exec_model(sys.argv[1])

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/make_circle_input.py
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/make_circle_input.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import sys
+import h5py
+
+from pathlib import Path
+
+# local python files
+import util_h5_file
+
+
+# convert() will generate exec_circle input data file from h5 file from exec_onnx
+def convert(ref_model, circle_model, is_nchw=False):
+    # load input data file genererated from exec_onnx, exec_tflite
+    ref_model_name = Path(ref_model).name
+    input_data_path = util_h5_file.get_input_filename(ref_model_name, is_nchw)
+    h5f = h5py.File(input_data_path, 'r')
+    input_names = []
+    input_data = dict()
+    for t in h5f:
+        input_name = str(t)
+        # HACK restore '|' to '/' in name
+        input_name_res = input_name.replace('|', '/')
+        input_names.append(input_name_res)
+        if h5f[input_name].shape == ():
+            input_data[input_name_res] = h5f[input_name][()]
+        else:
+            input_data[input_name_res] = h5f[input_name][:]
+
+    h5f.close()
+
+    # write numinputs file
+    num_inputs = len(input_names)
+    num_inputs_file = open(circle_model + '.numinputs', 'w')
+    num_inputs_file.write(str(num_inputs))
+    num_inputs_file.close()
+
+    # write input data file for exec_circle
+    for i in range(num_inputs):
+        input_name = input_names[i]
+        input_data[input_name].tofile(circle_model + '.input' + str(i))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        filepath = Path(sys.argv[0])
+        sys.exit('Usage: ' + filepath.name + ' [model.reference] [model.cirle]')
+
+    convert(sys.argv[1], sys.argv[2], True)


### PR DESCRIPTION
This will add exec_circle and make_circle_input script for onnx2circle-value-test.
These file are to (1) create circle input file(s) and
(2) execute circle model with the input files(s) with circle-interpreter.