### PR TITLE
[circle-mlir/overlay] Check python version

### DIFF
--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -35,8 +35,9 @@ PYTHON_BIN=$(which python3)
 PYTHON_VER=$($PYTHON_BIN -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 IFS='.' read -r CUR_MAJOR CUR_MINOR <<< "$PYTHON_VER"
 
-if [ "$CUR_MAJOR" -lt "$REQUIRED_MAJOR" ] || \
-  { [ "$CUR_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$CUR_MINOR" -lt "$REQUIRED_MINOR" ]; }; then
+if [ "$CUR_MAJOR" -lt "$PYTHON_REQUIRED_MAJOR" ] || \
+  { [ "$CUR_MAJOR" -eq "$PYTHON_REQUIRED_MAJOR" ] && \
+    [ "$CUR_MINOR" -lt "$PYTHON_REQUIRED_MINOR" ]; }; then
   echo "Python >= 3.10 is required. Found: $PYTHON_VER"
   exit 1
 fi

--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -27,9 +27,24 @@ VENV_ACTIVATE=${DRIVER_PATH}/${VENV_NAME}/bin/activate
 # NOTE please use venv's python instead of python after `source activation`.
 VENV_PYTHON=${DRIVER_PATH}/${VENV_NAME}/bin/python
 
+# Minimum python requirment version
+PYTHON_REQUIRED_MAJOR=3
+PYTHON_REQUIRED_MINOR=10
+
+PYTHON_BIN=$(which python3)
+PYTHON_VER=$($PYTHON_BIN -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+IFS='.' read -r CUR_MAJOR CUR_MINOR <<< "$PYTHON_VER"
+
+if [ "$CUR_MAJOR" -lt "$REQUIRED_MAJOR" ] || \
+  { [ "$CUR_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$CUR_MINOR" -lt "$REQUIRED_MINOR" ]; }; then
+  echo "Python >= 3.10 is required. Found: $PYTHON_VER"
+  exit 1
+fi
+echo "Found Python version $PYTHON_VER"
+
 if [ ! -f ${VENV_ACTIVATE} ]; then
   # Create python virtual enviornment
-  python3 -m venv "${DRIVER_PATH}/${VENV_NAME}"
+  $PYTHON_BIN -m venv "${DRIVER_PATH}/${VENV_NAME}"
 fi
 
 # NOTE version

--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -31,9 +31,9 @@ VENV_PYTHON=${DRIVER_PATH}/${VENV_NAME}/bin/python
 PYTHON_REQUIRED_MAJOR=3
 PYTHON_REQUIRED_MINOR=10
 
-PYTHON_BIN=$(which python$PYTHON_REQUIRED_MAJOR.$PYTHON_REQUIRED_MINOR 2>/dev/null || true)
+PYTHON_BIN=$(command -v python$PYTHON_REQUIRED_MAJOR.$PYTHON_REQUIRED_MINOR 2>/dev/null || true)
 if [ -z "$PYTHON_BIN" ]; then
-  PYTHON_BIN=$(which python3)
+  PYTHON_BIN=$(command -v python3)
 fi
 
 PYTHON_VER=$($PYTHON_BIN -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')

--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -31,14 +31,19 @@ VENV_PYTHON=${DRIVER_PATH}/${VENV_NAME}/bin/python
 PYTHON_REQUIRED_MAJOR=3
 PYTHON_REQUIRED_MINOR=10
 
-PYTHON_BIN=$(which python3)
+PYTHON_BIN=$(which python$PYTHON_REQUIRED_MAJOR.$PYTHON_REQUIRED_MINOR 2>/dev/null || true)
+if [ -z "$PYTHON_BIN" ]; then
+  PYTHON_BIN=$(which python3)
+fi
+
 PYTHON_VER=$($PYTHON_BIN -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 IFS='.' read -r CUR_MAJOR CUR_MINOR <<< "$PYTHON_VER"
 
 if [ "$CUR_MAJOR" -lt "$PYTHON_REQUIRED_MAJOR" ] || \
   { [ "$CUR_MAJOR" -eq "$PYTHON_REQUIRED_MAJOR" ] && \
     [ "$CUR_MINOR" -lt "$PYTHON_REQUIRED_MINOR" ]; }; then
-  echo "Python >= 3.10 is required. Found: $PYTHON_VER"
+  echo "Python >= $PYTHON_REQUIRED_MAJOR.$PYTHON_REQUIRED_MINOR is required."
+  echo "Found: $PYTHON_VER"
   exit 1
 fi
 echo "Found Python version $PYTHON_VER"


### PR DESCRIPTION
This adds a minimum Python version constraint (3.10),
in the `prepare-venv` script.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>