### PR TITLE
[cker] Fix `array-bounds` build error: Refactor Shape.h to use C++17 std::variant

### DIFF
--- a/runtime/compute/cker/include/cker/operation/Einsum.h
+++ b/runtime/compute/cker/include/cker/operation/Einsum.h
@@ -871,7 +871,7 @@ private:
     Tensor rhs;
     reshapeToRank3(inputs[1], bcast.y_batch_size(), &rhs);
     Shape old_output_shape = bcast.output_batch_shape();
-    Shape output_shape(old_output_shape.DimensionsCount() + inputs.size());
+    Shape output_shape(static_cast<int>(old_output_shape.DimensionsCount() + inputs.size()));
     for (int i = 0; i < old_output_shape.DimensionsCount(); i++)
     {
       output_shape.SetDim(i, old_output_shape.Dims(i));


### PR DESCRIPTION
This commit improves type-safety and memory management by leveraging modern C++17 features.
- Replace the old union-based storage (_dims and _dims_pointer) with a std::variant that holds either a std::array (for shapes with ≤ 6 dimensions) or a std::vector (for larger shapes)
- Update constructors to initialize and resize dims_ accordingly, ensuring that small shapes use the fixed-size array and larger ones use dynamic allocation
- Implement a custom copy constructor to perform a deep copy based on the current storage type and default the move constructor
- Update various member functions (Dims, SetDim, DimsData, Resize, ReplaceWith, BuildFrom, etc.) to use the new std::variant-based storage
- Minor include reordering and addition of necessary headers (e.g., <array>, <iterator>, <variant>)

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>