### PR TITLE
[infra] Use self-hosted runner for onert build

### DIFF
--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -1,4 +1,4 @@
-name: Run ONERT Ubuntu Build
+name: Run ONERT Ubuntu Cross Build
 
 on:
   push:
@@ -45,27 +45,22 @@ jobs:
   build:
     if: github.repository_owner == 'Samsung'
     strategy:
-      # Debug build test on ubuntu 20.04 only
+      # Debug build test on ubuntu arm32 only
       matrix:
         type: [ debug, release ]
-        ubuntu_code: [ focal, jammy ] # TODO: noble
-        arch: [ x86_64, armv7l, aarch64 ]
+        ubuntu_code: [ jammy ]
+        arch: [ armv7l ]
         include:
           - arch: armv7l
             platform: arm
-          - arch: aarch64
-            platform: aarch64
-        exclude:
-          - ubuntu_code: jammy
-            type: debug
-    runs-on: ubuntu-22.04
+    runs-on: one-x64-linux
     container:
-      image: nnfw/one-devtools:${{ matrix.ubuntu_code }}
+      image: nnfw/one-devtools:${{ matrix.ubuntu_code }}-cross
       options: --user root
     env:
       TARGET_ARCH: ${{ matrix.arch }}
       BUILD_TYPE: ${{ matrix.type }}
-      CROSS_BUILD: ${{ matrix.arch != 'x86_64' && '1' || '0' }}
+      CROSS_BUILD: 1
       OPTIONS: "-DBUILD_ARMCOMPUTE=OFF" # Disable arm compute library
     steps:
       - name: Checkout
@@ -82,7 +77,6 @@ jobs:
             external-
 
       - name: Download rootfs for cross build
-        if: matrix.arch != 'x86_64'
         uses: dawidd6/action-download-artifact@v7
         with:
           workflow: generate-rootfs.yml
@@ -91,7 +85,6 @@ jobs:
 
       # Workaround: symlink for rootfs checker in cmake toolchain file
       - name: Install rootfs for cross build
-        if: matrix.arch != 'x86_64'
         run: |
           mkdir -p tools/cross/rootfs
           tar -zxf rootfs_${{ matrix.platform }}_${{ matrix.ubuntu_code }}.tar.gz -C tools/cross/rootfs
@@ -102,12 +95,6 @@ jobs:
       - name: Build onert
         run: |
           make -f Makefile.template create-testsuite
-
-      - name: Run test on native build
-        if: matrix.arch == 'x86_64'
-        run: |
-          ./Product/out/test/onert-test unittest
-          ./Product/out/test/onert-test unittest --unittestdir=./Product/out/nnapi-gtest
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -123,13 +110,11 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ubuntu_code: [ focal, jammy ] # TODO: noble
-        arch: [ armv7l, aarch64 ]
+        ubuntu_code: [ jammy ]
+        arch: [ armv7l ]
         include:
           - arch: armv7l
             platform: linux/arm/v7
-          - arch: aarch64
-            platform: linux/arm64
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/run-onert-native-build.yml
+++ b/.github/workflows/run-onert-native-build.yml
@@ -1,0 +1,87 @@
+name: Run ONERT Ubuntu Native Build
+
+on:
+  push:
+    branches:
+      - master
+      - release/*
+    paths:
+      - '.github/workflows/run-onert-build.yml'
+      - 'nn*'
+      - 'Makefile.template'
+      - 'infra/buildtool/**'
+      - 'infra/cmake/**'
+      - 'infra/nncc/**'
+      - 'infra/nnfw/**'
+      - 'runtime/**'
+      - '!runtime/contrib/**'
+      - '!**/*.md'
+  pull_request:
+    branches:
+      - master
+      - release/*
+    paths:
+      - '.github/workflows/run-onert-build.yml'
+      - 'nn*'
+      - 'Makefile.template'
+      - 'infra/buildtool/**'
+      - 'infra/cmake/**'
+      - 'infra/nncc/**'
+      - 'infra/nnfw/**'
+      - 'runtime/**'
+      - '!runtime/contrib/**'
+      - '!**/*.md'
+
+defaults:
+  run:
+    shell: bash
+
+# Cancel previous running jobs when pull request is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.repository_owner == 'Samsung'
+    strategy:
+      # Release build test only on non arm32 platforms
+      matrix:
+        type: [ release ]
+        ubuntu_code: [ jammy ]
+        arch: [ x86_64, aarch64 ]
+        include:
+          - arch: x86_64
+            runner: one-x64-linux
+          - arch: aarch64
+            runner: one-arm-linux
+    runs-on: ${{ matrix.runner }}
+    container:
+      # Use test image: default image is not supporting arm64 yet
+      # TODO Use default image when it supports arm64
+      image: nnfw/one-devtools:${{ matrix.ubuntu_code }}-test
+      options: --user root
+    env:
+      TARGET_ARCH: ${{ matrix.arch }}
+      BUILD_TYPE: ${{ matrix.type }}
+      OPTIONS: "-DBUILD_ARMCOMPUTE=OFF" # Disable arm compute library
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Caching externals
+        uses: actions/cache@v4
+        with:
+          path: externals
+          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          restore-keys: |
+            external-onert-${{ matrix.ubuntu_code }}-
+            external-onert-
+            external-
+      - name: Build onert
+        run: |
+          make -f Makefile.template
+      - name: Run test on native
+        run: |
+          ./Product/out/test/onert-test unittest
+          ./Product/out/test/onert-test unittest --unittestdir=./Product/out/nnapi-gtest


### PR DESCRIPTION
This commit updates onert build test workflow to use self-hosted runner.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #14916 
Draft: #14756