### PR TITLE
[circle-mlir/infra] Revise the Dockerfile for Ubuntu-20.04

### DIFF
--- a/circle-mlir/infra/docker/u2004/Dockerfile
+++ b/circle-mlir/infra/docker/u2004/Dockerfile
@@ -166,8 +166,8 @@ RUN cd ./lib && strip -s *.so.*git
 
 # more cleanup
 RUN rm -f /usr/local/lib/libprotoc.* \
- && rm -f /usr/local/man \
- && rm -f /usr/local/doc \
+ && rm -rf /usr/local/man \
+ && rm -rf /usr/local/doc \
  && rm -rf ./onnx-mlir-build/docs/* \
  && rm -rf ./onnx-mlir-build/third_party/* \
  && rm -f ./onnx-mlir-build/.ninja_* \


### PR DESCRIPTION
This revises the Dockerfile to use `-rf` option when removing directory.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>