### PR TITLE
[infra] Use self-hosted runner for android build

### DIFF
--- a/.github/workflows/run-onert-android-build.yml
+++ b/.github/workflows/run-onert-android-build.yml
@@ -43,8 +43,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
     if: github.repository_owner == 'Samsung'
+    runs-on: one-x64-linux
+    container:
+      image: nnfw/one-devtools:android-sdk
+      options: --user root
     env:
       TARGET_ARCH: aarch64
       TARGET_OS: android
@@ -71,8 +74,7 @@ jobs:
           pip3 install numpy
           sudo apt-get update && sudo apt-get -qqy install scons
 
-      # Use NDK Default
+      # Use NDK Default - path set by containe envrionment variable
       - name: Build onert
         run: |
-          export NDK_DIR=${ANDROID_NDK}
           make -f Makefile.template


### PR DESCRIPTION
This commit updates android build workflow to use self-hosted runner and android-sdk image. 
It will resolve build fail by too high cmake version on github-hosted runner.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>