### PR TITLE
[onert/python] Add typing annotations across training API modules

### DIFF
--- a/runtime/onert/api/python/package/experimental/train/losses/cce.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/cce.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import numpy as np
 from .loss import LossFunction
 
@@ -6,7 +7,7 @@ class CategoricalCrossentropy(LossFunction):
     """
     Categorical Cross-Entropy Loss Function with reduction type.
     """
-    def __init__(self, reduction="mean"):
+    def __init__(self, reduction: Literal["mean", "sum"] = "mean") -> None:
         """
         Initialize the Categorical Cross-Entropy loss function.
         Args:

--- a/runtime/onert/api/python/package/experimental/train/losses/loss.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/loss.py
@@ -1,3 +1,4 @@
+from typing import Literal, Dict
 from onert.native.libnnfw_api_pybind import loss_reduction
 
 
@@ -5,13 +6,13 @@ class LossFunction:
     """
     Base class for loss functions with reduction type.
     """
-    def __init__(self, reduction="mean"):
+    def __init__(self, reduction: Literal["mean", "sum"] = "mean") -> None:
         """
         Initialize the Categorical Cross-Entropy loss function.
         Args:
             reduction (str): Reduction type ('mean', 'sum').
         """
-        reduction_mapping = {
+        reduction_mapping: Dict[Literal["mean", "sum"], loss_reduction] = {
             "mean": loss_reduction.SUM_OVER_BATCH_SIZE,
             "sum": loss_reduction.SUM
         }
@@ -21,4 +22,4 @@ class LossFunction:
             raise ValueError(
                 f"Invalid reduction type. Choose from {list(reduction_mapping.keys())}.")
 
-        self.reduction = reduction_mapping[reduction]
+        self.reduction: loss_reduction = reduction_mapping[reduction]

--- a/runtime/onert/api/python/package/experimental/train/losses/mse.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/mse.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import numpy as np
 from .loss import LossFunction
 
@@ -6,7 +7,7 @@ class MeanSquaredError(LossFunction):
     """
     Mean Squared Error (MSE) Loss Function with reduction type.
     """
-    def __init__(self, reduction="mean"):
+    def __init__(self, reduction: Literal["mean", "sum"] = "mean") -> None:
         """
         Initialize the MSE loss function.
         Args:

--- a/runtime/onert/api/python/package/experimental/train/losses/registry.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/registry.py
@@ -1,19 +1,21 @@
-from onert.native.libnnfw_api_pybind import loss as loss_type
+from typing import Type, Dict
+from .loss import LossFunction
 from .cce import CategoricalCrossentropy
 from .mse import MeanSquaredError
+from onert.native.libnnfw_api_pybind import loss as loss_type
 
 
 class LossRegistry:
     """
     Registry for creating and mapping losses by name or instance.
     """
-    _losses = {
+    _losses: Dict[str, Type[LossFunction]] = {
         "categorical_crossentropy": CategoricalCrossentropy,
         "mean_squared_error": MeanSquaredError
     }
 
     @staticmethod
-    def create_loss(name):
+    def create_loss(name: str) -> LossFunction:
         """
         Create a loss instance by name.
         Args:
@@ -26,7 +28,7 @@ class LossRegistry:
         return LossRegistry._losses[name]()
 
     @staticmethod
-    def map_loss_function_to_enum(loss_instance):
+    def map_loss_function_to_enum(loss_instance: LossFunction) -> loss_type:
         """
         Maps a LossFunction instance to the appropriate enum value.
         Args:
@@ -36,8 +38,7 @@ class LossRegistry:
         Raises:
             TypeError: If the loss_instance is not a recognized LossFunction type.
         """
-        # Loss to Enum mapping
-        loss_to_enum = {
+        loss_to_enum: Dict[Type[LossFunction], loss_type] = {
             CategoricalCrossentropy: loss_type.CATEGORICAL_CROSSENTROPY,
             MeanSquaredError: loss_type.MEAN_SQUARED_ERROR
         }

--- a/runtime/onert/api/python/package/experimental/train/metrics/categorical_accuracy.py
+++ b/runtime/onert/api/python/package/experimental/train/metrics/categorical_accuracy.py
@@ -1,4 +1,5 @@
 import numpy as np
+from typing import List
 from .metric import Metric
 
 
@@ -6,21 +7,26 @@ class CategoricalAccuracy(Metric):
     """
     Metric for computing categorical accuracy.
     """
-    def __init__(self):
-        self.correct = 0
-        self.total = 0
-        self.axis = 0
+    def __init__(self) -> None:
+        """
+        Initialize internal counters and axis.
+        """
+        self.correct: int = 0
+        self.total: int = 0
+        self.axis: int = 0
 
-    def reset_state(self):
+    def reset_state(self) -> None:
         """
         Reset the metric's state.
         """
         self.correct = 0
         self.total = 0
 
-    def update_state(self, outputs, expecteds):
+    def update_state(self, outputs: List[np.ndarray],
+                     expecteds: List[np.ndarray]) -> None:
         """
         Update the metric's state based on the outputs and expecteds.
+
         Args:
             outputs (list of np.ndarray): List of model outputs for each output layer.
             expecteds (list of np.ndarray): List of expected ground truth values for each output layer.
@@ -45,9 +51,10 @@ class CategoricalAccuracy(Metric):
                     self.correct += 1
             self.total += batch_size
 
-    def result(self):
+    def result(self) -> float:
         """
         Compute and return the final metric value.
+
         Returns:
             float: Metric value.
         """

--- a/runtime/onert/api/python/package/experimental/train/metrics/metric.py
+++ b/runtime/onert/api/python/package/experimental/train/metrics/metric.py
@@ -1,25 +1,30 @@
+from typing import Any
+
+
 class Metric:
     """
     Abstract base class for all metrics.
     """
-    def reset_state(self):
+    def reset_state(self) -> None:
         """
         Reset the metric's state.
         """
         raise NotImplementedError
 
-    def update_state(self, outputs, expecteds):
+    def update_state(self, outputs: Any, expecteds: Any) -> None:
         """
         Update the metric's state based on the outputs and expecteds.
+
         Args:
-            outputs (np.ndarray): Model outputs.
-            expecteds (np.ndarray): Expected ground truth values.
+            outputs (Any): Model outputs.
+            expecteds (Any): Expected ground truth values.
         """
         raise NotImplementedError
 
-    def result(self):
+    def result(self) -> float:
         """
         Compute and return the final metric value.
+
         Returns:
             float: Metric value.
         """

--- a/runtime/onert/api/python/package/experimental/train/metrics/registry.py
+++ b/runtime/onert/api/python/package/experimental/train/metrics/registry.py
@@ -1,3 +1,5 @@
+from typing import Type, Dict
+from .metric import Metric
 from .categorical_accuracy import CategoricalAccuracy
 
 
@@ -5,18 +7,20 @@ class MetricsRegistry:
     """
     Registry for creating metrics by name.
     """
-    _metrics = {
+    _metrics: Dict[str, Type[Metric]] = {
         "categorical_accuracy": CategoricalAccuracy,
     }
 
     @staticmethod
-    def create_metric(name):
+    def create_metric(name: str) -> Metric:
         """
         Create a metric instance by name.
+
         Args:
             name (str): Name of the metric.
+
         Returns:
-            BaseMetric: Metric instance.
+            Metric: Metric instance.
         """
         if name not in MetricsRegistry._metrics:
             raise ValueError(

--- a/runtime/onert/api/python/package/experimental/train/optimizer/adam.py
+++ b/runtime/onert/api/python/package/experimental/train/optimizer/adam.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from .optimizer import Optimizer
 
 
@@ -5,9 +6,14 @@ class Adam(Optimizer):
     """
     Adam optimizer.
     """
-    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999, epsilon=1e-7):
+    def __init__(self,
+                 learning_rate: float = 0.001,
+                 beta1: float = 0.9,
+                 beta2: float = 0.999,
+                 epsilon: float = 1e-7) -> None:
         """
         Initialize the Adam optimizer.
+
         Args:
             learning_rate (float): The learning rate for optimization.
             beta1 (float): Exponential decay rate for the first moment estimates.
@@ -15,6 +21,6 @@ class Adam(Optimizer):
             epsilon (float): Small constant to prevent division by zero.
         """
         super().__init__(learning_rate)
-        self.beta1 = beta1
-        self.beta2 = beta2
-        self.epsilon = epsilon
+        self.beta1: float = beta1
+        self.beta2: float = beta2
+        self.epsilon: float = epsilon

--- a/runtime/onert/api/python/package/experimental/train/optimizer/optimizer.py
+++ b/runtime/onert/api/python/package/experimental/train/optimizer/optimizer.py
@@ -5,11 +5,15 @@ class Optimizer:
     """
     Base class for optimizers.
     """
-    def __init__(self, learning_rate=0.001, nums_trainable_ops=trainable_ops.ALL):
+    def __init__(self,
+                 learning_rate: float = 0.001,
+                 nums_trainable_ops: int = trainable_ops.ALL) -> None:
         """
         Initialize the optimizer.
+
         Args:
             learning_rate (float): The learning rate for optimization.
+            nums_trainable_ops (int or enum): Number of trainable ops or enum mask.
         """
-        self.learning_rate = learning_rate
-        self.nums_trainable_ops = nums_trainable_ops
+        self.learning_rate: float = learning_rate
+        self.nums_trainable_ops: int = nums_trainable_ops

--- a/runtime/onert/api/python/package/experimental/train/optimizer/registry.py
+++ b/runtime/onert/api/python/package/experimental/train/optimizer/registry.py
@@ -1,22 +1,26 @@
-from onert.native.libnnfw_api_pybind import optimizer as optimizer_type
+from typing import Type, Dict
+from .optimizer import Optimizer
 from .adam import Adam
 from .sgd import SGD
+from onert.native.libnnfw_api_pybind import optimizer as optimizer_type
 
 
 class OptimizerRegistry:
     """
     Registry for creating optimizers by name.
     """
-    _optimizers = {"adam": Adam, "sgd": SGD}
+    _optimizers: Dict[str, Type[Optimizer]] = {"adam": Adam, "sgd": SGD}
 
     @staticmethod
-    def create_optimizer(name):
+    def create_optimizer(name: str) -> Optimizer:
         """
         Create an optimizer instance by name.
+
         Args:
             name (str): Name of the optimizer.
+
         Returns:
-            BaseOptimizer: Optimizer instance.
+            Optimizer: Optimizer instance.
         """
         if name not in OptimizerRegistry._optimizers:
             raise ValueError(
@@ -24,21 +28,26 @@ class OptimizerRegistry:
         return OptimizerRegistry._optimizers[name]()
 
     @staticmethod
-    def map_optimizer_to_enum(optimizer_instance):
+    def map_optimizer_to_enum(optimizer_instance: Optimizer) -> optimizer_type:
         """
         Maps an optimizer instance to the appropriate enum value.
+
         Args:
             optimizer_instance (Optimizer): An instance of an optimizer.
+
         Returns:
             optimizer_type: Corresponding enum value for the optimizer.
+
         Raises:
             TypeError: If the optimizer_instance is not a recognized optimizer type.
         """
-        # Optimizer to Enum mapping
-        optimizer_to_enum = {SGD: optimizer_type.SGD, Adam: optimizer_type.ADAM}
-        for optimizer_class, enum_value in optimizer_to_enum.items():
-            if isinstance(optimizer_instance, optimizer_class):
-                return enum_value
+        optimizer_to_enum: Dict[Type[Optimizer], optimizer_type] = {
+            SGD: optimizer_type.SGD,
+            Adam: optimizer_type.ADAM
+        }
+        for cls, enum_val in optimizer_to_enum.items():
+            if isinstance(optimizer_instance, cls):
+                return enum_val
         raise TypeError(
             f"Unsupported optimizer type: {type(optimizer_instance).__name__}. "
             f"Supported types are: {list(optimizer_to_enum.keys())}.")

--- a/runtime/onert/api/python/package/experimental/train/optimizer/sgd.py
+++ b/runtime/onert/api/python/package/experimental/train/optimizer/sgd.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from .optimizer import Optimizer
 
 
@@ -5,9 +6,10 @@ class SGD(Optimizer):
     """
     Stochastic Gradient Descent (SGD) optimizer.
     """
-    def __init__(self, learning_rate=0.001, momentum=0.0):
+    def __init__(self, learning_rate: float = 0.001, momentum: float = 0.0) -> None:
         """
         Initialize the SGD optimizer.
+
         Args:
             learning_rate (float): The learning rate for optimization.
             momentum (float): Momentum factor (default: 0.0).
@@ -17,5 +19,5 @@ class SGD(Optimizer):
         if momentum != 0.0:
             raise NotImplementedError(
                 "Momentum is not supported in the current version of SGD.")
-        self.momentum = momentum
-        self.velocity = None
+        self.momentum: float = momentum
+        self.velocity: Optional[float] = None

--- a/runtime/onert/api/python/package/experimental/train/session.py
+++ b/runtime/onert/api/python/package/experimental/train/session.py
@@ -1,14 +1,18 @@
+import time
 import numpy as np
+from typing import Any, List, Tuple, Dict, Union, Optional
 
 from onert.native import libnnfw_api_pybind
-from onert.native.libnnfw_api_pybind import optimizer as optimizer_type
-from onert.native.libnnfw_api_pybind import loss as loss_type
+# from onert.native.libnnfw_api_pybind import optimizer as optimizer_type, loss as loss_type
+from onert.native.libnnfw_api_pybind import traininfo
 from onert.common.basesession import BaseSession
+from .dataloader import DataLoader
+from .losses.loss import LossFunction
 from .losses.registry import LossRegistry
-from .metrics.registry import MetricsRegistry
 from .metrics.metric import Metric
+from .metrics.registry import MetricsRegistry
+from .optimizer.optimizer import Optimizer
 from .optimizer.registry import OptimizerRegistry
-import time
 
 
 # TODO: Support import checkpoint
@@ -16,289 +20,257 @@ class TrainSession(BaseSession):
     """
     Class for training and inference using nnfw_session.
     """
-    def __init__(self, nnpackage_path, backends="train"):
+    def __init__(self, nnpackage_path: str, backends: str = "train") -> None:
         """
         Initialize the train session.
+
         Args:
             nnpackage_path (str): Path to the nnpackage file or directory.
             backends (str): Backends to use, default is "train".
         """
-        load_start = time.perf_counter()
+        load_start: float = time.perf_counter()
         super().__init__(
             libnnfw_api_pybind.experimental.nnfw_session(nnpackage_path, backends))
-        load_end = time.perf_counter()
-        self.total_time = {'MODEL_LOAD': (load_end - load_start) * 1000}
-        self.train_info = self.session.train_get_traininfo()
-        self.optimizer = None
-        self.loss = None
-        self.metrics = []
+        load_end: float = time.perf_counter()
 
-    def compile(self, optimizer, loss, metrics=[], batch_size=16):
+        self.total_time: Dict[str, Union[float, List[float]]] = {
+            'MODEL_LOAD': (load_end - load_start) * 1000
+        }
+        self.train_info: traininfo = self.session.train_get_traininfo()
+        self.optimizer: Optional[Optimizer] = None
+        self.loss: Optional[LossFunction] = None
+        self.metrics: List[Metric] = []
+
+    def compile(self,
+                optimizer: Union[str, Optimizer],
+                loss: Union[str, LossFunction],
+                metrics: List[Union[str, Metric]] = [],
+                batch_size: int = 16) -> None:
         """
         Compile the session with optimizer, loss, and metrics.
+
         Args:
-            optimizer (Optimizer): Optimizer instance or str.
-            loss (Loss): Loss instance or str.
-            metrics (list): List of metrics to evaluate during training.
+            optimizer (str or Optimizer): Optimizer instance or name.
+            loss (str or LossFunction): Loss instance or name.
+            metrics (list of str or Metric): Metrics to evaluate during training.
             batch_size (int): Number of samples per batch.
-        Raises:
-            ValueError: If the number of metrics does not match the number of model outputs.
         """
-        self.optimizer = OptimizerRegistry.create_optimizer(optimizer) if isinstance(
-            optimizer, str) else optimizer
-        self.loss = LossRegistry.create_loss(loss) if isinstance(loss, str) else loss
+        self.optimizer = (OptimizerRegistry.create_optimizer(optimizer) if isinstance(
+            optimizer, str) else optimizer)
+        self.loss = (LossRegistry.create_loss(loss) if isinstance(loss, str) else loss)
         self.metrics = [
             MetricsRegistry.create_metric(m) if isinstance(m, str) else m for m in metrics
         ]
 
-        # Validate that all elements in self.metrics are instances of Metric
-        for metric in self.metrics:
-            if not isinstance(metric, Metric):
-                raise TypeError(f"Invalid metric type: {type(metric).__name__}. "
-                                "All metrics must inherit from the Metric base class.")
+        for m in self.metrics:
+            if not isinstance(m, Metric):
+                raise TypeError(f"Invalid metric type: {type(m).__name__}")
 
-        # Check if the number of metrics matches the number of outputs
-        num_model_outputs = self.session.output_size()
-        if 0 < len(self.metrics) != num_model_outputs:
+        num_outputs: int = self.session.output_size()
+        if 0 < len(self.metrics) != num_outputs:
             raise ValueError(
-                f"Number of metrics ({len(self.metrics)}) does not match the number of model outputs ({num_model_outputs}). "
-                "Please ensure one metric is provided for each model output.")
+                f"Number of metrics ({len(self.metrics)}) does not match outputs ({num_outputs})"
+            )
 
-        # Set training information
-        self.train_info.learning_rate = optimizer.learning_rate
+        # Set training info
+        self.train_info.learning_rate = self.optimizer.learning_rate
         self.train_info.batch_size = batch_size
-        self.train_info.loss_info.loss = LossRegistry.map_loss_function_to_enum(loss)
-        self.train_info.loss_info.reduction_type = loss.reduction
-        self.train_info.opt = OptimizerRegistry.map_optimizer_to_enum(optimizer)
-        self.train_info.num_of_trainable_ops = optimizer.nums_trainable_ops
+        self.train_info.loss_info.loss = LossRegistry.map_loss_function_to_enum(self.loss)
+        self.train_info.loss_info.reduction_type = self.loss.reduction
+        self.train_info.opt = OptimizerRegistry.map_optimizer_to_enum(self.optimizer)
+        self.train_info.num_of_trainable_ops = self.optimizer.nums_trainable_ops
         self.session.train_set_traininfo(self.train_info)
 
-        # Print training parameters
         self._print_training_parameters()
 
-        # Prepare session for training
-        compile_start = time.perf_counter()
+        compile_start: float = time.perf_counter()
         self.session.train_prepare()
-        compile_end = time.perf_counter()
+        compile_end: float = time.perf_counter()
         self.total_time["COMPILE"] = (compile_end - compile_start) * 1000
 
-    def _print_training_parameters(self):
+    def _print_training_parameters(self) -> None:
         """
         Print the training parameters in a formatted way.
         """
-        # Get loss function name
-        loss_name = self.loss.__class__.__name__ if self.loss else "Unknown Loss"
-
-        # Get reduction type name from enum value
-        reduction_name = self.train_info.loss_info.reduction_type.name.lower().replace(
-            "_", " ")
-
-        # Get optimizer name
-        optimizer_name = self.optimizer.__class__.__name__ if self.optimizer else "Unknown Optimizer"
+        loss_name: str = self.loss.__class__.__name__ if self.loss else "Unknown Loss"
+        reduction_name: str = (
+            self.train_info.loss_info.reduction_type.name.lower().replace("_", " "))
+        opt_name: str = self.optimizer.__class__.__name__ if self.optimizer else "Unknown Optimizer"
 
         print("== training parameter ==")
-        print(
-            f"- learning_rate        = {f'{self.train_info.learning_rate:.4f}'.rstrip('0').rstrip('.')}"
-        )
-        print(f"- batch_size           = {self.train_info.batch_size}")
-        print(
-            f"- loss_info            = {{loss = {loss_name}, reduction = {reduction_name}}}"
-        )
-        print(f"- optimizer            = {optimizer_name}")
+        print(f"- learning_rate = {self.train_info.learning_rate:.4f}".rstrip('0').rstrip(
+            '.'))
+        print(f"- batch_size = {self.train_info.batch_size}")
+        print(f"- loss_info = {{loss = {loss_name}, reduction = {reduction_name}}}")
+        print(f"- optimizer = {opt_name}")
         print(f"- num_of_trainable_ops = {self.train_info.num_of_trainable_ops}")
         print("========================")
 
-    def train(self, data_loader, epochs, validation_split=0.0, checkpoint_path=None):
+    def train(
+            self,
+            data_loader: DataLoader,
+            epochs: int,
+            validation_split: float = 0.0,
+            checkpoint_path: Optional[str] = None
+    ) -> Dict[str, Union[float, List[float]]]:
         """
         Train the model using the given data loader.
+
         Args:
-            data_loader: A data loader providing input and expected data.
-            batch_size (int): Number of samples per batch.
+            data_loader: Data loader providing input and expected data.
             epochs (int): Number of epochs to train.
-            validation_split (float): Ratio of validation data. Default is 0.0 (no validation).
-            checkpoint_path (str): Path to save or load the training checkpoint.
+            validation_split (float): Ratio of validation data. Default is 0.0.
+            checkpoint_path (str, optional): Path to save training checkpoints.
+
+        Returns:
+            dict: Timing and performance metrics.
         """
         if self.optimizer is None or self.loss is None:
-            raise RuntimeError(
-                "The training session is not properly configured. "
-                "Please call `compile(optimizer, loss)` before calling `train()`.")
+            raise RuntimeError("Call compile() before train().")
 
-        # Split data into training and validation
         train_data, val_data = data_loader.split(validation_split)
+        epoch_times: List[float] = []
 
-        # Timings for summary
-        epoch_times = []
-
-        # Training loop
         for epoch in range(epochs):
-            message = [f"Epoch {epoch + 1}/{epochs}"]
+            epoch_start = time.perf_counter()
+            train_loss, io_ms, train_ms = self._run_phase(train_data, train=True)
+            msg = [
+                f"Epoch {epoch+1}/{epochs}", f"Train time: {train_ms:.3f}ms/step",
+                f"IO time: {io_ms:.3f}ms/step", f"Train Loss: {train_loss:.4f}"
+            ]
 
-            epoch_start_time = time.perf_counter()
-            # Training phase
-            train_loss, avg_io_time, avg_train_time = self._run_phase(train_data,
-                                                                      train=True)
-            message.append(f"Train time: {avg_train_time:.3f}ms/step")
-            message.append(f"IO time: {avg_io_time:.3f}ms/step")
-            message.append(f"Train Loss: {train_loss:.4f}")
-
-            # Validation phase
             if validation_split > 0.0:
                 val_loss, _, _ = self._run_phase(val_data, train=False)
-                message.append(f"Validation Loss: {val_loss:.4f}")
+                msg.append(f"Validation Loss: {val_loss:.4f}")
+                for m in self.metrics:
+                    msg.append(f"{m.__class__.__name__}: {m.result():.4f}")
+                    m.reset_state()
 
-                # Print metrics
-                for metric in self.metrics:
-                    message.append(f"{metric.__class__.__name__}: {metric.result():.4f}")
-                    metric.reset_state()
+            epoch_times.append((time.perf_counter() - epoch_start) * 1000)
+            print(" - ".join(msg))
 
-            epoch_time = (time.perf_counter() - epoch_start_time) * 1000
-            epoch_times.append(epoch_time)
-
-            print(" - ".join(message))
-
-            # Save checkpoint
-            if checkpoint_path is not None:
+            if checkpoint_path:
                 self.session.train_export_checkpoint(checkpoint_path)
 
         self.total_time["EXECUTE"] = sum(epoch_times)
         self.total_time["EPOCH_TIMES"] = epoch_times
-
         return self.total_time
 
-    def _run_phase(self, data, train=True):
+    def _run_phase(self,
+                   data: Tuple[List[np.ndarray], List[np.ndarray]],
+                   train: bool = True) -> Tuple[float, float, float]:
         """
         Run a training or validation phase.
-        Args:
-            data: Data generator providing input and expected data.
-            train (bool): Whether to perform training or validation.
-        Returns:
-            float: Average loss for the phase.
-        """
-        total_loss = 0.0
-        num_batches = 0
 
-        io_time = 0
-        train_time = 0
+        Args:
+            data: Data generator.
+            train (bool): Whether to update weights.
+
+        Returns:
+            (avg_loss, avg_io_ms, avg_train_ms)
+        """
+        total_loss: float = 0.0
+        num_batches: int = 0
+        io_time: float = 0.0
+        train_time: float = 0.0
 
         for inputs, expecteds in data:
-            # Validate batch sizes
-            self._check_batch_size(inputs, self.train_info.batch_size, data_type="input")
-            self._check_batch_size(expecteds,
-                                   self.train_info.batch_size,
-                                   data_type="expected")
+            self._check_batch_size(inputs, self.train_info.batch_size, "input")
+            self._check_batch_size(expecteds, self.train_info.batch_size, "expected")
 
-            set_io_start = time.perf_counter()
-            # Set inputs
-            for i, input_data in enumerate(inputs):
-                self.session.train_set_input(i, input_data)
+            io_start = time.perf_counter()
+            for i, inp in enumerate(inputs):
+                self.session.train_set_input(i, inp)
+            outputs: List[np.ndarray] = []
+            for i, exp in enumerate(expecteds):
+                arr = np.array(exp, dtype=self.session.output_tensorinfo(i).dtype)
+                self.session.train_set_expected(i, arr)
+                out = np.zeros(arr.shape, dtype=self.session.output_tensorinfo(i).dtype)
+                self.session.train_set_output(i, out)
+                outputs.append(out)
+            io_end = time.perf_counter()
 
-            # Set expected outputs
-            outputs = []
-            for i, expected_data in enumerate(expecteds):
-                expected = np.array(expected_data,
-                                    dtype=self.session.output_tensorinfo(i).dtype)
-                self.session.train_set_expected(i, expected)
-
-                output = np.zeros(expected.shape,
-                                  dtype=self.session.output_tensorinfo(i).dtype)
-                self.session.train_set_output(i, output)
-                assert i == len(outputs)
-                outputs.append(output)
-
-            set_io_end = time.perf_counter()
-
-            # Run training or validation
-            train_start = time.perf_counter()
+            t_start = time.perf_counter()
             self.session.train(update_weights=train)
-            train_end = time.perf_counter()
+            t_end = time.perf_counter()
 
-            # Accumulate loss
             batch_loss = sum(
                 self.session.train_get_loss(i) for i in range(len(expecteds)))
             total_loss += batch_loss
             num_batches += 1
 
-            # Update metrics
             if not train:
-                for metric in self.metrics:
-                    metric.update_state(outputs, expecteds)
+                for m in self.metrics:
+                    m.update_state(outputs, expecteds)
 
-            # Calculate times
-            io_time += (set_io_end - set_io_start)
-            train_time += (train_end - train_start)
+            io_time += (io_end - io_start)
+            train_time += (t_end - t_start)
 
-        if num_batches > 0:
+        if num_batches:
             return (total_loss / num_batches, (io_time * 1000) / num_batches,
                     (train_time * 1000) / num_batches)
-        else:
-            return (0.0, 0.0, 0.0)
+        return (0.0, 0.0, 0.0)
 
-    def _check_batch_size(self, data, batch_size, data_type="input"):
+    def _check_batch_size(self,
+                          data: List[np.ndarray],
+                          batch_size: int,
+                          data_type: str = "input") -> None:
         """
         Validate that the batch size of the data matches the configured training batch size.
+
         Args:
             data (list of np.ndarray): The data to validate.
             batch_size (int): The expected batch size.
-            data_type (str): A string to indicate whether the data is 'input' or 'expected'.
-        Raises:
-            ValueError: If the batch size does not match the expected value.
+            data_type (str): 'input' or 'expected'.
         """
-        for i, array in enumerate(data):
-            if array.shape[0] > batch_size:
-                raise ValueError(
-                    f"Batch size mismatch for {data_type} data at index {i}: "
-                    f"batch size ({array.shape[0]}) does not match the configured "
-                    f"training batch size ({batch_size}).")
+        for idx, arr in enumerate(data):
+            if arr.shape[0] > batch_size:
+                raise ValueError(f"{data_type} batch size mismatch at index {idx}: "
+                                 f"{arr.shape[0]} vs {batch_size}")
 
-    def train_step(self, inputs, expecteds):
+    def train_step(self, inputs: List[np.ndarray],
+                   expecteds: List[np.ndarray]) -> Dict[str, Any]:
         """
         Train the model for a single batch.
+
         Args:
-            inputs (list of np.ndarray): List of input arrays for the batch.
-            expecteds (list of np.ndarray): List of expected output arrays for the batch.
+            inputs (list of np.ndarray): Input arrays.
+            expecteds (list of np.ndarray): Expected output arrays.
+
         Returns:
-            dict: A dictionary containing loss and metrics values.
+            dict: Loss and metrics values, and train_time in ms.
         """
         if self.optimizer is None or self.loss is None:
-            raise RuntimeError(
-                "The training session is not properly configured. "
-                "Please call `compile(optimizer, loss)` before calling `train_step()`.")
+            raise RuntimeError("Call compile() before train_step().")
 
-        # Validate batch sizes
-        self._check_batch_size(inputs, self.train_info.batch_size, data_type="input")
-        self._check_batch_size(expecteds,
-                               self.train_info.batch_size,
-                               data_type="expected")
+        self._check_batch_size(inputs, self.train_info.batch_size, "input")
+        self._check_batch_size(expecteds, self.train_info.batch_size, "expected")
 
-        # Set inputs
-        for i, input_data in enumerate(inputs):
-            self.session.train_set_input(i, input_data)
+        for i, inp in enumerate(inputs):
+            self.session.train_set_input(i, inp)
 
-        # Set expected outputs
-        outputs = []
-        for i, expected_data in enumerate(expecteds):
-            self.session.train_set_expected(i, expected_data)
-            output = np.zeros(expected_data.shape,
-                              dtype=self.session.output_tensorinfo(i).dtype)
-            self.session.train_set_output(i, output)
-            outputs.append(output)
+        outputs: List[np.ndarray] = []
+        for i, exp in enumerate(expecteds):
+            self.session.train_set_expected(i, exp)
+            out = np.zeros(exp.shape, dtype=self.session.output_tensorinfo(i).dtype)
+            self.session.train_set_output(i, out)
+            outputs.append(out)
 
-        # Run a single training step
-        train_start = time.perf_counter()
+        start: float = time.perf_counter()
         self.session.train(update_weights=True)
-        train_end = time.perf_counter()
+        end: float = time.perf_counter()
 
-        # Calculate loss
-        losses = [self.session.train_get_loss(i) for i in range(len(expecteds))]
+        losses: List[float] = [
+            self.session.train_get_loss(i) for i in range(len(expecteds))
+        ]
 
-        # Update metrics
-        metric_results = {}
-        for metric in self.metrics:
-            metric.update_state(outputs, expecteds)
-            metric_results[metric.__class__.__name__] = metric.result()
+        metric_results: Dict[str, float] = {}
+        for m in self.metrics:
+            m.update_state(outputs, expecteds)
+            metric_results[m.__class__.__name__] = m.result()
 
         return {
             "loss": losses,
             "metrics": metric_results,
-            "train_time": (train_end - train_start) * 1000
+            "train_time": (end - start) * 1000
         }

--- a/runtime/onert/api/python/package/experimental/train/session.py
+++ b/runtime/onert/api/python/package/experimental/train/session.py
@@ -3,7 +3,6 @@ import numpy as np
 from typing import Any, List, Tuple, Dict, Union, Optional
 
 from onert.native import libnnfw_api_pybind
-# from onert.native.libnnfw_api_pybind import optimizer as optimizer_type, loss as loss_type
 from onert.native.libnnfw_api_pybind import traininfo
 from onert.common.basesession import BaseSession
 from .dataloader import DataLoader


### PR DESCRIPTION
This commit adds typing annotations across training API modules.
- Applied `from typing` imports and added type hints to DataLoader methods and attributes
- Annotated LossFunction, MeanSquaredError, CategoricalCrossentropy constructors with `Literal`, `Dict` and return types
- Typed LossRegistry and MetricsRegistry: `create_*` and `map_*` methods use `str`, `Type[...]`, and enum return types
- Annotated Optimizer base class, Adam, SGD and OptimizerRegistry with `float`, `Optional`, `Dict`, and `Type[...]`
- Added precise types to TrainSession: `train_info: traininfo`, `optimizer: Optional[Optimizer]`, `loss: Optional[LossFunction]`, `metrics: List[Metric]`, `total_time: Dict[str, Union[float,List[float]]]`, and method signatures

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>