### PR TITLE
[circle-mlir/dialect] Tidy comment

### DIFF
--- a/circle-mlir/circle-mlir/lib/dialect/mlir/CircleOps.td
+++ b/circle-mlir/circle-mlir/lib/dialect/mlir/CircleOps.td
@@ -1085,7 +1085,6 @@ def CIR_SqrtOp: CIR_Op<"sqrt", [
     Pure,
     DeclareOpInterfaceMethods<CIR_ShapeInferenceOpInterface>,
     // NOTE TFL_SqrtOp used TF_SameOperandsAndResultTypeResolveRef
-    // REFER https://github.sec.samsung.net/one-project/circle-mlir/issues/292
     SameOperandsAndResultShape]> {
   let summary = "Square root operator";
 


### PR DESCRIPTION
This will tidy unreachable URL from openspace in the comment.
