### PR TITLE
[circle-mlir/models] Add MLIR test models for StridedSlice Op

### DIFF
--- a/circle-mlir/models/mlir/StridedSlice_F32_R2_ds.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_F32_R2_ds.circle.mlir
@@ -1,0 +1,16 @@
+// Circle.strided_slice with unknown shape to validate shape inference
+func.func @main_graph(%arg0: tensor<?x4xf32>) -> tensor<?x?xf32> attributes {
+  input_names = ["input"], output_names = ["output"]}
+{
+  %0 = "Circle.pseudo_const"() {value = dense<0> : tensor<2xi32>} :() -> tensor<2xi32>
+  %1 = "Circle.pseudo_const"() {value = dense<[0, 2]> : tensor<2xi32>} : () -> tensor<2xi32>
+  %2 = "Circle.pseudo_const"() {value = dense<1> : tensor<2xi32>} : () -> tensor<2xi32>
+  %4 = "Circle.strided_slice"(%arg0, %0, %1, %2) {
+    begin_mask = 0 : i32,
+    ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32,
+    new_axis_mask = 0 : i32,
+    shrink_axis_mask = 0 : i32} :
+    (tensor<?x4xf32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<?x?xf32>
+  return %4 : tensor<?x?xf32>
+}

--- a/circle-mlir/models/mlir/StridedSlice_F32_R4_us.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_F32_R4_us.circle.mlir
@@ -1,0 +1,20 @@
+// Circle.strided_slice with unknown shape to validate shape inference
+func.func @main_graph(%arg0: tensor<1x1x1x16xf32>) -> tensor<1x1x1x4xf32> attributes {
+  input_names = ["input"], output_names = ["output"]}
+{
+  %0 = "Circle.pseudo_const"() {value = dense<0> : tensor<4xi32>} :() -> tensor<4xi32>
+  %1 = "Circle.pseudo_const"() {value = dense<[1, 1, 1, 4]> : tensor<4xi32>} : () -> tensor<4xi32>
+  %2 = "Circle.pseudo_const"() {value = dense<1> : tensor<4xi32>} : () -> tensor<4xi32>
+  %3 = "Circle.add"(%arg0, %arg0) {fused_activation_function = "NONE"} :
+      (tensor<1x1x1x16xf32>, tensor<1x1x1x16xf32>) -> tensor<1x1x1x16xf32>
+  %4 = "Circle.strided_slice"(%3, %0, %1, %2) {
+    begin_mask = 0 : i32,
+    ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32,
+    new_axis_mask = 0 : i32,
+    shrink_axis_mask = 0 : i32} :
+    (tensor<1x1x1x16xf32>, tensor<4xi32>, tensor<4xi32>, tensor<4xi32>) -> tensor<1x1x1x?xf32>
+  %5 = "Circle.add"(%4, %4) {fused_activation_function = "NONE"} :
+    (tensor<1x1x1x?xf32>, tensor<1x1x1x?xf32>) -> tensor<1x1x1x4xf32>
+  return %5 : tensor<1x1x1x4xf32>
+}

--- a/circle-mlir/models/mlir/StridedSlice_I64_R1_C4.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_I64_R1_C4.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph()
+-> tensor<?xi64> attributes {
+  output_names = ["output"]}
+{
+  %data = "Circle.pseudo_const"() {
+    value = dense<[1, 2, 3, 4, 5, 6, 7, 8]> : tensor<8xi64>
+  } : () -> tensor<8xi64>
+
+  %begin = "Circle.pseudo_const"() {
+    value = dense<[4]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+  
+  %end = "Circle.pseudo_const"() {
+    value = dense<[8]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %stride = "Circle.pseudo_const"() {
+    value = dense<[1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %0 = "Circle.strided_slice"(%data, %begin, %end, %stride) {
+    begin_mask = 0 : i32, ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32, new_axis_mask = 0 : i32, shrink_axis_mask = 0 : i32
+  } : (tensor<8xi64>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?xi64>
+
+  return %0 : tensor<?xi64>
+}

--- a/circle-mlir/models/mlir/StridedSlice_I64_R1_C4_rev.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_I64_R1_C4_rev.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph()
+-> tensor<?xi64> attributes {
+  output_names = ["output"]}
+{
+  %data = "Circle.pseudo_const"() {
+    value = dense<[1, 2, 3, 4, 5, 6, 7, 8]> : tensor<8xi64>
+  } : () -> tensor<8xi64>
+
+  %begin = "Circle.pseudo_const"() {
+    value = dense<[-5]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %end = "Circle.pseudo_const"() {
+    value = dense<[-9]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %stride = "Circle.pseudo_const"() {
+    value = dense<[-1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %0 = "Circle.strided_slice"(%data, %begin, %end, %stride) {
+    begin_mask = 0 : i32, ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32, new_axis_mask = 0 : i32, shrink_axis_mask = 0 : i32
+  } : (tensor<8xi64>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<?xi64>
+
+  return %0 : tensor<?xi64>
+}

--- a/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_0.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_0.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph()
+-> tensor<4x2xi64> attributes {
+  output_names = ["output"]}
+{
+  %data = "Circle.pseudo_const"() {
+    value = dense<[[1, 2], [3, 4], [5, 6], [7, 8]]> : tensor<4x2xi64>
+  } : () -> tensor<4x2xi64>
+
+  %begin = "Circle.pseudo_const"() {
+    value = dense<[0, 0]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %end = "Circle.pseudo_const"() {
+    value = dense<[4, 2]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %stride = "Circle.pseudo_const"() {
+    value = dense<[1, 1]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %0 = "Circle.strided_slice"(%data, %begin, %end, %stride) {
+    begin_mask = 0 : i32, ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32, new_axis_mask = 0 : i32, shrink_axis_mask = 0 : i32
+  } : (tensor<4x2xi64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<4x2xi64>
+
+  return %0 : tensor<4x2xi64>
+}

--- a/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_1.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_1.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph()
+-> tensor<4x2xi64> attributes {
+  output_names = ["output"]}
+{
+  %data = "Circle.pseudo_const"() {
+    value = dense<[[1, 2], [3, 4], [5, 6], [7, 8]]> : tensor<4x2xi64>
+  } : () -> tensor<4x2xi64>
+
+  %begin = "Circle.pseudo_const"() {
+    value = dense<[-1, 0]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %end = "Circle.pseudo_const"() {
+    value = dense<[-5, 2]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %stride = "Circle.pseudo_const"() {
+    value = dense<[-1, 1]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %0 = "Circle.strided_slice"(%data, %begin, %end, %stride) {
+    begin_mask = 0 : i32, ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32, new_axis_mask = 0 : i32, shrink_axis_mask = 0 : i32
+  } : (tensor<4x2xi64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<4x2xi64>
+
+  return %0 : tensor<4x2xi64>
+}

--- a/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_2.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_2.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph()
+-> tensor<4x2xi64> attributes {
+  output_names = ["output"]}
+{
+  %data = "Circle.pseudo_const"() {
+    value = dense<[[1, 2], [3, 4], [5, 6], [7, 8]]> : tensor<4x2xi64>
+  } : () -> tensor<4x2xi64>
+
+  %begin = "Circle.pseudo_const"() {
+    value = dense<[0, -1]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %end = "Circle.pseudo_const"() {
+    value = dense<[4, -3]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %stride = "Circle.pseudo_const"() {
+    value = dense<[1, -1]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %0 = "Circle.strided_slice"(%data, %begin, %end, %stride) {
+    begin_mask = 0 : i32, ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32, new_axis_mask = 0 : i32, shrink_axis_mask = 0 : i32
+  } : (tensor<4x2xi64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<4x2xi64>
+
+  return %0 : tensor<4x2xi64>
+}

--- a/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_3.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_3.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph()
+-> tensor<4x2xi64> attributes {
+  output_names = ["output"]}
+{
+  %data = "Circle.pseudo_const"() {
+    value = dense<[[1, 2], [3, 4], [5, 6], [7, 8]]> : tensor<4x2xi64>
+  } : () -> tensor<4x2xi64>
+
+  %begin = "Circle.pseudo_const"() {
+    value = dense<[-1, -1]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %end = "Circle.pseudo_const"() {
+    value = dense<[-5, -3]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %stride = "Circle.pseudo_const"() {
+    value = dense<[-1, -1]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %0 = "Circle.strided_slice"(%data, %begin, %end, %stride) {
+    begin_mask = 0 : i32, ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32, new_axis_mask = 0 : i32, shrink_axis_mask = 0 : i32
+  } : (tensor<4x2xi64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<4x2xi64>
+
+  return %0 : tensor<4x2xi64>
+}

--- a/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_4.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_I64_R2_C4_4.circle.mlir
@@ -1,0 +1,27 @@
+func.func @main_graph()
+-> tensor<2x2xi64> attributes {
+  output_names = ["output"]}
+{
+  %data = "Circle.pseudo_const"() {
+    value = dense<[[1, 2], [3, 4], [5, 6], [7, 8]]> : tensor<4x2xi64>
+  } : () -> tensor<4x2xi64>
+
+  %begin = "Circle.pseudo_const"() {
+    value = dense<[-1, 0]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %end = "Circle.pseudo_const"() {
+    value = dense<[-3, 2]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %stride = "Circle.pseudo_const"() {
+    value = dense<[-1, 1]> : tensor<2xi32>
+  } : () -> tensor<2xi32>
+
+  %0 = "Circle.strided_slice"(%data, %begin, %end, %stride) {
+    begin_mask = 0 : i32, ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32, new_axis_mask = 0 : i32, shrink_axis_mask = 0 : i32
+  } : (tensor<4x2xi64>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<2x2xi64>
+
+  return %0 : tensor<2x2xi64>
+}

--- a/circle-mlir/models/mlir/StridedSlice_I64_R4_C4.circle.mlir
+++ b/circle-mlir/models/mlir/StridedSlice_I64_R4_C4.circle.mlir
@@ -1,0 +1,30 @@
+func.func @main_graph() -> tensor<2xi64> attributes { output_names = ["output"]}
+{
+  %input = "Circle.pseudo_const"() {
+    value = dense<[1, 80, 52, 52]> : tensor<4xi64>
+  } : () -> tensor<4xi64>
+
+  %begin = "Circle.pseudo_const"() {
+    value = dense<[0]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %end = "Circle.pseudo_const"() {
+    value = dense<[2]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %strides = "Circle.pseudo_const"() {
+    value = dense<[1]> : tensor<1xi32>
+  } : () -> tensor<1xi32>
+
+  %0 = "Circle.strided_slice"(%input, %begin, %end, %strides) {
+    onnx_node_name = "/Slice",
+    begin_mask = 0 : i32,
+    ellipsis_mask = 0 : i32,
+    end_mask = 0 : i32,
+    new_axis_mask = 0 : i32,
+    shrink_axis_mask = 0 : i32
+  } : (tensor<4xi64>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>)
+  -> tensor<2xi64>
+
+  return %0 : tensor<2xi64>
+}


### PR DESCRIPTION
This adds MLIR test models for the StridedSlice operation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>