### PR TITLE
[luci-interpreter] Support scalar index in Gather

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Gather.cpp
+++ b/compiler/luci-interpreter/src/kernels/Gather.cpp
@@ -55,7 +55,14 @@ void Gather::configure()
   // refer tensorflow/lite/kernels/gather.cc
 
   const Shape &params_shape = params()->shape();
-  const Shape &indices_shape = indices()->shape();
+  Shape indices_shape = indices()->shape();
+  {
+    // scalar index is treated as a tensor with the shape of [1]
+    if (indices_shape.num_dims() == 0)
+    {
+      indices_shape = Shape({1});
+    }
+  }
 
   int axis = _params.axis;
   if (axis < 0)

--- a/compiler/luci-interpreter/src/kernels/Gather.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Gather.test.cpp
@@ -62,6 +62,32 @@ TEST_F(GatherTest, Simple)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 4}));
 }
 
+TEST_F(GatherTest, Scalar_Index)
+{
+  std::vector<float> params_data{1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+  std::vector<int32_t> indices_data{1};
+  std::vector<float> ref_output_data{2.f};
+
+  Tensor params_tensor =
+    makeInputTensor<DataType::FLOAT32>({1, 1, 6}, params_data, _memory_manager.get());
+  Tensor indices_tensor =
+    makeInputTensor<DataType::S32>(/* scalar */ {}, indices_data, _memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+  GatherParams gparams;
+
+  gparams.axis = 2;
+  gparams.batch_dims = 0;
+
+  Gather kernel(&params_tensor, &indices_tensor, &output_tensor, gparams);
+  kernel.configure();
+  _memory_manager->allocate_memory(output_tensor);
+  kernel.execute();
+
+  EXPECT_THAT(extractTensorData<float>(output_tensor),
+              ::testing::ElementsAreArray(ref_output_data));
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 1, 1}));
+}
+
 TEST_F(GatherTest, Simple_Batch)
 {
   Shape params_shape = {3, 5};


### PR DESCRIPTION
This supports scalar index in Gather Op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/14804