### PR TITLE
[circle-mlir/tools-test] Enable tests for PadOp

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-models/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-models/test.lst
@@ -5,6 +5,11 @@
 
 AddModel(Add_F32_R4)
 AddModel(Add_F32_R4_C1)
+AddModel(Pad_Constant2d_F32_R4)
+# TODO AddModel(Pad_Constant2d_F32_R4_v14)
+AddModel(Pad_Constant2d_F32_R4_1)
+AddModel(Pad_Constant2d_F32_R4_t4)
+AddModel(Pad_Constant2d_F32_R4_t8)
 AddModel(Reshape_F32_R4_1)
 AddModel(Reshape_F32_R4_2)
 AddModel(Reshape_F32_R4_3)

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/test.lst
@@ -5,6 +5,11 @@
 
 AddModel(Add_F32_R4)
 AddModel(Add_F32_R4_C1)
+AddModel(Pad_Constant2d_F32_R4)
+# TODO AddModel(Pad_Constant2d_F32_R4_v14)
+AddModel(Pad_Constant2d_F32_R4_1)
+AddModel(Pad_Constant2d_F32_R4_t4)
+AddModel(Pad_Constant2d_F32_R4_t8)
 AddModel(Reshape_F32_R4_1)
 AddModel(Reshape_F32_R4_2)
 AddModel(Reshape_F32_R4_3)


### PR DESCRIPTION
This will enable conversion and value test of PadOp.
