### PR TITLE
[circle-mlir/models] Add unit test models for Slice Op

### DIFF
--- a/circle-mlir/models/unit/Slice_F32_R2_4/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R2_4/__init__.py
@@ -1,0 +1,19 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-2
+# Rank-2 from Slice_F32_R4_4
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input[4:8:2, :]
+
+    def onnx_opset_version(self):
+        return 14
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(16, 2)

--- a/circle-mlir/models/unit/Slice_F32_R3_4/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_4/__init__.py
@@ -1,0 +1,19 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-3
+# Rank-3 from Slice_F32_R4_4
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input[:, :, 4:8:2]
+
+    def onnx_opset_version(self):
+        return 14
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(2, 2, 16)

--- a/circle-mlir/models/unit/Slice_F32_R3_C2_1/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_C2_1/__init__.py
@@ -1,0 +1,102 @@
+import torch
+import onnx
+import json
+
+
+# Generate lower and upper limit of test value in the input node.
+# low : lower limit of the input value (inclusive)
+# high : upper limit of the input value (exclusive)
+def make_input_test_limit(input, low, high):
+    data = {"low": low, "high": high}
+    input.doc_string = json.dumps(data)
+
+
+# Generate Slice operator with Float32, Rank-3, non-const starts/ends, const axes/steps
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inputs):
+        return inputs[0], inputs[1], inputs[2]
+
+    def onnx_opset_version(self):
+        return 12
+
+    def post_process(self, model_path):
+        onnx_model = onnx.load(model_path)
+        # graph I/O
+        #   input: [ 'onnx::Identity_0', 'onnx::Identity_1', 'onnx::Identity_2' ]
+        #   output: [ '3', '4', '5' ]
+        #
+        # modify graph to
+        #   [Data, Starts, Ends]-Slice-[output]
+
+        for input in onnx_model.graph.input:
+            if input.name == 'onnx::Identity_0':
+                input.name = 'Data'
+            if input.name == 'onnx::Identity_1':
+                input.name = 'Starts'
+                make_input_test_limit(input, 0, 6)
+            if input.name == 'onnx::Identity_2':
+                input.name = 'Ends'
+                make_input_test_limit(input, 6, 12)
+
+        # Constant as 'axes' of Expand node
+        axes = onnx.helper.make_tensor(name='/Axes',
+                                       data_type=onnx.TensorProto.INT64,
+                                       dims=[1],
+                                       vals=[-1])
+        node_axes = onnx.helper.make_node('Constant', [], ['Axes'], value=axes)
+        onnx_model.graph.node.insert(0, node_axes)
+
+        # Constant as 'steps' of Expand node
+        steps = onnx.helper.make_tensor(name='/Steps',
+                                        data_type=onnx.TensorProto.INT64,
+                                        dims=[1],
+                                        vals=[1])
+        node_steps = onnx.helper.make_node('Constant', [], ['Steps'],
+                                           value=steps)
+        onnx_model.graph.node.insert(1, node_steps)
+
+        # Create SliceOp node
+        slice_node = onnx.helper.make_node(
+            'Slice',
+            inputs=['Data', 'Starts', 'Ends', 'Axes', 'Steps'],
+            outputs=['output'])
+        onnx_model.graph.node.insert(2, slice_node)
+
+        # Update output information
+        out = onnx.helper.make_tensor_value_info('output',
+                                                 onnx.TensorProto.FLOAT,
+                                                 [2, 2, 0])
+        onnx_model.graph.output.insert(102, out)
+
+        # Remove dummy identity
+        identities_to_remove = ['Identity_0', 'Identity_1', 'Identity_2']
+        nodes_to_remove = []
+        for node in onnx_model.graph.node:
+            if node.name in identities_to_remove:
+                nodes_to_remove.append(node)
+
+        for node in nodes_to_remove:
+            onnx_model.graph.node.remove(node)
+
+        remove_outputs = []
+        for output in onnx_model.graph.output:
+            if output.name == 'output':
+                continue
+            remove_outputs.append(output)
+
+        for output in remove_outputs:
+            onnx_model.graph.output.remove(output)
+
+        onnx.save(onnx_model, model_path)
+
+
+_model_ = net_Slice()
+
+_inputs_ = [
+    torch.randn(2, 2, 12),
+    torch.tensor([4], dtype=torch.int64),
+    torch.tensor([8], dtype=torch.int64)
+]

--- a/circle-mlir/models/unit/Slice_F32_R3_C2_1/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_C2_1/__init__.py
@@ -42,20 +42,15 @@ class net_Slice(torch.nn.Module):
                 make_input_test_limit(input, 6, 12)
 
         # Constant as 'axes' of Expand node
-        axes = onnx.helper.make_tensor(name='/Axes',
-                                       data_type=onnx.TensorProto.INT64,
-                                       dims=[1],
-                                       vals=[-1])
+        axes = onnx.helper.make_tensor(
+            name='/Axes', data_type=onnx.TensorProto.INT64, dims=[1], vals=[-1])
         node_axes = onnx.helper.make_node('Constant', [], ['Axes'], value=axes)
         onnx_model.graph.node.insert(0, node_axes)
 
         # Constant as 'steps' of Expand node
-        steps = onnx.helper.make_tensor(name='/Steps',
-                                        data_type=onnx.TensorProto.INT64,
-                                        dims=[1],
-                                        vals=[1])
-        node_steps = onnx.helper.make_node('Constant', [], ['Steps'],
-                                           value=steps)
+        steps = onnx.helper.make_tensor(
+            name='/Steps', data_type=onnx.TensorProto.INT64, dims=[1], vals=[1])
+        node_steps = onnx.helper.make_node('Constant', [], ['Steps'], value=steps)
         onnx_model.graph.node.insert(1, node_steps)
 
         # Create SliceOp node
@@ -66,8 +61,7 @@ class net_Slice(torch.nn.Module):
         onnx_model.graph.node.insert(2, slice_node)
 
         # Update output information
-        out = onnx.helper.make_tensor_value_info('output',
-                                                 onnx.TensorProto.FLOAT,
+        out = onnx.helper.make_tensor_value_info('output', onnx.TensorProto.FLOAT,
                                                  [2, 2, 0])
         onnx_model.graph.output.insert(102, out)
 

--- a/circle-mlir/models/unit/Slice_F32_R3_C2_1/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_C2_1/__init__.py
@@ -42,14 +42,18 @@ class net_Slice(torch.nn.Module):
                 make_input_test_limit(input, 6, 12)
 
         # Constant as 'axes' of Expand node
-        axes = onnx.helper.make_tensor(
-            name='/Axes', data_type=onnx.TensorProto.INT64, dims=[1], vals=[-1])
+        axes = onnx.helper.make_tensor(name='/Axes',
+                                       data_type=onnx.TensorProto.INT64,
+                                       dims=[1],
+                                       vals=[-1])
         node_axes = onnx.helper.make_node('Constant', [], ['Axes'], value=axes)
         onnx_model.graph.node.insert(0, node_axes)
 
         # Constant as 'steps' of Expand node
-        steps = onnx.helper.make_tensor(
-            name='/Steps', data_type=onnx.TensorProto.INT64, dims=[1], vals=[1])
+        steps = onnx.helper.make_tensor(name='/Steps',
+                                        data_type=onnx.TensorProto.INT64,
+                                        dims=[1],
+                                        vals=[1])
         node_steps = onnx.helper.make_node('Constant', [], ['Steps'], value=steps)
         onnx_model.graph.node.insert(1, node_steps)
 

--- a/circle-mlir/models/unit/Slice_F32_R3_C2_2/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_C2_2/__init__.py
@@ -42,14 +42,18 @@ class net_Slice(torch.nn.Module):
                 make_input_test_limit(input, -4, 0)  # negative input test
 
         # Constant as 'axes' of Expand node
-        axes = onnx.helper.make_tensor(
-            name='/Axes', data_type=onnx.TensorProto.INT64, dims=[1], vals=[-1])
+        axes = onnx.helper.make_tensor(name='/Axes',
+                                       data_type=onnx.TensorProto.INT64,
+                                       dims=[1],
+                                       vals=[-1])
         node_axes = onnx.helper.make_node('Constant', [], ['Axes'], value=axes)
         onnx_model.graph.node.insert(0, node_axes)
 
         # Constant as 'steps' of Expand node
-        steps = onnx.helper.make_tensor(
-            name='/Steps', data_type=onnx.TensorProto.INT64, dims=[1], vals=[1])
+        steps = onnx.helper.make_tensor(name='/Steps',
+                                        data_type=onnx.TensorProto.INT64,
+                                        dims=[1],
+                                        vals=[1])
         node_steps = onnx.helper.make_node('Constant', [], ['Steps'], value=steps)
         onnx_model.graph.node.insert(1, node_steps)
 

--- a/circle-mlir/models/unit/Slice_F32_R3_C2_2/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_C2_2/__init__.py
@@ -42,20 +42,15 @@ class net_Slice(torch.nn.Module):
                 make_input_test_limit(input, -4, 0)  # negative input test
 
         # Constant as 'axes' of Expand node
-        axes = onnx.helper.make_tensor(name='/Axes',
-                                       data_type=onnx.TensorProto.INT64,
-                                       dims=[1],
-                                       vals=[-1])
+        axes = onnx.helper.make_tensor(
+            name='/Axes', data_type=onnx.TensorProto.INT64, dims=[1], vals=[-1])
         node_axes = onnx.helper.make_node('Constant', [], ['Axes'], value=axes)
         onnx_model.graph.node.insert(0, node_axes)
 
         # Constant as 'steps' of Expand node
-        steps = onnx.helper.make_tensor(name='/Steps',
-                                        data_type=onnx.TensorProto.INT64,
-                                        dims=[1],
-                                        vals=[1])
-        node_steps = onnx.helper.make_node('Constant', [], ['Steps'],
-                                           value=steps)
+        steps = onnx.helper.make_tensor(
+            name='/Steps', data_type=onnx.TensorProto.INT64, dims=[1], vals=[1])
+        node_steps = onnx.helper.make_node('Constant', [], ['Steps'], value=steps)
         onnx_model.graph.node.insert(1, node_steps)
 
         # Create SliceOp node
@@ -66,8 +61,7 @@ class net_Slice(torch.nn.Module):
         onnx_model.graph.node.insert(2, slice_node)
 
         # Update output information
-        out = onnx.helper.make_tensor_value_info('output',
-                                                 onnx.TensorProto.FLOAT,
+        out = onnx.helper.make_tensor_value_info('output', onnx.TensorProto.FLOAT,
                                                  [2, 2, 0])
         onnx_model.graph.output.insert(102, out)
 

--- a/circle-mlir/models/unit/Slice_F32_R3_C2_2/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_C2_2/__init__.py
@@ -1,0 +1,102 @@
+import torch
+import onnx
+import json
+
+
+# Generate lower and upper limit of test value in the input node.
+# low : lower limit of the input value (inclusive)
+# high : upper limit of the input value (exclusive)
+def make_input_test_limit(input, low, high):
+    data = {"low": low, "high": high}
+    input.doc_string = json.dumps(data)
+
+
+# Generate Slice operator with Float32, Rank-3, non-const starts/ends, const axes/steps
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inputs):
+        return inputs[0], inputs[1], inputs[2]
+
+    def onnx_opset_version(self):
+        return 12
+
+    def post_process(self, model_path):
+        onnx_model = onnx.load(model_path)
+        # graph I/O
+        #   input: [ 'onnx::Identity_0', 'onnx::Identity_1', 'onnx::Identity_2' ]
+        #   output: [ '3', '4', '5' ]
+        #
+        # modify graph to
+        #   [Data, Starts, Ends]-Slice-[output]
+
+        for input in onnx_model.graph.input:
+            if input.name == 'onnx::Identity_0':
+                input.name = 'Data'
+            if input.name == 'onnx::Identity_1':
+                input.name = 'Starts'
+                make_input_test_limit(input, 0, 8)
+            if input.name == 'onnx::Identity_2':
+                input.name = 'Ends'
+                make_input_test_limit(input, -4, 0)  # negative input test
+
+        # Constant as 'axes' of Expand node
+        axes = onnx.helper.make_tensor(name='/Axes',
+                                       data_type=onnx.TensorProto.INT64,
+                                       dims=[1],
+                                       vals=[-1])
+        node_axes = onnx.helper.make_node('Constant', [], ['Axes'], value=axes)
+        onnx_model.graph.node.insert(0, node_axes)
+
+        # Constant as 'steps' of Expand node
+        steps = onnx.helper.make_tensor(name='/Steps',
+                                        data_type=onnx.TensorProto.INT64,
+                                        dims=[1],
+                                        vals=[1])
+        node_steps = onnx.helper.make_node('Constant', [], ['Steps'],
+                                           value=steps)
+        onnx_model.graph.node.insert(1, node_steps)
+
+        # Create SliceOp node
+        slice_node = onnx.helper.make_node(
+            'Slice',
+            inputs=['Data', 'Starts', 'Ends', 'Axes', 'Steps'],
+            outputs=['output'])
+        onnx_model.graph.node.insert(2, slice_node)
+
+        # Update output information
+        out = onnx.helper.make_tensor_value_info('output',
+                                                 onnx.TensorProto.FLOAT,
+                                                 [2, 2, 0])
+        onnx_model.graph.output.insert(102, out)
+
+        # Remove dummy identity
+        identities_to_remove = ['Identity_0', 'Identity_1', 'Identity_2']
+        nodes_to_remove = []
+        for node in onnx_model.graph.node:
+            if node.name in identities_to_remove:
+                nodes_to_remove.append(node)
+
+        for node in nodes_to_remove:
+            onnx_model.graph.node.remove(node)
+
+        remove_outputs = []
+        for output in onnx_model.graph.output:
+            if output.name == 'output':
+                continue
+            remove_outputs.append(output)
+
+        for output in remove_outputs:
+            onnx_model.graph.output.remove(output)
+
+        onnx.save(onnx_model, model_path)
+
+
+_model_ = net_Slice()
+
+_inputs_ = [
+    torch.randn(2, 2, 12),
+    torch.tensor([4], dtype=torch.int64),
+    torch.tensor([8], dtype=torch.int64)
+]

--- a/circle-mlir/models/unit/Slice_F32_R3_unk_1/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_unk_1/__init__.py
@@ -1,0 +1,24 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-3 with axes from input
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inputs):
+        input = inputs[0]
+        ends = inputs[1]
+        return input[:, :, :ends:]
+
+    def onnx_opset_version(self):
+        return 13
+
+
+_model_ = net_Slice()
+
+val = [2]
+_inputs_ = [torch.randn(2, 8, 6), torch.tensor(val)]
+
+_io_names_ = [['input', 'ends'], ['out']]
+_dynamic_axes_ = {'input': {0: '?'}}

--- a/circle-mlir/models/unit/Slice_F32_R3_unk_2/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R3_unk_2/__init__.py
@@ -1,0 +1,26 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-3 with axes from input
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inputs):
+        input = inputs[0]
+        starts = inputs[1]
+        ends = inputs[2]
+        return input[:, :, starts:ends:]
+
+    def onnx_opset_version(self):
+        return 13
+
+
+_model_ = net_Slice()
+
+vals = [1]
+vale = [1]
+_inputs_ = [torch.randn(2, 8, 6), torch.tensor(vals), torch.tensor(vale)]
+
+_io_names_ = [['input', 'starts', 'ends'], ['out']]
+_dynamic_axes_ = {'input': {0: '?'}}

--- a/circle-mlir/models/unit/Slice_F32_R4_1/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R4_1/__init__.py
@@ -1,0 +1,18 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-4
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input[:, :, :, 0:4]
+
+    def onnx_opset_version(self):
+        return 14
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(1, 1, 1, 16)

--- a/circle-mlir/models/unit/Slice_F32_R4_2/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R4_2/__init__.py
@@ -1,0 +1,18 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-4
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input[:, :, :, 4:8]
+
+    def onnx_opset_version(self):
+        return 14
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(1, 1, 1, 16)

--- a/circle-mlir/models/unit/Slice_F32_R4_3/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R4_3/__init__.py
@@ -1,0 +1,19 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-4
+# This will produce two Slice
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input[0:1, :, :, 0:4]
+
+    def onnx_opset_version(self):
+        return 14
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(2, 2, 2, 16)

--- a/circle-mlir/models/unit/Slice_F32_R4_4/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R4_4/__init__.py
@@ -1,0 +1,18 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-4
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input[:, :, :, 4:8:2]
+
+    def onnx_opset_version(self):
+        return 14
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(2, 2, 2, 16)

--- a/circle-mlir/models/unit/Slice_F32_R4_5/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R4_5/__init__.py
@@ -1,0 +1,18 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-4, minus values
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input[:, :, :, -8:-4]
+
+    def onnx_opset_version(self):
+        return 14
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(2, 2, 2, 16)

--- a/circle-mlir/models/unit/Slice_F32_R4_6/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R4_6/__init__.py
@@ -1,0 +1,18 @@
+import torch
+
+
+# Generate Slice operator with Float32, Rank-4,
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return input[:, 2:, :, :]
+
+    def onnx_opset_version(self):
+        return 14
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(1, 4, 1, 2)

--- a/circle-mlir/models/unit/Slice_F32_R4_7/__init__.py
+++ b/circle-mlir/models/unit/Slice_F32_R4_7/__init__.py
@@ -1,0 +1,86 @@
+import torch
+import onnx
+
+
+# Generate Slice operator with Float32, Rank-4
+class net_Slice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        # The slicing operation input[:, 0:12, 0:12, :] generates two separate Slice nodes,
+        # one for each axis (axes 1 and 2).
+        # To consolidate this into a single Slice node, we first generate a partial slice
+        # (e.g., input[:, 0:12, :, :]) and use the post_process() function to adjust its parameters.
+        # This ensures that the slicing is executed as a single operation across multiple axes.
+        return input[:, 0:12, :, :]
+
+    def onnx_opset_version(self):
+        return 14
+
+    def post_process(self, model_path):
+        onnx_model = onnx.load(model_path)
+
+        for node in onnx_model.graph.node:
+            if node.op_type == "Slice":
+                new_axes = [1, 2]
+                new_starts = [0, 0]
+                new_ends = [12, 12]
+                new_steps = [1, 1]
+
+                starts_initializer = onnx.helper.make_tensor(
+                    name="starts",
+                    data_type=onnx.TensorProto.INT64,
+                    dims=(len(new_starts), ),
+                    vals=new_starts)
+                ends_initializer = onnx.helper.make_tensor(
+                    name="ends",
+                    data_type=onnx.TensorProto.INT64,
+                    dims=(len(new_ends), ),
+                    vals=new_ends)
+                axes_initializer = onnx.helper.make_tensor(
+                    name="axes",
+                    data_type=onnx.TensorProto.INT64,
+                    dims=(len(new_axes), ),
+                    vals=new_axes)
+                steps_initializer = onnx.helper.make_tensor(
+                    name="steps",
+                    data_type=onnx.TensorProto.INT64,
+                    dims=(len(new_steps), ),
+                    vals=new_steps)
+
+                # Append the new initializers to the graph
+                onnx_model.graph.initializer.extend([
+                    starts_initializer, ends_initializer, axes_initializer,
+                    steps_initializer
+                ])
+
+                # Modify the Slice node to use the new parameters
+                node.input[1] = "starts"
+                node.input[2] = "ends"
+                node.input[3] = "axes"
+                node.input[4] = "steps"
+
+        # Remove old parameters of Slice
+        contRemove = True
+        didRemove = False
+        while contRemove:
+            didRemove = False
+            for node in onnx_model.graph.node:
+                if node.op_type == 'Constant':
+                    onnx_model.graph.node.remove(node)
+                    didRemove = True
+                    break
+            if not didRemove:
+                contRemove = False
+
+        # Modify the graph output to match the expected shape
+        for output in onnx_model.graph.output:
+            output.type.tensor_type.shape.dim[2].dim_value = 12
+
+        onnx.save(onnx_model, model_path)
+
+
+_model_ = net_Slice()
+
+_inputs_ = torch.randn(2, 16, 16, 4)


### PR DESCRIPTION
This adds the unit test models for Slice operation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>