### PR TITLE
[cicle-mlir/tools-test] Enable import test

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/CMakeLists.txt
@@ -21,6 +21,7 @@ endmacro(COPY_SCRIPT)
 
 # copy test scripts
 COPY_SCRIPT(run_value_test.sh)
+COPY_SCRIPT(run_import_test.sh)
 
 get_target_property(ONNX_ARTIFACTS_BIN_PATH gen_onnx_target BINARY_DIR)
 get_target_property(CIRCLE_ARTIFACTS_BIN_PATH onnx2circle_models_target BINARY_DIR)
@@ -75,5 +76,18 @@ foreach(MODEL IN ITEMS ${UNIT_TEST_MODELS})
   add_test(
     NAME circle_impexp_value_test_${MODEL}
     COMMAND bash run_value_test.sh ${VENV_PATH} ${TEST_MODEL_BASE}
+  )
+endforeach()
+
+add_custom_target(
+  circle_impexp_import_test_target ALL
+  DEPENDS ${FILE_DEPS_IMP}
+)
+
+foreach(MODEL IN ITEMS ${UNIT_TEST_MODELS_IMPORT})
+  set(TEST_MODEL_BASE "${CMAKE_CURRENT_BINARY_DIR}/${MODEL}")
+  add_test(
+    NAME circle_impexp_import_test_${MODEL}
+    COMMAND bash run_import_test.sh ${TEST_MODEL_BASE}
   )
 endforeach()

--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/run_import_test.sh
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/run_import_test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script ...
+#
+# HOW TO USE
+#
+# ./run_imp_test.sh <model>
+# model    : model base name
+
+set -e
+
+TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MODEL_NAME="$1"; shift
+
+CIRCLE_SOURCE_FILE="${MODEL_NAME}.circle"
+CIRCLE_TARGET_FILE="${MODEL_NAME}.2.circle"
+
+COMP_RESULT=0
+
+if [[ -f ${CIRCLE_TARGET_FILE} && -s ${CIRCLE_TARGET_FILE} ]]; then
+  # NOTE for initial version just check file exist and not zero length
+  # TODO do more validation
+  echo "${CIRCLE_TARGET_FILE} looks OK"
+else
+  COMP_RESULT=1
+fi
+
+exit ${COMP_RESULT}


### PR DESCRIPTION
This will enable import test, for models that cannot do value test, in circle-impexp-test.
