### PR TITLE
[luci] Add additional check of unknown dimension for Reshape

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -212,7 +212,7 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
     {
       if (input_element_count % output_element_count != 0)
       {
-        INTERNAL_EXN("Unknown output dimension cannot be calculated for inputs");
+        INTERNAL_EXN("Reshape Op cannot infer unknown dimension from inputs.");
       }
       output_shape.dim(unknown_dim_index) = input_element_count / output_element_count;
     }

--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -210,6 +210,10 @@ loco::TensorShape Algorithm::visit(const luci::CircleReshape *node)
     }
     if (unknown_dim_index != UINT32_MAX)
     {
+      if (input_element_count % output_element_count != 0)
+      {
+        INTERNAL_EXN("Unknown output dimension cannot be calculated for inputs");
+      }
       output_shape.dim(unknown_dim_index) = input_element_count / output_element_count;
     }
   }

--- a/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
@@ -135,6 +135,32 @@ TEST(ShapeRuleTest, reshape_should_infer)
   ASSERT_EQ(4, output_shape.dim(1).value());
 }
 
+TEST(ShapeRuleTest, reshape_wrong_target_shape_NEG)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  auto tensor_input = g->nodes()->create<luci::CircleInput>();
+  auto shape_by_input = g->nodes()->create<luci::CircleConst>();
+
+  tensor_input->dtype(loco::DataType::S32);
+  tensor_input->shape({2, 4});
+  tensor_input->shape_status(luci::ShapeStatus::VALID);
+
+  shape_by_input->dtype(loco::DataType::S32);
+  shape_by_input->size<loco::DataType::S32>(3);
+  shape_by_input->at<loco::DataType::S32>(0) = 6;
+  shape_by_input->at<loco::DataType::S32>(2) = -1;
+  shape_by_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_reshape->tensor(tensor_input);
+  node_reshape->shape(shape_by_input);
+
+  loco::TensorShape output_shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_THROW(shape_inf_rule.infer(node_reshape, output_shape), oops::InternalExn);
+}
+
 TEST(ShapeRuleTest, reshape_by_input_node)
 {
   auto g = loco::make_graph();


### PR DESCRIPTION
… inference

This commit adds checking of number of remaining elements in order to confirm if it matches expected output shape.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>