### PR TITLE
[luci/import] Add an error handler to ImporterEx

### DIFF
--- a/compiler/luci/import/include/luci/ImporterEx.h
+++ b/compiler/luci/import/include/luci/ImporterEx.h
@@ -25,6 +25,7 @@
 // #include "luci/Import/GraphBuilderRegistry.h"
 struct GraphBuilderSource;
 
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -34,14 +35,12 @@ namespace luci
 class ImporterEx final
 {
 public:
-  ImporterEx() = default;
+  ImporterEx();
+  ImporterEx(const std::function<void(const std::exception &)> &error_handler);
 
 public:
   // TODO remove this after embedded-import-value-test has moved to onert-micro
-  explicit ImporterEx(const GraphBuilderSource *source) : _source{source}
-  {
-    // DO NOTHING
-  }
+  explicit ImporterEx(const GraphBuilderSource *source);
 
 public:
   std::unique_ptr<Module> importVerifyModule(const std::string &input_path) const;
@@ -54,6 +53,7 @@ public:
 
 private:
   const GraphBuilderSource *_source = nullptr;
+  std::function<void(const std::exception &)> _error_handler;
 };
 
 } // namespace luci

--- a/compiler/luci/import/src/ImporterEx.cpp
+++ b/compiler/luci/import/src/ImporterEx.cpp
@@ -19,7 +19,6 @@
 
 #include <foder/FileLoader.h>
 
-#include <memory>
 #include <iostream>
 
 namespace luci
@@ -33,6 +32,22 @@ inline constexpr uint64_t FLATBUFFERS_SIZE_MAX = 2147483648UL; // 2GB
 
 } // namespace
 
+ImporterEx::ImporterEx()
+  : _error_handler{[](const std::exception &e) { std::cerr << e.what() << std::endl; }}
+{
+}
+
+ImporterEx::ImporterEx(const std::function<void(const std::exception &)> &error_handler)
+  : _error_handler{error_handler}
+{
+  if (!error_handler)
+  {
+    throw std::runtime_error{"The error handler passed to ImporterEx is invalid"};
+  }
+}
+
+ImporterEx::ImporterEx(const GraphBuilderSource *source) : ImporterEx{} { _source = source; }
+
 std::unique_ptr<Module> ImporterEx::importVerifyModule(const std::string &input_path) const
 {
   foder::FileLoader file_loader{input_path};
@@ -44,7 +59,7 @@ std::unique_ptr<Module> ImporterEx::importVerifyModule(const std::string &input_
   }
   catch (const std::runtime_error &err)
   {
-    std::cerr << err.what() << std::endl;
+    _error_handler(err);
     return nullptr;
   }
 
@@ -56,7 +71,7 @@ std::unique_ptr<Module> ImporterEx::importVerifyModule(const std::string &input_
     flatbuffers::Verifier verifier{data_data, data_size};
     if (!circle::VerifyModelBuffer(verifier))
     {
-      std::cerr << "ERROR: Invalid input file '" << input_path << "'" << std::endl;
+      _error_handler(std::runtime_error{"ERROR: Invalid input file '" + input_path + "'"});
       return nullptr;
     }
   }

--- a/compiler/luci/import/src/ImporterEx.cpp
+++ b/compiler/luci/import/src/ImporterEx.cpp
@@ -20,6 +20,8 @@
 #include <foder/FileLoader.h>
 
 #include <iostream>
+#include <memory>
+#include <stdexcept>
 
 namespace luci
 {

--- a/compiler/luci/import/src/ImporterEx.cpp
+++ b/compiler/luci/import/src/ImporterEx.cpp
@@ -19,8 +19,8 @@
 
 #include <foder/FileLoader.h>
 
-#include <iostream>
 #include <memory>
+#include <iostream>
 #include <stdexcept>
 
 namespace luci

--- a/compiler/luci/import/src/ImporterEx.test.cpp
+++ b/compiler/luci/import/src/ImporterEx.test.cpp
@@ -27,10 +27,13 @@ TEST(ImporterEx, uses_default_error_handler_NEG)
   std::cerr.rdbuf(cerr_substitute.rdbuf());
 
   luci::ImporterEx importer;
-  importer.importVerifyModule("/non/existent.path");
+  const auto model = importer.importVerifyModule("/non/existent.path");
 
   std::cerr.rdbuf(cerr_original_buffer);
 
+  // the test is supposed to fail for a model path that doesn't exist
+  ASSERT_EQ(model, nullptr);
+  // the default constructed importer is expected to log to std::cerr
   ASSERT_GT(cerr_substitute.str().length(), 0);
 }
 
@@ -50,13 +53,17 @@ TEST(ImporterEx, calls_external_error_handler_NEG)
   ErrorHandler handler{error_handler_called};
 
   luci::ImporterEx importer{handler};
-  importer.importVerifyModule("/non/existent.path");
+  const auto model = importer.importVerifyModule("/non/existent.path");
 
+  // the test is supposed to fail for a model path that doesn't exist
+  ASSERT_EQ(model, nullptr);
+  // this importer is expected to call an externally defined error handler
   ASSERT_TRUE(error_handler_called);
 }
 
-TEST(ImporterEx, throws_with_empty_handler_NEG)
+TEST(ImporterEx, constructor_throws_with_empty_handler_NEG)
 {
   std::function<void(const std::exception &)> empty_handler; // this doesn't contain any callable
+  // the constructor should throw to avoid segmentation faults with an empty handler
   ASSERT_THROW(luci::ImporterEx{empty_handler}, std::runtime_error);
 }

--- a/compiler/luci/import/src/ImporterEx.test.cpp
+++ b/compiler/luci/import/src/ImporterEx.test.cpp
@@ -39,7 +39,6 @@ TEST(ImporterEx, uses_default_error_handler_NEG)
 
 TEST(ImporterEx, calls_external_error_handler_NEG)
 {
-
   struct ErrorHandler
   {
     ErrorHandler(bool &flag) : _flag{flag} {}

--- a/compiler/luci/import/src/ImporterEx.test.cpp
+++ b/compiler/luci/import/src/ImporterEx.test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <gtest/gtest.h>
 #include <sstream>
 
-TEST(ImporterEx, logs_to_stderr)
+TEST(ImporterEx, uses_default_error_handler_NEG)
 {
   std::ostringstream cerr_substitute;
 
@@ -34,7 +34,7 @@ TEST(ImporterEx, logs_to_stderr)
   ASSERT_GT(cerr_substitute.str().length(), 0);
 }
 
-TEST(ImporterEx, calls_external_error_handler)
+TEST(ImporterEx, calls_external_error_handler_NEG)
 {
 
   struct ErrorHandler
@@ -55,7 +55,7 @@ TEST(ImporterEx, calls_external_error_handler)
   ASSERT_TRUE(error_handler_called);
 }
 
-TEST(ImporterEx, throws_with_empty_handler_N)
+TEST(ImporterEx, throws_with_empty_handler_NEG)
 {
   std::function<void(const std::exception &)> empty_handler; // this doesn't contain any callable
   ASSERT_THROW(luci::ImporterEx{empty_handler}, std::runtime_error);

--- a/compiler/luci/import/src/ImporterEx.test.cpp
+++ b/compiler/luci/import/src/ImporterEx.test.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/ImporterEx.h"
+
+#include <gtest/gtest.h>
+#include <sstream>
+
+TEST(ImporterEx, logs_to_stderr)
+{
+  std::ostringstream cerr_substitute;
+
+  auto cerr_original_buffer = std::cerr.rdbuf();
+  std::cerr.rdbuf(cerr_substitute.rdbuf());
+
+  luci::ImporterEx importer;
+  importer.importVerifyModule("/non/existent.path");
+
+  std::cerr.rdbuf(cerr_original_buffer);
+
+  ASSERT_GT(cerr_substitute.str().length(), 0);
+}
+
+TEST(ImporterEx, calls_external_error_handler)
+{
+
+  struct ErrorHandler
+  {
+    ErrorHandler(bool &flag) : _flag{flag} {}
+
+    void operator()(const std::exception &) { _flag = true; }
+
+    bool &_flag;
+  };
+
+  bool error_handler_called = false;
+  ErrorHandler handler{error_handler_called};
+
+  luci::ImporterEx importer{handler};
+  importer.importVerifyModule("/non/existent.path");
+
+  ASSERT_TRUE(error_handler_called);
+}
+
+TEST(ImporterEx, throws_with_empty_handler_N)
+{
+  std::function<void(const std::exception &)> empty_handler; // this doesn't contain any callable
+  ASSERT_THROW(luci::ImporterEx{empty_handler}, std::runtime_error);
+}


### PR DESCRIPTION
This commit adds the ability to add external error handlers to the ImporterEx.

By default the class logs all messages from potential errors occurring during the call to importVerifyModule(). Users can inject their own error handler in a form of a callable satisfying the following signature:
    void(const std::exception&)
The error handler should be injected using a new ImporterEx constructor.

Draft: https://github.com/Samsung/ONE/pull/14792

ONE-DCO-1.0-Signed-off-by: Tomasz Dolbniak <t.dolbniak@partner.samsung.com>