### PR TITLE
[circle-mlir] Simplify max value calculation by replacing it with np.max

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/comp_onnx_circle.py
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/comp_onnx_circle.py
@@ -74,8 +74,7 @@ def compare_outputs(onnx_model,
             diff_val = np.subtract(onnx_output, circle_output)
             print('ONNX Result', onnx_output)
             print('Diff', diff_val)
-            print('Diff Max', np.ndarray.max(diff_val), 'in tolerance', rtolerance,
-                  atolerance)
+            print('Diff Max', np.max(diff_val), 'in tolerance', rtolerance, atolerance)
 
         result_compare = result_compare and result_compare_one
 


### PR DESCRIPTION
This commit refactores the code to use np.max instead of np.ndarray.max, simplifying the syntax while retaining equivalent functionality.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>