### PR TITLE
[compiler/one-cmds] Fix fsspec package version in venv

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -93,5 +93,8 @@ fi
 # Fix version to that of TF release date
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade protobuf==4.23.3
 
+# Fix version with fsspec error on U20.04
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade fsspec==2024.6.1
+
 # Install pydot for visq
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install pydot==${VER_PYDOT}

--- a/compiler/one-cmds/one-prepare-venv.u1804
+++ b/compiler/one-cmds/one-prepare-venv.u1804
@@ -93,5 +93,8 @@ fi
 # Fix version to that of TF release date
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade protobuf==4.23.3
 
+# Fix version with fsspec error on U18.04
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade fsspec==2024.6.1
+
 # Install pydot for visq
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install pydot==${VER_PYDOT}


### PR DESCRIPTION
This fixes the version of the `fsspec` package in the venv environment, to resolve a version mismatch issue with Python 3.8.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>