### PR TITLE
[onert] Add typecheck for Transpose

### DIFF
--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -551,6 +551,14 @@ void OperationValidator::visit(const operation::StridedSlice &node)
   OP_REQUIRES(isSameType(output_index, input_index));
 }
 
+void OperationValidator::visit(const operation::Transpose &node)
+{
+  const auto output_index{node.getOutputs().at(0)};
+  const auto input_index{node.getInputs().at(operation::Transpose::Input::INPUT)};
+
+  OP_REQUIRES(isSameType(output_index, input_index));
+}
+
 void OperationValidator::visit(const operation::TransposeConv &node)
 {
   OP_REQUIRES((node.param().padding.type == PaddingType::SAME) ||

--- a/runtime/onert/core/src/ir/OperationValidator.h
+++ b/runtime/onert/core/src/ir/OperationValidator.h
@@ -75,6 +75,7 @@ public:
   void visit(const operation::SquaredDifference &node) override;
   void visit(const operation::StatelessRandomUniform &node) override;
   void visit(const operation::StridedSlice &node) override;
+  void visit(const operation::Transpose &node) override;
   void visit(const operation::TransposeConv &node) override;
   void visit(const operation::Unpack &node) override;
   void visit(const operation::While &node) override;

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Transpose.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Transpose.test.cc
@@ -140,3 +140,21 @@ TEST_F(GenModelTest, neg_OneOp_Transpose_DuplicatedPermsVal)
 
   SUCCEED();
 }
+
+TEST_F(GenModelTest, neg_OneOp_Transpose_DifferentType)
+{
+  CircleGen cgen;
+  std::vector<int32_t> perms_data{3, 2, 1, 0};
+  uint32_t perms_buf = cgen.addBuffer(perms_data);
+  int perms = cgen.addTensor({{4}, circle::TensorType::TensorType_INT32, perms_buf});
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorTranspose({{in, perms}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}


### PR DESCRIPTION
It adds typecheck (input type = output type) for Transpose. Also, it adds 1 negative testcase.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

-----

```
$ Product/x86_64-linux.debug/out/unittest/nnfw_api_gtest
  . . .
[ RUN      ] GenModelTest.neg_OneOp_Transpose_DifferentType
Error during model loading : OperationValidator failed at line 559
Failed model loading as expected.
[       OK ] GenModelTest.neg_OneOp_Transpose_DifferentType (0 ms)
```