### PR TITLE
[onert] Support to load BROADCAST_TO operation

### DIFF
--- a/runtime/onert/core/src/compiler/ShapeValidator.h
+++ b/runtime/onert/core/src/compiler/ShapeValidator.h
@@ -48,6 +48,7 @@ public:
   void visit(const ir::operation::BatchToSpaceND &node) override;
   void visit(const ir::operation::BCQFullyConnected &node) override;
   void visit(const ir::operation::BCQGather &node) override;
+  void visit(const ir::operation::BroadcastTo &node) override;
   void visit(const ir::operation::Conv2D &node) override;
   void visit(const ir::operation::Comparison &node) override;
   void visit(const ir::operation::DepthwiseConv2D &node) override;

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -149,6 +149,14 @@ void OperationValidator::visit(const operation::BinaryArithmetic &node)
   OP_REQUIRES(isSameType(lhs_index, output_index));
 }
 
+void OperationValidator::visit(const operation::BroadcastTo &node)
+{
+  const auto input_index(node.getInputs().at(operation::BroadcastTo::Input::INPUT));
+  const auto output_index(node.getOutputs().at(0));
+
+  OP_REQUIRES(isSameType(input_index, output_index));
+}
+
 void OperationValidator::visit(const operation::Comparison &node)
 {
   const auto output_index{node.getOutputs().at(0)};

--- a/runtime/onert/core/src/ir/OperationValidator.h
+++ b/runtime/onert/core/src/ir/OperationValidator.h
@@ -45,6 +45,7 @@ public:
   void visit(const operation::BatchMatMul &node) override;
   void visit(const operation::BatchToSpaceND &node) override;
   void visit(const operation::BinaryArithmetic &node) override;
+  void visit(const operation::BroadcastTo &node) override;
   void visit(const operation::Comparison &node) override;
   void visit(const operation::Concat &node) override;
   void visit(const operation::Conv2D &node) override;

--- a/runtime/onert/core/src/loader/BaseLoader.h
+++ b/runtime/onert/core/src/loader/BaseLoader.h
@@ -1721,6 +1721,9 @@ void BaseLoader<LoaderDomain>::loadOperation(const Operator *op, ir::Graph &subg
     case BuiltinOperator::BuiltinOperator_BATCH_MATMUL:
       loadBatchMatMul(op, subg);
       return;
+    case BuiltinOperator::BuiltinOperator_BROADCAST_TO:
+      loadOperationTo<ir::operation::BroadcastTo>(op, subg);
+      return;
     case BuiltinOperator::BuiltinOperator_LOG_SOFTMAX:
       loadLogSoftmax(op, subg);
       return;

--- a/runtime/tests/nnfw_api/lib/CircleGen.cc
+++ b/runtime/tests/nnfw_api/lib/CircleGen.cc
@@ -148,6 +148,13 @@ uint32_t CircleGen::addOperatorBatchMatMul(const OperatorParams &params, bool ad
                                 circle::BuiltinOptions_BatchMatMulOptions, options);
 }
 
+uint32_t CircleGen::addOperatorBroadcastTo(const OperatorParams &params)
+{
+  auto options = circle::CreateBroadcastToOptions(_fbb).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_BROADCAST_TO,
+                                circle::BuiltinOptions_BroadcastToOptions, options);
+}
+
 uint32_t CircleGen::addOperatorCast(const OperatorParams &params, circle::TensorType input_type,
                                     circle::TensorType output_type)
 {

--- a/runtime/tests/nnfw_api/lib/CircleGen.h
+++ b/runtime/tests/nnfw_api/lib/CircleGen.h
@@ -150,6 +150,7 @@ public:
   uint32_t addOperatorBatchMatMul(const OperatorParams &params, bool adj_x, bool adj_y,
                                   bool asymmetric_quantize_inputs = false);
   uint32_t addOperatorBatchToSpaceND(const OperatorParams &params);
+  uint32_t addOperatorBroadcastTo(const OperatorParams &params);
   uint32_t addOperatorCast(const OperatorParams &params, circle::TensorType input_type,
                            circle::TensorType output_type);
   uint32_t addOperatorConcatenation(const OperatorParams &params, int axis,

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/BroadcastTo.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/BroadcastTo.test.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+TEST_F(GenModelTest, OneOp_BroadcastTo_1D_to_2D)
+{
+  CircleGen cgen;
+  const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{3, 3});
+  int shape = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32, shape_buf});
+  int in = cgen.addTensor({{3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{3, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorBroadcastTo({{in, shape}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3}}, {{1, 2, 3, 1, 2, 3, 1, 2, 3}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_BroadcastTo_2D_to_3D)
+{
+  CircleGen cgen;
+  const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{3, 2, 2});
+  int shape = cgen.addTensor({{3}, circle::TensorType::TensorType_INT32, shape_buf});
+  int in = cgen.addTensor({{2, 2}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{3, 2, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorBroadcastTo({{in, shape}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3, 4}}, {{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_BroadcastTo_3D_to_3D)
+{
+  CircleGen cgen;
+  const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{2, 3, 2});
+  int shape = cgen.addTensor({{3}, circle::TensorType::TensorType_INT32, shape_buf});
+  int in = cgen.addTensor({{2, 1, 2}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorBroadcastTo({{in, shape}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3, 4}}, {{1, 2, 1, 2, 1, 2, 3, 4, 3, 4, 3, 4}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/BroadcastTo.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/BroadcastTo.test.cc
@@ -67,7 +67,7 @@ TEST_F(GenModelTest, OneOp_BroadcastTo_3D_to_3D)
   SUCCEED();
 }
 
-TEST_F(GenModelTest, OneOp_BroadcastTo_InputOutputDifferentType)
+TEST_F(GenModelTest, neg_OneOp_BroadcastTo_InputOutputDifferentType)
 {
   CircleGen cgen;
   const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{3, 3});
@@ -85,7 +85,7 @@ TEST_F(GenModelTest, OneOp_BroadcastTo_InputOutputDifferentType)
   SUCCEED();
 }
 
-TEST_F(GenModelTest, OneOp_BroadcastTo_1D_to_2D_InvalidShape)
+TEST_F(GenModelTest, neg_OneOp_BroadcastTo_1D_to_2D_InvalidShape)
 {
   CircleGen cgen;
   const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{3, 2});
@@ -103,7 +103,7 @@ TEST_F(GenModelTest, OneOp_BroadcastTo_1D_to_2D_InvalidShape)
   SUCCEED();
 }
 
-TEST_F(GenModelTest, OneOp_BroadcastTo_2D_to_3D_InvalidShape)
+TEST_F(GenModelTest, neg_OneOp_BroadcastTo_2D_to_3D_InvalidShape)
 {
   CircleGen cgen;
   const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{2, 1, 3});
@@ -121,7 +121,7 @@ TEST_F(GenModelTest, OneOp_BroadcastTo_2D_to_3D_InvalidShape)
   SUCCEED();
 }
 
-TEST_F(GenModelTest, OneOp_BroadcastTo_3D_to_3D_InvalidShape)
+TEST_F(GenModelTest, neg_OneOp_BroadcastTo_3D_to_3D_InvalidShape)
 {
   CircleGen cgen;
   const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{2, 3, 2});

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/BroadcastTo.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/BroadcastTo.test.cc
@@ -66,3 +66,76 @@ TEST_F(GenModelTest, OneOp_BroadcastTo_3D_to_3D)
 
   SUCCEED();
 }
+
+TEST_F(GenModelTest, OneOp_BroadcastTo_InputOutputDifferentType)
+{
+  CircleGen cgen;
+  const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{3, 3});
+  int shape = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32, shape_buf});
+  int in = cgen.addTensor({{3}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{3, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorBroadcastTo({{in, shape}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3}}, {{1, 2, 3, 1, 2, 3, 1, 2, 3}}));
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_BroadcastTo_1D_to_2D_InvalidShape)
+{
+  CircleGen cgen;
+  const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{3, 2});
+  int shape = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32, shape_buf});
+  int in = cgen.addTensor({{3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorBroadcastTo({{in, shape}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3}}, {{1, 2, 3, 1, 2, 3}}));
+  _context->setBackends({"cpu"});
+  _context->expectFailCompile();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_BroadcastTo_2D_to_3D_InvalidShape)
+{
+  CircleGen cgen;
+  const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{2, 1, 3});
+  int shape = cgen.addTensor({{3}, circle::TensorType::TensorType_INT32, shape_buf});
+  int in = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorBroadcastTo({{in, shape}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3, 1, 2, 3}}, {{1, 2, 3, 1, 2, 3}}));
+  _context->setBackends({"cpu"});
+  _context->expectFailCompile();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_BroadcastTo_3D_to_3D_InvalidShape)
+{
+  CircleGen cgen;
+  const uint32_t shape_buf = cgen.addBuffer(std::vector<int32_t>{2, 3, 2});
+  int shape = cgen.addTensor({{3}, circle::TensorType::TensorType_INT32, shape_buf});
+  int in = cgen.addTensor({{2, 2, 2}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorBroadcastTo({{in, shape}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(
+    uniformTCD<float>({{1, 2, 1, 2, 1, 2, 1, 2}}, {{1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2}}));
+  _context->setBackends({"cpu"});
+  _context->expectFailCompile();
+
+  SUCCEED();
+}


### PR DESCRIPTION
- BROADCAST_TO operation is already supported in runtime, but it was under CUSTOM operation. so it's fixed to load BROADCAST_TO directly.
- Added test cases for BROADCAST_TO operation.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com