### PR TITLE
[circle-mlir] Prevent division by zero in PEIR calculation

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/util_validation.py
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/util_validation.py
@@ -20,7 +20,8 @@ def get_peir_from(baseline_output, target_output):
     else:
         INTERVAL = baseline_max - baseline_min
         if INTERVAL == 0:
-            PEIR = 0
+            # Set to infinity because INTERVAL is zero
+            PEIR = np.inf
         else:
             PEIR = PEAK_ERROR / INTERVAL
 

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/util_validation.py
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/util_validation.py
@@ -19,7 +19,10 @@ def get_peir_from(baseline_output, target_output):
         PEIR = 0
     else:
         INTERVAL = baseline_max - baseline_min
-        PEIR = PEAK_ERROR / INTERVAL
+        if INTERVAL == 0:
+            PEIR = 0
+        else:
+            PEIR = PEAK_ERROR / INTERVAL
 
     PEIR_res = '{:.4f}'.format(PEIR) if PEIR <= 1.0 else '> 1'
 


### PR DESCRIPTION
This commit adds a check to set PEIR to 0 when INTERVAL is 0, ensuring that division by zero is avoided.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>