### PR TITLE
[onert] Check shape type of BroadcastTo

### DIFF
--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -152,9 +152,11 @@ void OperationValidator::visit(const operation::BinaryArithmetic &node)
 void OperationValidator::visit(const operation::BroadcastTo &node)
 {
   const auto input_index(node.getInputs().at(operation::BroadcastTo::Input::INPUT));
+  const auto shape_index(node.getInputs().at(operation::BroadcastTo::Input::SHAPE));
   const auto output_index(node.getOutputs().at(0));
 
   OP_REQUIRES(isSameType(input_index, output_index));
+  OP_REQUIRES(isValidType(shape_index, {DataType::INT32, DataType::INT64}));
 }
 
 void OperationValidator::visit(const operation::Comparison &node)

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/BroadcastTo.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/BroadcastTo.test.cc
@@ -139,3 +139,21 @@ TEST_F(GenModelTest, neg_OneOp_BroadcastTo_3D_to_3D_InvalidShape)
 
   SUCCEED();
 }
+
+TEST_F(GenModelTest, neg_OneOp_BroadcastTo_InvalidShapeType)
+{
+  CircleGen cgen;
+  const uint32_t shape_buf = cgen.addBuffer(std::vector<float>{3, 3});
+  int shape = cgen.addTensor({{2}, circle::TensorType::TensorType_FLOAT32, shape_buf});
+  int in = cgen.addTensor({{3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{3, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorBroadcastTo({{in, shape}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3}}, {{1, 2, 3, 1, 2, 3, 1, 2, 3}}));
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}


### PR DESCRIPTION
It ensures shape's type is either int32 or int64.
It also adds a negative case.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

```
$ Product/x86_64-linux.debug/out/unittest/nnfw_api_gtest
...
[ RUN      ] GenModelTest.neg_OneOp_BroadcastTo_InvalidShapeType
Error during model loading : OperationValidator failed at line 159
Failed model loading as expected.
[       OK ] GenModelTest.neg_OneOp_BroadcastTo_InvalidShapeType (0 ms)
```

Related: https://github.com/Samsung/ONE/pull/15164#discussion_r2047906033