### PR TITLE
[luci-interpreter] Support S32 for Gather

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Gather.cpp
+++ b/compiler/luci-interpreter/src/kernels/Gather.cpp
@@ -40,7 +40,7 @@ void Gather::configure()
   {
     LUCI_INTERPRETER_CHECK(output()->element_type() == DataType::FLOAT32);
   }
-  else if(params()->element_type() == DataType::S32)
+  else if (params()->element_type() == DataType::S32)
   {
     LUCI_INTERPRETER_CHECK(output()->element_type() == DataType::S32);
   }
@@ -113,8 +113,7 @@ void Gather::execute() const
   }
 }
 
-template<typename T>
-void Gather::eval() const
+template <typename T> void Gather::eval() const
 {
   assert(indices()->element_type() == DataType::S32 || indices()->element_type() == DataType::S64);
 
@@ -130,16 +129,16 @@ void Gather::eval() const
     const auto indices_data = getTensorData<int32_t>(indices());
 
     luci_interpreter_pal::Gather<T, int32_t>(tparams, getTensorShape(params()), params_data,
-                                                 getTensorShape(indices()), indices_data,
-                                                 getTensorShape(output()), output_data);
+                                             getTensorShape(indices()), indices_data,
+                                             getTensorShape(output()), output_data);
   }
   else
   {
     const auto indices_data = getTensorData<int64_t>(indices());
 
     luci_interpreter_pal::Gather<T, int64_t>(tparams, getTensorShape(params()), params_data,
-                                                 getTensorShape(indices()), indices_data,
-                                                 getTensorShape(output()), output_data);
+                                             getTensorShape(indices()), indices_data,
+                                             getTensorShape(output()), output_data);
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Gather.h
+++ b/compiler/luci-interpreter/src/kernels/Gather.h
@@ -38,8 +38,7 @@ public:
   void execute() const override;
 
 private:
-  template<typename T>
-  void eval() const;
+  template <typename T> void eval() const;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Gather.h
+++ b/compiler/luci-interpreter/src/kernels/Gather.h
@@ -38,7 +38,8 @@ public:
   void execute() const override;
 
 private:
-  void evalFloat() const;
+  template<typename T>
+  void eval() const;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Gather.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Gather.test.cpp
@@ -97,8 +97,7 @@ TEST_F(GatherTest, S32ParamsDataType)
   std::vector<int32_t> indices_data{1, 0, 1, 5};
   std::vector<float> ref_output_data{2, 1, 2, 6};
 
-  Tensor params_tensor =
-    makeInputTensor<DataType::S32>({1, 6}, params_data, _memory_manager.get());
+  Tensor params_tensor = makeInputTensor<DataType::S32>({1, 6}, params_data, _memory_manager.get());
   Tensor indices_tensor = makeInputTensor<DataType::S32>({4}, indices_data, _memory_manager.get());
   Tensor output_tensor = makeOutputTensor(DataType::S32);
   GatherParams gparams;


### PR DESCRIPTION
The commit extend Gather kernel implementation to support S32 (int32_t) data type.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Issue: https://github.com/Samsung/ONE/issues/14791