### PR TITLE
[circle-mlir/tools-test] Enable Upsample

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/test.lst
@@ -194,6 +194,7 @@ AddModel(Unsqueeze_F32_R2_d01_v11)
 AddModel(Unsqueeze_F32_R2_d02_v11)
 AddModel(Unsqueeze_F32_R2_d13_v11)
 AddModel(Unsqueeze_F32_R3_d3_v11)
+AddModel(Upsample_F32_R4)
 AddModel(Where_F32_R3_bc)
 AddModel(Where_F32_R4)
 

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-models/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-models/test.lst
@@ -202,6 +202,7 @@ AddModel(Unsqueeze_F32_R2_d01_v11)
 AddModel(Unsqueeze_F32_R2_d02_v11)
 AddModel(Unsqueeze_F32_R2_d13_v11)
 AddModel(Unsqueeze_F32_R3_d3_v11)
+AddModel(Upsample_F32_R4)
 AddModel(Where_F32_R3_bc)
 AddModel(Where_F32_R4)
 

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/test.lst
@@ -202,6 +202,7 @@ AddModel(Unsqueeze_F32_R2_d01_v11)
 AddModel(Unsqueeze_F32_R2_d02_v11)
 AddModel(Unsqueeze_F32_R2_d13_v11)
 AddModel(Unsqueeze_F32_R3_d3_v11)
+AddModel(Upsample_F32_R4)
 AddModel(Where_F32_R3_bc)
 AddModel(Where_F32_R4)
 


### PR DESCRIPTION
This will enable conversion, value and import/export test of onnx.Upsample.
torch.nn.Upsample is exported as onnx.Upsample for op version 9 or lower.
This test is added to check old Upsample is converted correctly.
