### PR TITLE
[circle-mlir/models] Add MLIR test models for Slice Op

### DIFF
--- a/circle-mlir/models/mlir/Slice_F32_R2_ds.circle.mlir
+++ b/circle-mlir/models/mlir/Slice_F32_R2_ds.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph(%arg0: tensor<?x4xf32>) -> tensor<?x?xf32> attributes {
+  input_names = ["input_data"],
+  output_names = ["output"]}
+{
+  %starts = "Circle.pseudo_const"() {
+    value = dense<[0]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %ends = "Circle.pseudo_const"() {
+    value = dense<[2]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %axes = "Circle.pseudo_const"() {
+    value = dense<[1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %steps = "Circle.pseudo_const"() {
+    value = dense<[1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) {
+    onnx_node_name = "/Slice"
+  } : (tensor<?x4xf32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>)
+  -> tensor<?x?xf32>
+
+  return %0 : tensor<?x?xf32>
+}

--- a/circle-mlir/models/mlir/Slice_F32_R3_C1_0.circle.mlir
+++ b/circle-mlir/models/mlir/Slice_F32_R3_C1_0.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph(%arg0: tensor<3x2x3xf32>) -> tensor<2x2x3xf32> attributes {
+  input_names = ["input_data"],
+  output_names = ["output"]}
+{
+  %starts = "Circle.pseudo_const"() {
+    value = dense<[0]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %ends = "Circle.pseudo_const"() {
+    value = dense<[2]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %axes = "Circle.pseudo_const"() {
+    value = dense<[0]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %steps = "Circle.pseudo_const"() {
+    value = dense<[1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) {
+    onnx_node_name = "/Slice"
+  } : (tensor<3x2x3xf32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>)
+  -> tensor<2x2x3xf32>
+
+  return %0 : tensor<2x2x3xf32>
+}

--- a/circle-mlir/models/mlir/Slice_F32_R3_C1_1.circle.mlir
+++ b/circle-mlir/models/mlir/Slice_F32_R3_C1_1.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph(%arg0: tensor<3x2x3xf32>) -> tensor<3x2x2xf32> attributes {
+  input_names = ["input_data"],
+  output_names = ["output"]}
+{
+  %starts = "Circle.pseudo_const"() {
+    value = dense<[0]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %ends = "Circle.pseudo_const"() {
+    value = dense<[2]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %axes = "Circle.pseudo_const"() {
+    value = dense<[-1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %steps = "Circle.pseudo_const"() {
+    value = dense<[1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %0 = "onnx.Slice"(%arg0, %starts, %ends, %axes, %steps) {
+    onnx_node_name = "/Slice"
+  } : (tensor<3x2x3xf32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>)
+  -> tensor<3x2x2xf32>
+
+  return %0 : tensor<3x2x2xf32>
+}

--- a/circle-mlir/models/mlir/Slice_F32_R3_C1_2.circle.mlir
+++ b/circle-mlir/models/mlir/Slice_F32_R3_C1_2.circle.mlir
@@ -1,0 +1,20 @@
+func.func @main_graph(%arg0: tensor<3x2x3xf32>, %arg1: tensor<1xi32>, %arg2: tensor<1xi32>)
+-> tensor<3x2x?xf32> attributes {
+  input_names = ["input_data", "starts", "ends"],
+  output_names = ["output"]}
+{
+  %axes = "Circle.pseudo_const"() {
+    value = dense<[-1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %steps = "Circle.pseudo_const"() {
+    value = dense<[1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %0 = "onnx.Slice"(%arg0, %arg1, %arg2, %axes, %steps) {
+    onnx_node_name = "/Slice"
+  } : (tensor<3x2x3xf32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>)
+  -> tensor<3x2x?xf32>
+
+  return %0 : tensor<3x2x?xf32>
+}


### PR DESCRIPTION
This adds MLIR test models for the Slice operation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>