### PR TITLE
[circle-mlir/tools-test] Enable local test list

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/.gitignore
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/.gitignore
@@ -1,0 +1,1 @@
+test.local.lst

--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/CMakeLists.txt
@@ -102,6 +102,8 @@ endmacro(ImportModel)
 
 # Read "test.lst"
 include("test.lst")
+# Read "test.local.lst" if exists
+include("test.local.lst" OPTIONAL)
 
 add_custom_target(
   circle_impexp_value_test_target ALL


### PR DESCRIPTION
This will enable to use local test model list in circle-impexp-test.
