### PR TITLE
[circle-mlir/tools] Test coverage for SelectV2 Op

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
@@ -15,6 +15,9 @@ ConvertUnitModel(Custom_F32.circle.mlir)
 ConvertUnitModel(ReduceProd_I64_R1_1.circle.mlir)
 ConvertUnitModel(ReduceProd_I64_R1_3.circle.mlir)
 ConvertUnitModel(Rsqrt_F32_R1_C1.circle.mlir)
+ConvertUnitModel(SelectV2_I32_R2.circle.mlir)
+ConvertUnitModel(SelectV2_I64_R2.circle.mlir)
+ConvertUnitModel(SelectV2_F32_R2.circle.mlir)
 
 # negative
 


### PR DESCRIPTION
This enables tests to cover the SelectV2 operation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>