### PR TITLE
[github] Add focal to cirle-mlir build

### DIFF
--- a/.github/workflows/run-circle-mlir-build.yml
+++ b/.github/workflows/run-circle-mlir-build.yml
@@ -31,8 +31,10 @@ jobs:
     strategy:
       matrix:
         type: [ Debug, Release ]
-        ubuntu_code: [ jammy ]
+        ubuntu_code: [ focal, jammy ]
         include:
+          - ubuntu_code: focal
+            ubuntu_vstr: u2004
           - ubuntu_code: jammy
             ubuntu_vstr: u2204
 


### PR DESCRIPTION
This will revise run-circle-mlir-build workflow to run focal too.
