### PR TITLE
[visq-unittest] Add dependency on add_custom_command

### DIFF
--- a/compiler/visq-unittest/CMakeLists.txt
+++ b/compiler/visq-unittest/CMakeLists.txt
@@ -43,6 +43,7 @@ get_target_property(FP32_MODEL_DIR testDataGenerator BINARY_DIR)
 add_custom_command(
   OUTPUT ${RESOURCE_FILE}
   COMMAND ${CMAKE_COMMAND} -E echo 'fp32_model_dir=\"${FP32_MODEL_DIR}\"' >> ${RESOURCE_FILE}
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/test
   COMMENT "Generate file to specify resource location"
 )
 


### PR DESCRIPTION
This commit adds dependency to add_custom_command. 
It confirms ordering of commands, then resolves random build fail.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #14925