### PR TITLE
[luci/service] Enable CircleOutput shape inference

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -173,7 +173,7 @@ public:
   // loco::TensorShape visit(const luci::CircleInput *node) final;
   // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV4Out *node) final;
   // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV5Out *node) final;
-  // loco::TensorShape visit(const luci::CircleOutput *node) final;
+  loco::TensorShape visit(const luci::CircleOutput *node) final;
   // loco::TensorShape visit(const luci::CircleOutputDummy *node) final;
   // loco::TensorShape visit(const luci::CircleOutputExclude *node) final;
   // loco::TensorShape visit(const luci::CircleSplitOut *node) final;

--- a/compiler/luci/service/src/Nodes/CircleOutput.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutput.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleShapeInference.h"
+#include "CircleShapeInferenceHelper.h"
+
+namespace luci
+{
+
+namespace sinf
+{
+
+loco::TensorShape Algorithm::visit(const luci::CircleOutput *node)
+{
+  const auto from_shape = loco::must_cast<luci::CircleNode *>(node->from());
+  return sinf::circle_shape(from_shape);
+}
+
+} // namespace sinf
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleOutput.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutput.cpp
@@ -15,11 +15,11 @@
  */
 
 #include "luci/Service/CircleShapeInference.h"
+
 #include "CircleShapeInferenceHelper.h"
 
 namespace luci
 {
-
 namespace sinf
 {
 
@@ -30,5 +30,4 @@ loco::TensorShape Algorithm::visit(const luci::CircleOutput *node)
 }
 
 } // namespace sinf
-
 } // namespace luci


### PR DESCRIPTION
This commit enables shape inference for CircleOutput node.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Issue: https://github.com/Samsung/ONE/issues/14791