### PR TITLE
[infra] Add path filter for docker build test

### DIFF
--- a/.github/workflows/build-dev-docker.yml
+++ b/.github/workflows/build-dev-docker.yml
@@ -13,13 +13,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build on docker CLI for PR test without login
-  build-pr-test:
-    if: github.repository_owner == 'Samsung'
+  filtering:
     runs-on: ubuntu-latest
+    outputs:
+      yml: ${{ steps.filter.outputs.yml }}
+      android: ${{ steps.filter.outputs.android }}
+      ubuntu: ${{ steps.filter.outputs.ubuntu }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            android:
+              - '.github/**'
+              - 'infra/docker/android-sdk/**'
+            ubuntu:
+              - '.github/**'
+              - 'infra/docker/focal/**'
+              - 'infra/docker/jammy/**'
+              - 'infra/docker/noble/**'
+
+  # Build on docker CLI for PR test without login
+  build-ubuntu:
+    needs: filtering
+    if: github.repository_owner == 'Samsung' && needs.filtering.outputs.ubuntu == 'true'
+    runs-on: one-x64-linux
     strategy:
       matrix:
-        version: [ 'android-sdk', 'focal', 'jammy', 'noble' ]
+        version: [ 'focal', 'jammy', 'noble' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,9 +50,27 @@ jobs:
           ./nnas build-docker-image --codename ${{ matrix.version }} --tag one-test
 
       - name: Test onert build
-        if: matrix.version != 'android-sdk'
         env:
           DOCKER_IMAGE_NAME: one-test
         run: |
           ./nnas docker-run --user make -f Makefile.template
           ./nnas docker-run --user Product/out/test/onert-test unittest
+
+  build-android:
+    needs: filtering
+    if: github.repository_owner == 'Samsung' && needs.filtering.outputs.android == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Docker Image
+        run: |
+          ./nnas build-docker-image --codename android-sdk --tag one-test
+
+      - name: Test onert build
+        env:
+          DOCKER_IMAGE_NAME: one-test
+          DOCKER_ENV_VARS: '-e CROSS_BUILD=1 -e TARGET_OS=android -e BUILD_TYPE=release'
+        run: |
+          ./nnas docker-run --user make -f Makefile.template


### PR DESCRIPTION
This commit adds a path filtering job to check updated dockerfile and run build job only if it is changed.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>