### PR TITLE
[circle-mlir/models] Add MLIR models for Cast Op

### DIFF
--- a/circle-mlir/models/mlir/Cast_F32_F32.circle.mlir
+++ b/circle-mlir/models/mlir/Cast_F32_F32.circle.mlir
@@ -1,0 +1,7 @@
+func.func @main_graph(%arg0: tensor<1x2x3x3xf32>) -> tensor<1x2x3x3xf32> attributes {
+input_names = ["input"], output_names = ["output"]}
+{
+  %0 = "Circle.cast"(%arg0) : (tensor<1x2x3x3xf32>) -> tensor<1x2x3x3xf32>
+
+  return %0 : tensor<1x2x3x3xf32>
+}

--- a/circle-mlir/models/mlir/Cast_I64_F32_C1.circle.mlir
+++ b/circle-mlir/models/mlir/Cast_I64_F32_C1.circle.mlir
@@ -1,0 +1,10 @@
+func.func @main_graph() -> tensor<4xf32> attributes {
+input_names = [], output_names = ["output"]}
+{
+  %0 = "Circle.pseudo_const"() {
+    value = dense<[-1, 0, 1, 64]> : tensor<4xi64>
+  } : () -> tensor<4xi64>
+  %1 = "Circle.cast"(%0) : (tensor<4xi64>) -> tensor<4xf32>
+
+  return %1 : tensor<4xf32>
+}

--- a/circle-mlir/models/mlir/Cast_I64_F32_ds.circle.mlir
+++ b/circle-mlir/models/mlir/Cast_I64_F32_ds.circle.mlir
@@ -1,0 +1,7 @@
+// shape inference with dynamic shape
+func.func @main_graph(%arg0: tensor<1x?xi64>) -> tensor<?x?xf32> attributes {
+  input_names = ["input"], output_names = ["output"]}
+{
+  %0 = "Circle.cast"(%arg0) : (tensor<1x?xi64>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}

--- a/circle-mlir/models/mlir/Cast_I8_I16_C1.circle.mlir
+++ b/circle-mlir/models/mlir/Cast_I8_I16_C1.circle.mlir
@@ -1,0 +1,10 @@
+func.func @main_graph() -> tensor<2xi16> attributes {
+input_names = [], output_names = ["output"]}
+{
+  %0 = "Circle.pseudo_const"() {
+    value = dense<[-1, 1]> : tensor<2xi8>
+  } : () -> tensor<2xi8>
+  %1 = "Circle.cast"(%0) : (tensor<2xi8>) -> tensor<2xi16>
+
+  return %1 : tensor<2xi16>
+}


### PR DESCRIPTION
This adds MLIR test models for the Cast operation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>