### PR TITLE
[circle-mlir/utils] Fix reference source

### DIFF
--- a/circle-mlir/circle-mlir/lib/utils/src/FlatbufferOperator.cpp
+++ b/circle-mlir/circle-mlir/lib/utils/src/FlatbufferOperator.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-// from tensorflow/compiler/mlir/lite/flatbuffer_operator.cpp
+// from tensorflow/compiler/mlir/lite/flatbuffer_operator.cc
 
 #include "circle-mlir/utils/FlatbufferOperator.h"
 #include "circle-mlir/utils/ConvertType.h"


### PR DESCRIPTION
This will fix reference source path of FlatbufferOperator.cpp.
