### PR TITLE
[circle-mlir/tools-test] Introduce make_circle_input and util_h5_file

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/CMakeLists.txt
@@ -24,6 +24,8 @@ COPY_SCRIPT(run_value_test.sh)
 COPY_SCRIPT(run_import_test.sh)
 COPY_SCRIPT(exec_onnx.py)
 COPY_SCRIPT(exec_circle.py)
+COPY_SCRIPT(make_circle_input.py)
+COPY_SCRIPT(util_h5_file.py)
 
 get_target_property(ONNX_ARTIFACTS_BIN_PATH gen_onnx_target BINARY_DIR)
 get_target_property(CIRCLE_ARTIFACTS_BIN_PATH onnx2circle_models_target BINARY_DIR)

--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/make_circle_input.py
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/make_circle_input.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import sys
+import h5py
+
+from pathlib import Path
+
+# local python files
+import util_h5_file
+
+
+# convert() will generate exec_circle input data files from h5 file from exec_onnx
+def convert(ref_model, circle_model, is_nchw=False):
+    ref_model_name = Path(ref_model).name
+    input_data_path = util_h5_file.get_input_filename(ref_model_name, is_nchw)
+    h5f = h5py.File(input_data_path, 'r')
+    input_names = []
+    input_data = dict()
+    for t in h5f:
+        input_name = str(t)
+        input_names.append(input_name)
+        if h5f[input_name].shape == ():
+            input_data[input_name] = h5f[input_name][()]
+        else:
+            input_data[input_name] = h5f[input_name][:]
+
+    h5f.close()
+
+    # write numinputs file
+    num_inputs = len(input_names)
+    num_inputs_file = open(circle_model + '.numinputs', 'w')
+    num_inputs_file.write(str(num_inputs))
+    num_inputs_file.close()
+
+    # write input data file for exec_circle
+    for i in range(num_inputs):
+        input_name = input_names[i]
+        input_data[input_name].tofile(circle_model + '.input' + str(i))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        filepath = Path(sys.argv[0])
+        sys.exit('Usage: ' + filepath.name + ' [model.reference] [model.cirle]')
+
+    convert(sys.argv[1], sys.argv[2], True)

--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/util_h5_file.py
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/util_h5_file.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import h5py
+
+
+def get_input_filename(model_name, is_nchw=False):
+    if is_nchw:
+        return model_name + '.nchw.input.h5'
+    else:
+        return model_name + '.nhwc.input.h5'
+
+
+def get_output_filename(model_name, is_nchw=False):
+    if is_nchw:
+        return model_name + '.nchw.output.h5'
+    else:
+        return model_name + '.nhwc.output.h5'
+
+
+def get_h5_from(file_path, mode='r'):
+    if mode != 'r' and mode != 'w':
+        print('Invalid file mode for get_h5_from')
+        raise
+
+    try:
+        h5 = h5py.File(file_path, mode)
+    except:
+        print('cannot open {}. Please check the file path.'.format(file_path))
+        raise
+
+    return h5


### PR DESCRIPTION
This will introduce make_circle_input to generate circle input
for exec_circle script from exec_onnx execution result and
necessary util_h5_file script.
