### PR TITLE
[circle-mlir/dialect] Add the shape inference to Cast Op

### DIFF
--- a/circle-mlir/circle-mlir/lib/dialect/mlir/CircleOps.td
+++ b/circle-mlir/circle-mlir/lib/dialect/mlir/CircleOps.td
@@ -366,6 +366,7 @@ def CIR_ArgMaxOp : CIR_Op<"arg_max", [
 
 def CIR_CastOp : CIR_Op<"cast", [
     Pure,
+    DeclareOpInterfaceMethods<CIR_ShapeInferenceOpInterface>,
     SameOperandsAndResultShape]> {
   let summary = "Cast operator";
 

--- a/circle-mlir/circle-mlir/lib/dialect/src/ShapeInference.cpp
+++ b/circle-mlir/circle-mlir/lib/dialect/src/ShapeInference.cpp
@@ -112,6 +112,29 @@ void AddOp::inferShapes()
 }
 
 //===----------------------------------------------------------------------===//
+// CastOp
+//===----------------------------------------------------------------------===//
+
+void CastOp::inferShapes(void)
+{
+  CastOp op = *this;
+  auto output_type = op.getOutput().getType().cast<ShapedType>();
+  if (output_type.hasStaticShape())
+    return;
+
+  // follow input shape
+  auto input_type = op.getInput().getType().cast<TensorType>();
+  auto input_shape = input_type.getShape();
+  llvm::SmallVector<int64_t, 4> inferred(input_shape.begin(), input_shape.end());
+
+  dumpShape<CastOp>(op, inferred);
+
+  // preserve output dtype as-is
+  RankedTensorType inferred_type = RankedTensorType::get(inferred, output_type.getElementType());
+  getResult().setType(inferred_type);
+}
+
+//===----------------------------------------------------------------------===//
 // Conv2DOp
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This adds the shape inference interface to the Cast operation on dialect.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>