### PR TITLE
[circle-mlir/tools] Introduce one-import-onnx-ext

### DIFF
--- a/circle-mlir/circle-mlir/tools/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(onnx2circle)
+add_subdirectory(one-import-onnx-ext)
 add_subdirectory(circle-impexp)

--- a/circle-mlir/circle-mlir/tools/one-import-onnx-ext/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools/one-import-onnx-ext/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(EXT_FILES
+    one-import-onnx-ext
+)
+
+# NOTE using loop is to prepare 
+foreach(EXT_FILE IN ITEMS ${EXT_FILES})
+  set(EXT_FILE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${EXT_FILE}")
+
+  # strip extension from the name if exist
+  get_filename_component(EXT_FILE_NAME ${EXT_FILE} NAME_WE)
+  set(EXT_FILE_BIN "${CMAKE_CURRENT_BINARY_DIR}/${EXT_FILE_NAME}")
+
+  add_custom_command(OUTPUT ${EXT_FILE_BIN}
+    COMMAND ${CMAKE_COMMAND} -E copy "${EXT_FILE_SRC}" "${EXT_FILE_BIN}"
+    DEPENDS ${EXT_FILE_SRC}
+    COMMENT "Generate ${EXT_FILE_BIN}"
+  )
+
+  set(EXT_FILE_TARGET "${EXT_FILE}_target")
+  add_custom_target(${EXT_FILE_TARGET} ALL DEPENDS ${EXT_FILE_BIN})
+
+  install(FILES ${EXT_FILE_BIN}
+          PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                      GROUP_READ GROUP_EXECUTE
+                      WORLD_READ WORLD_EXECUTE
+          DESTINATION bin)
+
+endforeach()

--- a/circle-mlir/circle-mlir/tools/one-import-onnx-ext/README.md
+++ b/circle-mlir/circle-mlir/tools/one-import-onnx-ext/README.md
@@ -1,0 +1,7 @@
+# one-import-onnx-ext
+
+_one-import-onnx-ext_ follows _one_import_onnx_ extension discuessed in
+https://github.com/Samsung/ONE/issues/10702.
+
+_one-import-onnx-ext_ acts as simple wrapper to execute _onnx2circle_ tool
+to convert ONNX model to Circle model.

--- a/circle-mlir/circle-mlir/tools/one-import-onnx-ext/one-import-onnx-ext
+++ b/circle-mlir/circle-mlir/tools/one-import-onnx-ext/one-import-onnx-ext
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+''''export SCRIPT_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)" # '''
+''''export PY_PATH=${SCRIPT_PATH}/venv/bin/python                                       # '''
+''''test -f ${PY_PATH} && exec ${PY_PATH} "$0" "$@"                                     # '''
+''''echo "Error: Virtual environment not found. Please run 'one-prepare-venv' command." # '''
+''''exit 255                                                                            # '''
+
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer https://github.com/Samsung/ONE/issues/10702 for this file
+# this file follows one-cmds script structure
+
+import os
+import sys
+import subprocess
+
+
+def main():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    o2c_path = os.path.join(dir_path, 'onnx2circle')
+    o2c_cmd = [o2c_path]
+    leng = len(sys.argv)
+    # add only supported options, or onnx2circle will exit with help message.
+    for i in range(1, leng):
+        option = sys.argv[i]
+        if option.startswith('--'):
+            valid_options = [
+                '--unroll_rnn', '--unroll_lstm',
+                '--experimental_disable_batchmatmul_unfold',
+                '--save_intermediate', '--keep_io_order'
+            ]
+            if not option in valid_options:
+                print('[one-import-onnx-ext] skip unknown option:', option)
+                continue
+
+        o2c_cmd.append(option)
+
+    print('[one-import-onnx-ext] from Circle-MLIR:', o2c_cmd)
+    subprocess.run(o2c_cmd, check=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This will introduce one-import-onnx-ext as extension
for one-import-onnx of compiler/one-cmds to invoke onnx2circle tool
for conversion of onnx to circle.
