### PR TITLE
[circle-mlir/tools] Enable test for dynamic shape inf

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/TestModels.cmake
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/TestModels.cmake
@@ -31,6 +31,22 @@ macro(ValidateShapeInf MLIR_FNAME)
   list(APPEND FILE_DEPS "${TEST_MLIR_MODEL_DST}")
 endmacro(ValidateShapeInf)
 
+# ValidateDynaShapeInf is to test output should have dynamic shape from dynamic shape input
+set(VALIDATE_DYNASHAPEINF_MODELS)
+macro(ValidateDynaShapeInf MLIR_FNAME)
+  # copy to build folder
+  set(TEST_MLIR_MODEL_SRC "${CMAKE_SOURCE_DIR}/models/mlir/${MLIR_FNAME}")
+  set(TEST_MLIR_MODEL_DST "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MLIR_FNAME}")
+  add_custom_command(
+    OUTPUT ${TEST_MLIR_MODEL_DST}
+    COMMAND ${CMAKE_COMMAND} -E copy "${TEST_MLIR_MODEL_SRC}" "${TEST_MLIR_MODEL_DST}"
+    DEPENDS ${TEST_MLIR_MODEL_SRC}
+    COMMENT "tools/onnx2circle: prepare mlir/${MLIR_FNAME}"
+  )
+  list(APPEND VALIDATE_DYNASHAPEINF_MODELS "${MLIR_FNAME}")
+  list(APPEND FILE_DEPS "${TEST_MLIR_MODEL_DST}")
+endmacro(ValidateDynaShapeInf)
+
 # Read "test.lst"
 include("test.lst")
 
@@ -53,6 +69,17 @@ foreach(MODEL IN ITEMS ${VALIDATE_SHAPEINF_MODELS})
   add_test(
     NAME onnx2circle_valshapeinf_${MODEL}
     COMMAND "$<TARGET_FILE:onnx2circle>" "--check_shapeinf"
+      "${MLIR_MODEL_PATH}"
+      "${CIRCLE_MODEL_PATH}"
+  )
+endforeach()
+
+foreach(MODEL IN ITEMS ${VALIDATE_DYNASHAPEINF_MODELS})
+  set(MLIR_MODEL_PATH "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MODEL}")
+  set(CIRCLE_MODEL_PATH "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MODEL}.circle")
+  add_test(
+    NAME onnx2circle_valdynshapeinf_${MODEL}
+    COMMAND "$<TARGET_FILE:onnx2circle>" "--check_dynshapeinf"
       "${MLIR_MODEL_PATH}"
       "${CIRCLE_MODEL_PATH}"
   )


### PR DESCRIPTION
This will introduce macros for testing dynamic shape inference of ops.
