### PR TITLE
Add debian to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 
 # Python virtualenv
 /.venv
+
+# Debian folder for multiple packages
+/debian


### PR DESCRIPTION
This will add /debian folder to gitignore as /debian is temporary folder for multiple Debian package generation.
