### PR TITLE
[DRAFT] Rename the base interface of optimization passes

### DIFF
--- a/compiler/logo-core/include/logo/Pass.h
+++ b/compiler/logo-core/include/logo/Pass.h
@@ -38,7 +38,7 @@ public:
    *
    * @return false if there was nothing changed
    */
-  virtual bool run(loco::Graph *graph) = 0;
+  virtual bool run_on_graph(loco::Graph *graph) = 0;
 };
 
 std::string pass_name(const Pass *);

--- a/compiler/logo/include/logo/RemoveForwardNodePass.h
+++ b/compiler/logo/include/logo/RemoveForwardNodePass.h
@@ -38,7 +38,7 @@ struct RemoveForwardNodePass final : public Pass
 {
   const char *name(void) const final { return "RemoveForwardNodePass"; }
 
-  bool run(loco::Graph *g) final;
+  bool run_on_graph(loco::Graph *g) final;
 };
 
 } // namespace logo

--- a/compiler/logo/src/Passes/RemoveForwardNodePass.cpp
+++ b/compiler/logo/src/Passes/RemoveForwardNodePass.cpp
@@ -24,7 +24,7 @@
 namespace logo
 {
 
-bool RemoveForwardNodePass::run(loco::Graph *g)
+bool RemoveForwardNodePass::run_on_graph(loco::Graph *g)
 {
   struct Collector final : public loco::CanonicalNodeMutableVisitor<void>
   {

--- a/compiler/luci/pass/include/luci/ModulePass.h
+++ b/compiler/luci/pass/include/luci/ModulePass.h
@@ -29,7 +29,7 @@ class Pass : public logo::Pass
 {
 public:
   // Run module pass and return false if there was nothing changed
-  virtual bool run(luci::Module *) = 0;
+  virtual bool run_on_module(luci::Module *) = 0;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/FuseBCQPass.h
+++ b/compiler/luci/pass/include/luci/Pass/FuseBCQPass.h
@@ -30,8 +30,8 @@ struct FuseBCQPass final : public luci::Pass
 {
   const char *name(void) const final { return "luci::FuseBCQPass"; }
 
-  bool run(luci::Module *m) final;
-  bool run(loco::Graph *g) final;
+  bool run_on_module(luci::Module *m) final;
+  bool run_on_graph(loco::Graph *g) final;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -610,7 +610,7 @@ private:
 namespace luci
 {
 
-bool FuseBCQPass::run(luci::Module *m)
+bool FuseBCQPass::run_on_module(luci::Module *m)
 {
   bool changed = false;
 
@@ -689,7 +689,7 @@ bool FuseBCQPass::run(luci::Module *m)
   return changed;
 }
 
-bool FuseBCQPass::run(loco::Graph *)
+bool FuseBCQPass::run_on_graph(loco::Graph *)
 {
   // Do nothing for graph
   return false;


### PR DESCRIPTION
This commit attempts to demonstrate how the base interface of the optimization passes could be renamed to eliminate the error coming from hiding the virtual methods.

It's an alternative approach to the one presented in https://github.com/Samsung/ONE/pull/14594

ONE-DCO-1.0-Signed-off-by: Tomasz Dolbniak <t.dolbniak@partner.samsung.com>