### PR TITLE
[onert] Transpose supports up to 6D Tensor

### DIFF
--- a/runtime/compute/cker/include/cker/Shape.h
+++ b/runtime/compute/cker/include/cker/Shape.h
@@ -31,9 +31,9 @@ namespace cker
 class Shape
 {
 public:
-  // Shapes with dimensions up to 5 are stored directly in the structure, while
+  // Shapes with dimensions up to 6 are stored directly in the structure, while
   // larger shapes are separately allocated.
-  static constexpr int kMaxSmallSize = 5;
+  static constexpr int kMaxSmallSize = 6;
 
   Shape &operator=(Shape const &) = delete;
 
@@ -111,8 +111,8 @@ public:
 
   inline int32_t *DimsData() { return _size > kMaxSmallSize ? _dims_pointer : _dims; }
   inline const int32_t *DimsData() const { return _size > kMaxSmallSize ? _dims_pointer : _dims; }
-  // The caller must ensure that the shape is no bigger than 4-D.
-  inline const int32_t *DimsDataUpTo4D() const { return _dims; }
+  // The caller must ensure that the shape is no bigger than 6D.
+  inline const int32_t *DimsDataUpTo6D() const { return _dims; }
 
   inline void Resize(int dimensions_count)
   {
@@ -237,7 +237,7 @@ inline Shape GetShape(const std::vector<int32_t> &data) { return Shape(data.size
 inline int Offset(const Shape &shape, int i0, int i1, int i2, int i3)
 {
   assert(shape.DimensionsCount() == 4);
-  const int *dims_data = shape.DimsDataUpTo4D();
+  const int *dims_data = shape.DimsDataUpTo6D();
   assert(i0 >= 0 && i0 < dims_data[0]);
   assert(i1 >= 0 && i1 < dims_data[1]);
   assert(i2 >= 0 && i2 < dims_data[2]);
@@ -245,9 +245,24 @@ inline int Offset(const Shape &shape, int i0, int i1, int i2, int i3)
   return ((i0 * dims_data[1] + i1) * dims_data[2] + i2) * dims_data[3] + i3;
 }
 
+inline int Offset(const Shape &shape, int i0, int i1, int i2, int i3, int i4, int i5)
+{
+  assert(shape.DimensionsCount() == 6);
+  const int *dim = shape.DimsDataUpTo6D();
+  assert(i0 >= 0 && i0 < dim[0]);
+  assert(i1 >= 0 && i1 < dim[1]);
+  assert(i2 >= 0 && i2 < dim[2]);
+  assert(i3 >= 0 && i3 < dim[3]);
+  assert(i4 >= 0 && i4 < dim[4]);
+  assert(i5 >= 0 && i5 < dim[5]);
+  // clang format off
+  return (((((i0 * dim[1] + i1) * dim[2] + i2) * dim[3] + i3) * dim[4]) + i4) * dim[5] + i5;
+  // clang format on
+}
+
 inline int Offset(const Shape &shape, int *index)
 {
-  return Offset(shape, index[0], index[1], index[2], index[3]);
+  return Offset(shape, index[0], index[1], index[2], index[3], index[4], index[5]);
 }
 
 inline int FlatSizeSkipDim(const Shape &shape, int skip_dim)

--- a/runtime/compute/cker/include/cker/Types.h
+++ b/runtime/compute/cker/include/cker/Types.h
@@ -215,7 +215,7 @@ struct BinaryArithmeticOpParam
 struct TransposeParams
 {
   int8_t perm_count;
-  int32_t perm[4];
+  int32_t perm[6];
 };
 
 struct ConcatenationParams

--- a/runtime/compute/cker/include/cker/operation/Transpose.h
+++ b/runtime/compute/cker/include/cker/operation/Transpose.h
@@ -34,17 +34,15 @@ void TransposeImpl(const TransposeParams &params, const Shape &unextended_input_
                    const T *input_data, const Shape &unextended_output_shape, T *output_data)
 {
   const int unextended_output_size = unextended_output_shape.DimensionsCount();
-  assert(unextended_input_shape.DimensionsCount() <= 4);
-  assert(unextended_output_size <= 4);
+  assert(unextended_input_shape.DimensionsCount() <= 6);
+  assert(unextended_output_size <= 6);
   assert(unextended_output_size == params.perm_count);
-  const Shape input_shape = Shape::ExtendedShape(4, unextended_input_shape);
-  const Shape output_shape = Shape::ExtendedShape(4, unextended_output_shape);
-  const int input_ext_size = 4 - unextended_input_shape.DimensionsCount();
-  const int output_ext_size = 4 - unextended_output_size;
+  const Shape input_shape = Shape::ExtendedShape(6, unextended_input_shape);
+  const Shape output_shape = Shape::ExtendedShape(6, unextended_output_shape);
+  const int input_ext_size = 6 - unextended_input_shape.DimensionsCount();
+  const int output_ext_size = 6 - unextended_output_size;
 
-  // The perm data is extended to match the output, each index incremented by
-  // the amount of front padding of the input shape.
-  int extended_perm[4];
+  int extended_perm[6];
   for (int i = 0; i < output_ext_size; ++i)
   {
     extended_perm[i] = i;
@@ -54,30 +52,35 @@ void TransposeImpl(const TransposeParams &params, const Shape &unextended_input_
     extended_perm[i + output_ext_size] = params.perm[i] + input_ext_size;
   }
 
-  int out_sizes[4];
-  // Compute the inverse permutation array so we can do an output centered
-  // transpose. Also, check to make sure output_dims is matching input_dims.
-  for (int k = 0; k < 4; k++)
+  int out_sizes[6];
+  for (int k = 0; k < 6; k++)
   {
     out_sizes[k] = MatchingDim(input_shape, extended_perm[k], output_shape, k);
   }
 
-  // Naive transpose loop (iterate on output index and compute input index).
-  int o[4]; // loop index (on output).
-  int i[4];
-  for (o[3] = 0; o[3] < out_sizes[3]; o[3]++)
+  int o[6];
+  int i[6];
+  for (o[5] = 0; o[5] < out_sizes[5]; o[5]++)
   {
-    i[extended_perm[3]] = o[3];
-    for (o[2] = 0; o[2] < out_sizes[2]; o[2]++)
+    i[extended_perm[5]] = o[5];
+    for (o[4] = 0; o[4] < out_sizes[4]; o[4]++)
     {
-      i[extended_perm[2]] = o[2];
-      for (o[1] = 0; o[1] < out_sizes[1]; o[1]++)
+      i[extended_perm[4]] = o[4];
+      for (o[3] = 0; o[3] < out_sizes[3]; o[3]++)
       {
-        i[extended_perm[1]] = o[1];
-        for (o[0] = 0; o[0] < out_sizes[0]; o[0]++)
+        i[extended_perm[3]] = o[3];
+        for (o[2] = 0; o[2] < out_sizes[2]; o[2]++)
         {
-          i[extended_perm[0]] = o[0];
-          output_data[Offset(output_shape, o)] = input_data[Offset(input_shape, i)];
+          i[extended_perm[2]] = o[2];
+          for (o[1] = 0; o[1] < out_sizes[1]; o[1]++)
+          {
+            i[extended_perm[1]] = o[1];
+            for (o[0] = 0; o[0] < out_sizes[0]; o[0]++)
+            {
+              i[extended_perm[0]] = o[0];
+              output_data[Offset(output_shape, o)] = input_data[Offset(input_shape, i)];
+            }
+          }
         }
       }
     }
@@ -510,8 +513,8 @@ void Transpose(const TransposeParams &unshrunk_params, const Shape &unshrunk_inp
                const T *input_data, const Shape &unshrunk_output_shape, T *output_data)
 {
   const int output_size = unshrunk_output_shape.DimensionsCount();
-  assert(unshrunk_input_shape.DimensionsCount() <= 4);
-  assert(output_size <= 4);
+  assert(unshrunk_input_shape.DimensionsCount() <= 6);
+  assert(output_size <= 6);
   assert(output_size == unshrunk_params.perm_count);
 
   Shape shrunk_input_shape = Shape(unshrunk_input_shape);

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Transpose.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Transpose.test.cc
@@ -17,6 +17,7 @@
 #include "GenModelTest.h"
 
 #include <memory>
+#include <numeric>
 
 TEST_F(GenModelTest, OneOp_Transpose_PermsToConst)
 {
@@ -84,6 +85,58 @@ TEST_F(GenModelTest, OneOp_Transpose_RegularTranspose)
                           .addOutput<float>({1, 4, 2, 5, 3, 6}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Transpose_6D)
+{
+  CircleGen cgen;
+
+  std::vector<int32_t> in_shape{2, 3, 4, 5, 6, 2};
+  std::vector<int32_t> perms_data{5, 3, 4, 0, 2, 1};
+  std::vector<int32_t> out_shape{2, 5, 6, 2, 4, 3};
+
+  std::vector<int32_t> in_data(
+    std::accumulate(in_shape.begin(), in_shape.end(), 1, std::multiplies{}));
+  std::iota(in_data.begin(), in_data.end(), 0);
+
+  std::vector<int32_t> out_data(in_data.size());
+  auto p = perms_data.data();
+  auto i_ne = in_shape.data();
+  auto o_ne = out_shape.data();
+
+  // clang-format off
+  for (int i0 = 0; i0 < i_ne[0]; ++i0)
+    for (int i1 = 0; i1 < i_ne[1]; ++i1)
+      for (int i2 = 0; i2 < i_ne[2]; ++i2)
+        for (int i3 = 0; i3 < i_ne[3]; ++i3)
+          for (int i4 = 0; i4 < i_ne[4]; ++i4)
+            for (int i5 = 0; i5 < i_ne[5]; ++i5)
+            {
+              int i_idx = ((((i0 * i_ne[1] + i1) * i_ne[2] + i2) * i_ne[3] + i3) * i_ne[4] + i4) * i_ne[5] + i5;
+              int o_i0 = p[0] == 0 ? i0 : p[0] == 1 ? i1 : p[0] == 2 ? i2 : p[0] == 3 ? i3 : p[0] == 4 ? i4 : i5;
+              int o_i1 = p[1] == 0 ? i0 : p[1] == 1 ? i1 : p[1] == 2 ? i2 : p[1] == 3 ? i3 : p[1] == 4 ? i4 : i5;
+              int o_i2 = p[2] == 0 ? i0 : p[2] == 1 ? i1 : p[2] == 2 ? i2 : p[2] == 3 ? i3 : p[2] == 4 ? i4 : i5;
+              int o_i3 = p[3] == 0 ? i0 : p[3] == 1 ? i1 : p[3] == 2 ? i2 : p[3] == 3 ? i3 : p[3] == 4 ? i4 : i5;
+              int o_i4 = p[4] == 0 ? i0 : p[4] == 1 ? i1 : p[4] == 2 ? i2 : p[4] == 3 ? i3 : p[4] == 4 ? i4 : i5;
+              int o_i5 = p[5] == 0 ? i0 : p[5] == 1 ? i1 : p[5] == 2 ? i2 : p[5] == 3 ? i3 : p[5] == 4 ? i4 : i5;
+              int o_idx = ((((o_i0 * o_ne[1] + o_i1) * o_ne[2] + o_i2) * o_ne[3] + o_i3) * o_ne[4] + o_i4) * o_ne[5] + o_i5;
+              out_data[o_idx] = in_data[i_idx];
+            }
+  // clang-format on
+
+  int in = cgen.addTensor({in_shape, circle::TensorType::TensorType_INT32});
+  uint32_t perms_buf = cgen.addBuffer(perms_data);
+  int perms = cgen.addTensor({{6}, circle::TensorType::TensorType_INT32, perms_buf});
+  int out = cgen.addTensor({out_shape, circle::TensorType::TensorType_INT32});
+
+  cgen.addOperatorTranspose({{in, perms}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(TestCaseData{}.addInput<int32_t>(in_data).addOutput<int32_t>(out_data));
+
+  _context->setBackends({"cpu"});
   SUCCEED();
 }
 


### PR DESCRIPTION
It supports 6D input data and perms.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #14928 

```
[ RUN      ] GenModelTest.OneOp_Transpose_6D
[       OK ] GenModelTest.OneOp_Transpose_6D (0 ms)
```