### PR TITLE
[compute/cker] Fix einsum test error

### DIFF
--- a/runtime/compute/cker/include/cker/Shape.h
+++ b/runtime/compute/cker/include/cker/Shape.h
@@ -205,7 +205,10 @@ public:
   // Replaces the current shape with a new one defined by dimensions_count and dims_data.
   inline void ReplaceWith(int dimensions_count, const int32_t *dims_data)
   {
-    assert(dims_data != nullptr);
+    // Allow dims_data to be nullptr when dimensions_count is 0,
+    // because there are no dimensions to copy. For any non-zero dimensions_count,
+    // dims_data must not be nullptr to ensure valid shape data is provided.
+    assert(dimensions_count == 0 || dims_data != nullptr);
     Resize(dimensions_count);
     std::memcpy(DimsData(), dims_data, dimensions_count * sizeof(int32_t));
   }


### PR DESCRIPTION
This commit allows dims_data to be nullptr when dimensions_count is 0.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>