### PR TITLE
[circle-mlir] Enable tests for TransposeOp

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-models/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-models/test.lst
@@ -5,3 +5,5 @@
 
 AddModel(Add_F32_R4)
 AddModel(Add_F32_R4_C1)
+AddModel(Transpose_F32_R4)
+AddModel(Transpose_F32_R4_pm)

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/test.lst
@@ -5,3 +5,5 @@
 
 AddModel(Add_F32_R4)
 AddModel(Add_F32_R4_C1)
+AddModel(Transpose_F32_R4)
+AddModel(Transpose_F32_R4_pm)

--- a/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
@@ -8,3 +8,4 @@ ConvertUnitModel(Add_F32.onnx.mlir)
 # shape inference validation
 
 ValidateShapeInf(Add_F32_us.circle.mlir)
+ValidateShapeInf(Transpose_F32_R4_us.circle.mlir)


### PR DESCRIPTION
This will enable shapeinf, conversion and value tests for TransposeOp.
