### PR TITLE
[circle-mlir/tools] Test coverage and shape inference for Cast Op

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
@@ -7,6 +7,9 @@ ConvertUnitModel(Add_F32_0.circle.mlir)
 ConvertUnitModel(Add_F32_1.circle.mlir)
 ConvertUnitModel(Add_F32_2.circle.mlir)
 ConvertUnitModel(Add_F32.onnx.mlir)
+ConvertUnitModel(Cast_F32_F32.circle.mlir)
+ConvertUnitModel(Cast_I8_I16_C1.circle.mlir)
+ConvertUnitModel(Cast_I64_F32_C1.circle.mlir)
 ConvertUnitModel(ReduceProd_I64_R1_1.circle.mlir)
 ConvertUnitModel(ReduceProd_I64_R1_3.circle.mlir)
 ConvertUnitModel(Rsqrt_F32_R1_C1.circle.mlir)
@@ -28,6 +31,7 @@ ValidateShapeInf(Transpose_F32_R4_us.circle.mlir)
 
 # dynamic shape inference validation
 
+ValidateDynaShapeInf(Cast_I64_F32_ds.circle.mlir)
 ValidateDynaShapeInf(Mul_F32_R2_ds.circle.mlir)
 ValidateDynaShapeInf(PRelu_F32_R4_ds.circle.mlir)
 ValidateDynaShapeInf(Reshape_F32_R4_ds.circle.mlir)


### PR DESCRIPTION
This enables tests to cover and infer the shape of the Cast operation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>