### PR TITLE
[luci] Use static dimensions from new_shape attribute

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -120,8 +120,7 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
       // for non-existing `shape`, we can use `newShape` if it's valid
       auto new_shape = node->newShape();
       auto rank = new_shape->rank();
-      auto shape_dummy = dynamic_cast<luci::CircleOutputDummy *>(node->shape());
-      if (shape_dummy && rank > 0)
+      if (rank > 0)
       {
         is_static_shape = true;
         shape_by_input.rank(rank);
@@ -154,7 +153,14 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
 
     for (uint32_t axis = 0; axis < shape_by_attr.rank(); ++axis)
     {
-      shape_by_attr.dim(axis) = node->newShape()->dim(axis);
+      if (node->newShape()->dim(axis) > 0)
+      {
+        shape_by_attr.dim(axis) = node->newShape()->dim(axis);
+      }
+      else
+      {
+        shape_by_attr.dim(axis).unset(); // unset means unknown dimension
+      }
     }
   }
 

--- a/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
@@ -204,7 +204,6 @@ TEST(ShapeRuleTest, reshape_by_newShape_dynamic)
   auto node_reshape = g->nodes()->create<luci::CircleReshape>();
   auto tensor_input = g->nodes()->create<luci::CircleInput>();
   auto target_shape = g->nodes()->create<luci::CircleInput>();
-  ;
 
   tensor_input->dtype(loco::DataType::S32);
   tensor_input->shape({2, 3, 4});
@@ -220,7 +219,7 @@ TEST(ShapeRuleTest, reshape_by_newShape_dynamic)
   // reshape to {dynamic, 4, dynamic}
   node_reshape->newShape()->rank(3);
   node_reshape->newShape()->dim(0) = -1;
-  node_reshape->newShape()->dim(1) = 4;
+  node_reshape->newShape()->dim(1) = 2;
   node_reshape->newShape()->dim(2) = -1;
 
   loco::TensorShape output_shape;
@@ -231,6 +230,6 @@ TEST(ShapeRuleTest, reshape_by_newShape_dynamic)
   ASSERT_EQ(3, output_shape.rank());
   ASSERT_FALSE(output_shape.dim(0).known());
   ASSERT_TRUE(output_shape.dim(1).known());
-  ASSERT_EQ(4, output_shape.dim(1).value());
+  ASSERT_EQ(2, output_shape.dim(1).value());
   ASSERT_FALSE(output_shape.dim(2).known());
 }


### PR DESCRIPTION
This PR adds use static dimension from new_shape attribute even if only some of them are static and the rest dynamic.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Issue: https://github.com/Samsung/ONE/issues/14791