### PR TITLE
[luci] Add additional negative unit test for Reshape

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
@@ -135,6 +135,33 @@ TEST(ShapeRuleTest, reshape_should_infer)
   ASSERT_EQ(4, output_shape.dim(1).value());
 }
 
+TEST(ShapeRuleTest, reshape_zero_rank_mismatch_NEG)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  auto tensor_input = g->nodes()->create<luci::CircleInput>();
+  auto shape_by_input = g->nodes()->create<luci::CircleConst>();
+
+  tensor_input->dtype(loco::DataType::S32);
+  tensor_input->shape({2, 4});
+  tensor_input->shape_status(luci::ShapeStatus::VALID);
+
+  shape_by_input->dtype(loco::DataType::S32);
+  shape_by_input->size<loco::DataType::S32>(3);
+  shape_by_input->at<loco::DataType::S32>(0) = 2;
+  shape_by_input->at<loco::DataType::S32>(1) = 2;
+  shape_by_input->at<loco::DataType::S32>(2) = 0;
+  shape_by_input->shape_status(luci::ShapeStatus::VALID);
+
+  node_reshape->tensor(tensor_input);
+  node_reshape->shape(shape_by_input);
+
+  loco::TensorShape output_shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_THROW(shape_inf_rule.infer(node_reshape, output_shape), oops::InternalExn);
+}
+
 TEST(ShapeRuleTest, reshape_by_input_node)
 {
   auto g = loco::make_graph();


### PR DESCRIPTION
This commit adds additional unit test for negative scenario where "0" indicates not existing input dimension.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>