### PR TITLE
[circle-mlir/tools-test] Enable tests for AddOp in import/export

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/test.lst
@@ -3,3 +3,6 @@
 # AddModel(test_model)
 # ImportModel(test_model)
 #
+
+AddModel(Add_F32_R4)
+AddModel(Add_F32_R4_C1)


### PR DESCRIPTION
This will enable value tests for AddOp in import/export tests.
