### PR TITLE
[infra] Split dev docker image build workflow

### DIFF
--- a/.github/workflows/build-dev-docker.yml
+++ b/.github/workflows/build-dev-docker.yml
@@ -1,16 +1,8 @@
-name: Build docker image for CI/CD infra
+name: Build docker image for CI/CD infra on PR
 on:
-  push:
-    branches:
-      - master
-      - release/*
-    paths:
-      - '.github/workflows/build-dev-docker.yml'
-      - 'infra/docker/**'
   pull_request:
     branches:
       - master
-      - release/*
     paths:
       - '.github/workflows/build-dev-docker.yml'
       - 'infra/docker/**'
@@ -23,7 +15,7 @@ concurrency:
 jobs:
   # Build on docker CLI for PR test without login
   build-pr-test:
-    if: github.event_name == 'pull_request' && github.repository_owner == 'Samsung'
+    if: github.repository_owner == 'Samsung'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -43,27 +35,3 @@ jobs:
         run: |
           ./nnas docker-run --user make -f Makefile.template
           ./nnas docker-run --user Product/out/test/onert-test unittest
-
-  # Use github action for build and push to docker hub
-  build-docker-image:
-    if: github.event_name == 'push' && github.repository_owner == 'Samsung'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [ 'android-sdk', 'focal', 'jammy', 'noble' ]
-    steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Install Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v6
-        with:
-          file: ./infra/docker/${{ matrix.version }}/Dockerfile
-          push: true
-          tags: nnfw/one-devtools:${{ matrix.version }}

--- a/.github/workflows/build-pub-dev-docker.yml
+++ b/.github/workflows/build-pub-dev-docker.yml
@@ -1,0 +1,29 @@
+name: Build and publish docker image for CI/CD infra
+on:
+  workflow_dispatch:
+
+jobs:
+  # TODO Add test job for each image before publishing
+  publish-image:
+    if: github.repository_owner == 'Samsung'
+    strategy:
+      matrix:
+        version: [ 'android-sdk', 'focal', 'jammy', 'noble' ]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Install Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          file: ./infra/docker/${{ matrix.version }}/Dockerfile
+          push: true
+          tags: nnfw/one-devtools:${{ matrix.version }}


### PR DESCRIPTION
This commit splits the dev docker image build workflow into two separate workflows: PR test and publish image. Publishing docker image workflow is triggered by workflow_dispatch, not push.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

--- 

Draft: #14758