### PR TITLE
[circle-mlir/tools-test] Introduce exec_circle

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/CMakeLists.txt
@@ -23,6 +23,7 @@ endmacro(COPY_SCRIPT)
 COPY_SCRIPT(run_value_test.sh)
 COPY_SCRIPT(run_import_test.sh)
 COPY_SCRIPT(exec_onnx.py)
+COPY_SCRIPT(exec_circle.py)
 
 get_target_property(ONNX_ARTIFACTS_BIN_PATH gen_onnx_target BINARY_DIR)
 get_target_property(CIRCLE_ARTIFACTS_BIN_PATH onnx2circle_models_target BINARY_DIR)

--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/exec_circle.py
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/exec_circle.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+from pathlib import Path
+
+
+def exec_model(circle_model):
+    # Execute circle-interpreter
+    one_compiler_root = os.getenv('ONE_COMPILER_ROOT')
+    if not one_compiler_root:
+        one_compiler_root = '/usr/share/one'
+    driver = Path(one_compiler_root) / 'bin/circle-interpreter'
+    input_data = circle_model + '.input'
+    output_res_data = circle_model + '.output'
+    return subprocess.run([driver, circle_model, input_data, output_res_data], check=True)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        filepath = Path(sys.argv[0])
+        sys.exit('Usage: ' + filepath.name + ' [model.cirle]')
+
+    exec_model(sys.argv[1])


### PR DESCRIPTION
This will introduce exec_circle script in circle-impexp-test
to execute circle model with circle-interpreter.
