### PR TITLE
[circle-resizer] Resolve warning of operator<< for Shape

### DIFF
--- a/compiler/circle-resizer/include/Shape.h
+++ b/compiler/circle-resizer/include/Shape.h
@@ -85,14 +85,14 @@ public:
    */
   bool operator==(const Shape &rhs) const;
 
-  /**
-   * @brief Print the shape in format [1, 2, 3].
-   */
-  friend std::ostream &operator<<(std::ostream &os, const Shape &shape);
-
 private:
   std::vector<Dim> _dims;
 };
+
+/**
+ * @brief Print the shape in format [1, 2, 3].
+ */
+std::ostream &operator<<(std::ostream &os, const Shape &shape);
 
 } // namespace circle_resizer
 


### PR DESCRIPTION
This commit resolves warning "circle_resizer::operator<< has not been declared within ‘circle_resizer’"

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer m.bencer@partner.samsung.com

Draft: https://github.com/Samsung/ONE/pull/14727