### PR TITLE
[circle-mlir/models] Add MLIR test models for SelectV2 Op

### DIFF
--- a/circle-mlir/models/mlir/SelectV2_F32_R2.circle.mlir
+++ b/circle-mlir/models/mlir/SelectV2_F32_R2.circle.mlir
@@ -1,0 +1,24 @@
+func.func @main_graph() -> tensor<2x3xf32> attributes {
+  input_names = [],
+  output_names = ["output"]
+}
+{
+  %condition = "Circle.pseudo_const"() {
+    value = dense<[[1, 1, 0], [0, 1, 0]]> : tensor<2x3xi1>
+  } : () -> tensor<2x3xi1>
+
+  %x = "Circle.pseudo_const"() {
+    value = dense<[[-4.572, 1.58053, 3.566],
+      [2.4901099, -1.77580, 4.4327]]> : tensor<2x3xf32>
+  } : () -> tensor<2x3xf32>
+
+  %y = "Circle.pseudo_const"() {
+    value = dense<[[3.3505549, -1.779503, 4.3055594],
+      [3.55379045, -2.436065, 2.478764]]> : tensor<2x3xf32>
+  } : () -> tensor<2x3xf32>
+
+  %0 = "Circle.select_v2"(%condition, %x, %y) : (tensor<2x3xi1>, tensor<2x3xf32>, tensor<2x3xf32>)
+    -> tensor<2x3xf32>
+
+  return %0 : tensor<2x3xf32>
+}

--- a/circle-mlir/models/mlir/SelectV2_I32_R2.circle.mlir
+++ b/circle-mlir/models/mlir/SelectV2_I32_R2.circle.mlir
@@ -1,0 +1,24 @@
+func.func @main_graph() -> tensor<2x3xi32> attributes {
+  input_names = [],
+  output_names = ["output"]
+}
+{
+  %condition = "Circle.pseudo_const"() {
+    value = dense<[[1, 1, 0], [0, 1, 0]]> : tensor<2x3xi1>
+  } : () -> tensor<2x3xi1>
+
+  %x = "Circle.pseudo_const"() {
+    value = dense<[[-4572, 158053, 3566],
+      [24901099, -177580, 44327]]> : tensor<2x3xi32>
+  } : () -> tensor<2x3xi32>
+
+  %y = "Circle.pseudo_const"() {
+    value = dense<[[33505549, -1779503, 43055594],
+      [355379045, -2436065, 2478764]]> : tensor<2x3xi32>
+  } : () -> tensor<2x3xi32>
+
+  %0 = "Circle.select_v2"(%condition, %x, %y) : (tensor<2x3xi1>, tensor<2x3xi32>, tensor<2x3xi32>)
+    -> tensor<2x3xi32>
+
+  return %0 : tensor<2x3xi32>
+}

--- a/circle-mlir/models/mlir/SelectV2_I64_R2.circle.mlir
+++ b/circle-mlir/models/mlir/SelectV2_I64_R2.circle.mlir
@@ -1,0 +1,24 @@
+func.func @main_graph() -> tensor<2x3xi64> attributes {
+  input_names = [],
+  output_names = ["output"]
+}
+{
+  %condition = "Circle.pseudo_const"() {
+    value = dense<[[1, 1, 0], [0, 1, 0]]> : tensor<2x3xi1>
+  } : () -> tensor<2x3xi1>
+
+  %x = "Circle.pseudo_const"() {
+    value = dense<[[-4572, 158053, 3566],
+      [24901099, -177580, 44327]]> : tensor<2x3xi64>
+  } : () -> tensor<2x3xi64>
+
+  %y = "Circle.pseudo_const"() {
+    value = dense<[[33505549, -1779503, 43055594],
+      [355379045, -2436065, 2478764]]> : tensor<2x3xi64>
+  } : () -> tensor<2x3xi64>
+
+  %0 = "Circle.select_v2"(%condition, %x, %y) : (tensor<2x3xi1>, tensor<2x3xi64>, tensor<2x3xi64>)
+    -> tensor<2x3xi64>
+
+  return %0 : tensor<2x3xi64>
+}


### PR DESCRIPTION
This adds MLIR test models for the SelectV2 operation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>