### PR TITLE
[circle-mlir/pass] Add the pass for Cast Op

### DIFF
--- a/circle-mlir/circle-mlir/lib/pass/src/ConvertONNXToCirclePass.cpp
+++ b/circle-mlir/circle-mlir/lib/pass/src/ConvertONNXToCirclePass.cpp
@@ -25,6 +25,7 @@
 //   class: ConvAbcd
 //    file: AbcdOp.h
 #include "ops/ArgMaxOp.h"
+#include "ops/CastOp.h"
 #include "ops/ClipOp.h"
 #include "ops/ConstantOp.h"
 #include "ops/ConvOp.h"
@@ -171,6 +172,7 @@ void ConvertONNXToCirclePass::runOnOperation()
   patterns.insert<ConvBinaryT<mlir::ONNXSubOp, mlir::Circle::SubOp>>(typeConverter, context);
 
   patterns.insert<ConvArgMax>(typeConverter, context);
+  patterns.insert<ConvCast>(typeConverter, context);
   patterns.insert<ConvClip>(typeConverter, context);
   patterns.insert<ConvConstant>(typeConverter, context);
   patterns.insert<ConvConv>(typeConverter, context);

--- a/circle-mlir/circle-mlir/lib/pass/src/ops/CastOp.h
+++ b/circle-mlir/circle-mlir/lib/pass/src/ops/CastOp.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLE_MLIR_PASS_OPS_CAST_OP_H__
+#define __CIRCLE_MLIR_PASS_OPS_CAST_OP_H__
+
+#include <circle-mlir/dialect/CircleDialect.h>
+
+#include <mlir/Transforms/DialectConversion.h>
+
+#include <src/Dialect/ONNX/ONNXOps.hpp>
+
+namespace mlir
+{
+namespace Circle
+{
+
+class ConvCast : public mlir::OpConversionPattern<mlir::ONNXCastOp>
+{
+public:
+  using mlir::OpConversionPattern<mlir::ONNXCastOp>::OpConversionPattern;
+  using OpAdaptor = typename mlir::ONNXCastOp::Adaptor;
+
+  mlir::LogicalResult matchAndRewrite(mlir::ONNXCastOp op, OpAdaptor adaptor,
+                                      mlir::ConversionPatternRewriter &rewriter) const override
+  {
+    mlir::Value input = adaptor.getInput();
+
+    rewriter.replaceOpWithNewOp<CastOp>(op, op.getType(), input);
+
+    return mlir::success();
+  }
+};
+
+} // namespace Circle
+} // namespace mlir
+
+#endif // __CIRCLE_MLIR_PASS_OPS_CAST_OP_H__


### PR DESCRIPTION
This enables conversion of the Cast operation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>