### PR TITLE
[onert] Support constant input BatchMatMul

### DIFF
--- a/runtime/compute/cker/include/cker/operation/BatchMatMul.h
+++ b/runtime/compute/cker/include/cker/operation/BatchMatMul.h
@@ -44,7 +44,8 @@ public:
   /**
    * @brief   Prepare temporary area for calculation
    */
-  void prepare(const Shape &lhs_shape, const Shape &rhs_shape, bool adj_x, bool adj_y)
+  void prepare(const Shape &lhs_shape, const Shape &rhs_shape, bool adj_x, bool adj_y,
+               bool rhs_const)
   {
     if (adj_x)
     {
@@ -75,18 +76,19 @@ public:
 
       _temp_rhs.resize(_temp_rhs_shape.FlatSize());
     }
+
+    _rhs_constant = rhs_const;
   }
 
   void operator()(const Shape &lhs_shape, const float *lhs_data, const Shape &rhs_shape,
                   const float *rhs_data, bool adj_x, bool adj_y, const Shape & /*output_shape*/,
                   float *output_data)
   {
-    // Assume lhs and rhs is not constant
-    // TODO Handle constant input
-
-    if (!adj_y)
+    // Don't need transpose if rhas is constant already transposed
+    if (!adj_y && !(_rhs_constant && _rhs_transposed))
     {
       transposeRowsCols(rhs_shape, rhs_data, _temp_rhs_shape, _temp_rhs.data());
+      _rhs_transposed = true;
     }
 
     if (adj_x)
@@ -144,6 +146,8 @@ private:
   Shape _temp_lhs_shape;
   std::vector<float> _temp_rhs;
   Shape _temp_rhs_shape;
+  bool _rhs_constant = false;
+  bool _rhs_transposed = false;
 };
 
 } // namespace cker

--- a/runtime/compute/cker/include/cker/operation/BatchMatMul.h
+++ b/runtime/compute/cker/include/cker/operation/BatchMatMul.h
@@ -84,7 +84,7 @@ public:
                   const float *rhs_data, bool adj_x, bool adj_y, const Shape & /*output_shape*/,
                   float *output_data)
   {
-    // Don't need transpose if rhas is constant already transposed
+    // Don't need transpose if rhs is constant and already transposed
     if (!adj_y && !(_rhs_constant && _rhs_transposed))
     {
       transposeRowsCols(rhs_shape, rhs_data, _temp_rhs_shape, _temp_rhs.data());

--- a/runtime/compute/cker/include/cker/operation/Einsum.h
+++ b/runtime/compute/cker/include/cker/operation/Einsum.h
@@ -903,7 +903,8 @@ private:
 
     // LaunchBatchMatMul::Launch(lhs, rhs, adj_x, adj_y, bcast, &output_reshaped);
     BatchMatMul batchMatMul;
-    batchMatMul.prepare(lhs.shape, rhs.shape, adj_x, adj_y);
+    // Set rhs is not constant: don't use optimization
+    batchMatMul.prepare(lhs.shape, rhs.shape, adj_x, adj_y, false);
     batchMatMul(lhs.shape, lhs.base<float>(), rhs.shape, rhs.base<float>(), adj_x, adj_y,
                 output_reshaped.shape, output_reshaped.base<float>());
   }

--- a/runtime/onert/backend/cpu/ops/BatchMatMulLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BatchMatMulLayer.cc
@@ -39,7 +39,7 @@ void BatchMatMulLayer::batchMatMulFloat32()
 
   // TODO implement for constant input
 
-  batchmatmul_kernel.prepare(lhs_shape, rhs_shape, _adj_x, _adj_y);
+  batchmatmul_kernel.prepare(lhs_shape, rhs_shape, _adj_x, _adj_y, _rhs->is_constant());
   batchmatmul_kernel(lhs_shape, getBuffer<float>(_lhs), rhs_shape, getBuffer<float>(_rhs), _adj_x,
                      _adj_y, output_shape, getBuffer<float>(_output));
 }

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -117,8 +117,10 @@ void OperationValidator::visit(const operation::BatchMatMul &node)
   const auto rhs_index(node.getInputs().at(operation::BatchMatMul::Input::RHS));
   const auto output_index(node.getOutputs().at(0));
 
-  // Constant lhs and rhs is not implemented yet
-  OP_REQUIRES(!isConstant(lhs_index) && !isConstant(rhs_index));
+  // RHS can be constant, but LHS is not constant
+  // If one of inputs is constant, it must be RHS
+  // If two inputs are constant, BatchMatMul is optimized into constant by compiler
+  OP_REQUIRES(!isConstant(lhs_index));
 
   // Allow hybrid quantization (lhs: float / rhs: qint8 / out: float)
   OP_REQUIRES(isValidType(


### PR DESCRIPTION
This commit adds support for constant input BatchMatMul. 
It includes BatchMatMul constant input tests.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/14905
Related issue: #14951