### PR TITLE
[github] Add U20.04 to build-docker-circle-mlir

### DIFF
--- a/.github/workflows/build-docker-circle-mlir.yml
+++ b/.github/workflows/build-docker-circle-mlir.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 'u2204' ]
+        version: [ 'u2004', 'u2204' ]
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
This will revise build-docker-circle-mlir workflow to build U20.04 Docker image.
