### PR TITLE
[infra] Use self-hosted runner for onecc build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -51,7 +51,10 @@ jobs:
             ubuntu_ver: 20.04
           - ubuntu_code: jammy
             ubuntu_ver: 22.04
-    runs-on: ubuntu-${{ matrix.ubuntu_ver }}
+    runs-on: one-x64-linux
+    container:
+      image: nnfw/one-devtools:${{ matrix.ubuntu_code }}
+      options: --user root
     env:
       NNCC_WORKSPACE : build
       NNCC_INSTALL_PREFIX : install


### PR DESCRIPTION
This commit updates onecc build test workflow to use self-hosted runner.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #14915 