### PR TITLE
[circle-mlir/arser] Add missing cstdint header

### DIFF
--- a/circle-mlir/circle-mlir/lib/arser/include/arser/arser.h
+++ b/circle-mlir/circle-mlir/lib/arser/include/arser/arser.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 
+#include <cstdint>
 #include <cstring>
 
 #include <cassert>


### PR DESCRIPTION
This will explictly add missing cstdint header.
