### PR TITLE
[onert-micro/onert-micro] Fixes and code cleanup for Mean/ReduceProd/Sum kernels

### DIFF
--- a/onert-micro/onert-micro/src/execute/kernels/Mean.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Mean.cpp
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 
-#include "execute/OMUtils.h"
-#include "execute/OMKernelExecutionBuilder.h"
-#include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
+#include "core/OMRuntimeShape.h"
 #include "core/OMUtils.h"
 
-#include "core/OMRuntimeShape.h"
+#include "execute/OMKernelExecutionBuilder.h"
+#include "execute/OMRuntimeKernel.h"
+#include "execute/OMUtils.h"
+
 #include "PALReduceCommon.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
+// ------------------------------------------------------------------------------------------------
+
+#if 0 // TODO: Remove unused?
 namespace
 {
-
-constexpr uint32_t input1TensorIdx = 0;
-constexpr uint32_t input2TensorIdx = 1;
-constexpr uint32_t outputTensorIdx = 0;
 
 template <typename T>
 void reduceMeanGeneric(core::OMRuntimeShape &input_shape, const T *input_data,
@@ -46,85 +45,81 @@ void reduceMeanGeneric(core::OMRuntimeShape &input_shape, const T *input_data,
 }
 
 } // namespace
+#endif
 
-namespace onert_micro
-{
-namespace execute
+// ------------------------------------------------------------------------------------------------
+
+namespace onert_micro::execute
 {
 
 OMStatus execute_kernel_CircleMean(const OMExecuteArgs &execute_args)
 {
+  constexpr static uint32_t inputTensorIdx = 0;
+  constexpr static uint32_t axisTensorIdx = 1;
+  constexpr static uint32_t outputTensorIdx = 0;
+
   core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
   core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
 
-  const circle::Tensor *input;
-  const circle::Tensor *axis;
-  const circle::Tensor *output;
+  const uint16_t op_index = execute_args.kernel_index;
 
-  uint8_t *input_data;
-  uint8_t *axis_data;
-  uint8_t *output_data;
+  execute::OMRuntimeKernel runtime_kernel;
+  runtime_kernel.readKernel(op_index, runtime_context);
 
-  uint16_t input_index = 0;
-  uint16_t axis_index = 0;
+  const circle::Tensor *input = runtime_kernel.inputs[inputTensorIdx];
+  const circle::Tensor *axis = runtime_kernel.inputs[axisTensorIdx];
+  const circle::Tensor *output = runtime_kernel.outputs[outputTensorIdx];
 
-  const circle::ReducerOptions *options;
-  // Read kernel
-  {
-    execute::OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
+  assert(input != nullptr);
+  assert(axis != nullptr);
+  assert(output != nullptr);
 
-    input = runtime_kernel.inputs[input1TensorIdx];
-    axis = runtime_kernel.inputs[input2TensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-    assert(input != nullptr);
-    assert(axis != nullptr);
-    assert(output != nullptr);
+  runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
 
-    runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
+  uint8_t *input_data = runtime_kernel.inputs_data[inputTensorIdx];
+  uint8_t *axis_data = runtime_kernel.inputs_data[axisTensorIdx];
+  uint8_t *output_data = runtime_kernel.outputs_data[outputTensorIdx];
 
-    input_data = runtime_kernel.inputs_data[input1TensorIdx];
-    axis_data = runtime_kernel.inputs_data[input2TensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-    assert(input_data != nullptr);
-    assert(axis_data != nullptr);
-    assert(output_data != nullptr);
+  assert(input_data != nullptr);
+  assert(axis_data != nullptr);
+  assert(output_data != nullptr);
 
-    options = runtime_kernel.first_operator->builtin_options_as_ReducerOptions();
+  // TODO: Remove unused?
+  // uint16_t input_index = runtime_kernel.inputs_index[inputTensorIdx];
+  // uint16_t axis_index = runtime_kernel.inputs_index[axisTensorIdx];
+  // auto options = runtime_kernel.first_operator->builtin_options_as_ReducerOptions();
 
-    input_index = runtime_kernel.inputs_index[input1TensorIdx];
-    axis_index = runtime_kernel.inputs_index[input2TensorIdx];
-  }
+  const core::OMRuntimeShape input_shape(input);
+  const core::OMRuntimeShape axis_shape(axis);
+  const core::OMRuntimeShape output_shape(output);
 
-  OMStatus status;
-
-  core::OMRuntimeShape input_shape(input);
-  core::OMRuntimeShape axis_shape(axis);
-  core::OMRuntimeShape output_shape(output);
+  // clang-format off
 
   switch (input->type())
   {
 #ifndef DIS_FLOAT
     case circle::TensorType_FLOAT32:
-      onert_micro::execute::pal::Mean<float>(
+    {
+      const bool is_ok = pal::Mean<float>
+      (
         input_shape.dimsData(), core::utils::castInputData<float>(input_data),
         input_shape.dimensionsCount(), core::utils::castOutputData<float>(output_data),
         output_shape.flatSize(), core::utils::castInputData<int>(axis_data),
-        axis_shape.dimensionsCount());
+        axis_shape.dimensionsCount()
+      );
 
-      break;
+      return is_ok ? Ok : UnknownError;
+    }
 #endif // DIS_FLOAT
+
     case circle::TensorType_INT32:
-      break;
     case circle::TensorType_INT64:
-      break;
     default:
       assert(false && "Unsupported type");
+      break;
   }
 
-  return status;
+  return UnsupportedType;
 }
 
-} // namespace execute
-} // namespace onert_micro
+} // namespace onert_micro::execute

--- a/onert-micro/onert-micro/src/execute/kernels/Sum.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Sum.cpp
@@ -14,105 +14,93 @@
  * limitations under the License.
  */
 
-#include "execute/OMUtils.h"
-#include "execute/OMKernelExecutionBuilder.h"
 #include "OMStatus.h"
-#include "execute/OMRuntimeKernel.h"
+#include "core/OMRuntimeShape.h"
 #include "core/OMUtils.h"
 
-#include "core/OMRuntimeShape.h"
+#include "execute/OMKernelExecutionBuilder.h"
+#include "execute/OMRuntimeKernel.h"
+
 #include "PALReduceCommon.h"
 
 using namespace onert_micro;
 using namespace onert_micro::execute;
 
-namespace
-{
+// ------------------------------------------------------------------------------------------------
 
-constexpr uint32_t input1TensorIdx = 0;
-constexpr uint32_t input2TensorIdx = 1;
-constexpr uint32_t outputTensorIdx = 0;
-
-} // namespace
-
-namespace onert_micro
-{
-namespace execute
+namespace onert_micro::execute
 {
 
 // TODO: remove duplicated codes in ReduceXXX type operations
 OMStatus execute_kernel_CircleSum(const OMExecuteArgs &execute_args)
 {
+  constexpr static uint32_t inputTensorIdx = 0;
+  constexpr static uint32_t axisTensorIdx = 1;
+  constexpr static uint32_t outputTensorIdx = 0;
+
   core::OMRuntimeContext &runtime_context = execute_args.runtime_context;
   core::OMRuntimeStorage &runtime_storage = execute_args.runtime_storage;
-  uint16_t op_index = execute_args.kernel_index;
 
-  const circle::Tensor *input;
-  const circle::Tensor *axis;
-  const circle::Tensor *output;
+  const uint16_t op_index = execute_args.kernel_index;
 
-  uint8_t *input_data;
-  uint8_t *axis_data;
-  uint8_t *output_data;
+  execute::OMRuntimeKernel runtime_kernel;
+  runtime_kernel.readKernel(op_index, runtime_context);
 
-  uint16_t input_index = 0;
-  uint16_t axis_index = 0;
+  const circle::Tensor *input = runtime_kernel.inputs[inputTensorIdx];
+  const circle::Tensor *axis = runtime_kernel.inputs[axisTensorIdx];
+  const circle::Tensor *output = runtime_kernel.outputs[outputTensorIdx];
 
-  const circle::ReducerOptions *options;
-  // Read kernel
-  {
-    execute::OMRuntimeKernel runtime_kernel;
-    runtime_kernel.readKernel(op_index, runtime_context);
+  assert(input != nullptr);
+  assert(axis != nullptr);
+  assert(output != nullptr);
 
-    input = runtime_kernel.inputs[input1TensorIdx];
-    axis = runtime_kernel.inputs[input2TensorIdx];
-    output = runtime_kernel.outputs[outputTensorIdx];
-    assert(input != nullptr);
-    assert(axis != nullptr);
-    assert(output != nullptr);
+  runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
 
-    runtime_kernel.getDataFromStorage(op_index, runtime_storage, runtime_context);
+  uint8_t *input_data = runtime_kernel.inputs_data[inputTensorIdx];
+  uint8_t *axis_data = runtime_kernel.inputs_data[axisTensorIdx];
+  uint8_t *output_data = runtime_kernel.outputs_data[outputTensorIdx];
 
-    input_data = runtime_kernel.inputs_data[input1TensorIdx];
-    axis_data = runtime_kernel.inputs_data[input2TensorIdx];
-    output_data = runtime_kernel.outputs_data[outputTensorIdx];
-    assert(input_data != nullptr);
-    assert(axis_data != nullptr);
-    assert(output_data != nullptr);
+  assert(input_data != nullptr);
+  assert(axis_data != nullptr);
+  assert(output_data != nullptr);
 
-    options = runtime_kernel.first_operator->builtin_options_as_ReducerOptions();
+  // TODO: Remove unused?
+  // const circle::ReducerOptions *options;
+  // uint16_t input_index = 0;
+  // uint16_t axis_index = 0;
+  // options = runtime_kernel.first_operator->builtin_options_as_ReducerOptions();
+  // input_index = runtime_kernel.inputs_index[input1TensorIdx];
+  // axis_index = runtime_kernel.inputs_index[input2TensorIdx];
 
-    input_index = runtime_kernel.inputs_index[input1TensorIdx];
-    axis_index = runtime_kernel.inputs_index[input2TensorIdx];
-  }
+  const core::OMRuntimeShape input_shape(input);
+  const core::OMRuntimeShape axis_shape(axis);
+  const core::OMRuntimeShape output_shape(output);
 
-  OMStatus status;
-
-  core::OMRuntimeShape input_shape(input);
-  core::OMRuntimeShape axis_shape(axis);
-  core::OMRuntimeShape output_shape(output);
+  // clang-format off
 
   switch (input->type())
   {
 #ifndef DIS_FLOAT
     case circle::TensorType_FLOAT32:
-      onert_micro::execute::pal::reduceSumImpl<float>(
+    {
+      const bool is_ok = pal::reduceSumImpl<float>
+      (
         core::utils::castInputData<float>(input_data), input_shape.dimsData(),
         input_shape.dimensionsCount(), core::utils::castOutputData<float>(output_data),
         core::utils::castInputData<int>(axis_data), axis_shape.dimensionsCount(),
-        output_shape.flatSize());
-      break;
+        output_shape.flatSize()
+      );
+
+      return is_ok ? Ok : UnknownError;
+    }
 #endif // DIS_FLOAT
+
     case circle::TensorType_INT32:
-      break;
     case circle::TensorType_INT64:
-      break;
     default:
       assert(false && "Unsupported type");
+      return UnsupportedType;
   }
-
-  return status;
 }
 
-} // namespace execute
-} // namespace onert_micro
+} // namespace onert_micro::execute


### PR DESCRIPTION
- This fixes Mean/ReduceProd/Sum kernels so that appropriate execution status is returned.
- Minor code cleanup is done (based on clang-tidy warnings).

ONE-DCO-1.0-Signed-off-by: Denis Tarasenko <monoamind@outlook.com>