### PR TITLE
[luci-interpreter] Support S32 for Abs

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Abs.cpp
+++ b/compiler/luci-interpreter/src/kernels/Abs.cpp
@@ -41,6 +41,9 @@ void Abs::execute() const
     case DataType::FLOAT32:
       eval<float>();
       break;
+    case DataType::S32:
+      eval<int32_t>();
+      break;
     default:
       throw std::runtime_error("luci-intp Abs Unsupported type.");
   }

--- a/compiler/luci-interpreter/src/kernels/Abs.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Abs.test.cpp
@@ -65,6 +65,24 @@ TEST(AbsTest, FloatSimple)
   SUCCEED();
 }
 
+TEST(AbsTest, S32Simple)
+{
+  Check<int32_t>(/*input_shape=*/{2, 3},
+                 /*output_shape=*/{2, 3},
+                 /*input_data=*/
+                 {
+                   0, -1, 3,  // Row 1
+                   1, -1, -2, // Row 2
+                 },
+                 /*output_data=*/
+                 {
+                   0, 1, 3, // Row 1
+                   1, 1, 2, // Row 2
+                 });
+
+  SUCCEED();
+}
+
 TEST(AbsTest, Type_Mismatch_NEG)
 {
   std::unique_ptr<IMemoryManager> memory_manager = std::make_unique<TestMemoryManager>();


### PR DESCRIPTION
The commit extend Abs kernel implementation to support S32 (int32_t) data type.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer m.bencer@partner.samsung.com

Issue: https://github.com/Samsung/ONE/issues/14791