### PR TITLE
[circle-mlir/pass] Rewrite MirrorPad

### DIFF
--- a/circle-mlir/circle-mlir/lib/pass/src/RewriteCirclePass.cpp
+++ b/circle-mlir/circle-mlir/lib/pass/src/RewriteCirclePass.cpp
@@ -29,6 +29,7 @@
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
 // Optimizations
+#include "opt/ConvertMirrorPadPad32.h"
 #include "opt/ConvertReshapeShape32.h"
 
 namespace mlir
@@ -91,6 +92,7 @@ void RewriteCirclePass::applyActivationFusion()
   // TODO enable Tanh after circle-interpreter works
   // patterns.add<FuseConv2DRelu<TanhOp, ACT_TANH>>(context);
 
+  patterns.add<ConvertMirrorPadPad32>(context);
   patterns.add<ConvertReshapeShape32>(context);
 
   // TODO add more patterns

--- a/circle-mlir/circle-mlir/lib/pass/src/opt/ConvertMirrorPadPad32.h
+++ b/circle-mlir/circle-mlir/lib/pass/src/opt/ConvertMirrorPadPad32.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLE_MLIR_PASS_OPT_CONVERT_MIRRORPAD_PAD_32_H__
+#define __CIRCLE_MLIR_PASS_OPT_CONVERT_MIRRORPAD_PAD_32_H__
+
+#include "ConvertHelper.h"
+
+#include <cassert>
+
+namespace mlir
+{
+namespace Circle
+{
+
+// Find INT64 Const pad of MirrorPad
+//    Const(pad/INT64)-MirrorPad
+// Relace Const(pad/INT64) with Const(pad/INT32)
+//    Const(pad/INT32)-MirrorPad
+struct ConvertMirrorPadPad32 : public OpRewritePattern<MirrorPadOp>
+{
+  using OpRewritePattern<MirrorPadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MirrorPadOp mirrorpad_op, PatternRewriter &rewriter) const override
+  {
+    mlir::Operation *is_const = mirrorpad_op.getOperand(1).getDefiningOp();
+    if (!mlir::isa_and_nonnull<ConstOp>(is_const))
+      return mlir::failure();
+
+    auto const_op = cast<ConstOp>(is_const);
+    auto const_type = const_op.getType().cast<TensorType>();
+    if (const_type.getElementType().isInteger(32))
+      return mlir::failure();
+    assert(const_type.getElementType().isInteger(64));
+
+    mlir::Value mirrorpad_pad = const_op; // ExtractConstantValues requries mlir::Value
+    std::vector<int32_t> values;
+    if (!ExtractConstantValues(mirrorpad_pad, values))
+      return mlir::failure();
+
+    auto opLoc = const_op->getLoc();
+    auto stype = const_op.getType().dyn_cast_or_null<mlir::RankedTensorType>();
+    auto si32stype = RankedTensorType::get(stype.getShape(), rewriter.getI32Type());
+    auto intattr = DenseIntElementsAttr::get(si32stype, values);
+    mlir::Value shape32 = rewriter.create<ConstOp>(opLoc, intattr);
+
+    auto pad_mutable = mirrorpad_op.getPadMutable();
+    pad_mutable.assign(shape32);
+
+    return mlir::success();
+  }
+};
+
+} // namespace Circle
+} // namespace mlir
+
+#endif // __CIRCLE_MLIR_PASS_OPT_CONVERT_MIRRORPAD_PAD_32_H__


### PR DESCRIPTION
This will rewrite pad of MirrorPad type to I32 for luci-interpreter compatibility.
