### PR TITLE
[compute/cker] BinaryArithmetic op supports rank 6

### DIFF
--- a/runtime/compute/cker/include/cker/Utils.h
+++ b/runtime/compute/cker/include/cker/Utils.h
@@ -272,6 +272,19 @@ inline int SubscriptToIndex(const NdArrayDesc<5> &desc, int i0, int i1, int i2, 
          i4 * desc.strides[4];
 }
 
+inline int SubscriptToIndex(const NdArrayDesc<6> &desc, int i0, int i1, int i2, int i3, int i4,
+                            int i5)
+{
+  assert(i0 >= 0 && i0 < desc.extents[0]);
+  assert(i1 >= 0 && i1 < desc.extents[1]);
+  assert(i2 >= 0 && i2 < desc.extents[2]);
+  assert(i3 >= 0 && i3 < desc.extents[3]);
+  assert(i4 >= 0 && i4 < desc.extents[4]);
+  assert(i5 >= 0 && i5 < desc.extents[5]);
+  return i0 * desc.strides[0] + i1 * desc.strides[1] + i2 * desc.strides[2] + i3 * desc.strides[3] +
+         i4 * desc.strides[4] + i5 * desc.strides[5];
+}
+
 template <int N> inline int SubscriptToIndexGeneric(const NdArrayDesc<N> *desc, int *iter)
 {
   int ret_indx = 0;

--- a/runtime/compute/cker/include/cker/Utils.h
+++ b/runtime/compute/cker/include/cker/Utils.h
@@ -261,6 +261,17 @@ inline int SubscriptToIndex(const NdArrayDesc<4> &desc, int i0, int i1, int i2, 
   return i0 * desc.strides[0] + i1 * desc.strides[1] + i2 * desc.strides[2] + i3 * desc.strides[3];
 }
 
+inline int SubscriptToIndex(const NdArrayDesc<5> &desc, int i0, int i1, int i2, int i3, int i4)
+{
+  assert(i0 >= 0 && i0 < desc.extents[0]);
+  assert(i1 >= 0 && i1 < desc.extents[1]);
+  assert(i2 >= 0 && i2 < desc.extents[2]);
+  assert(i3 >= 0 && i3 < desc.extents[3]);
+  assert(i4 >= 0 && i4 < desc.extents[4]);
+  return i0 * desc.strides[0] + i1 * desc.strides[1] + i2 * desc.strides[2] + i3 * desc.strides[3] +
+         i4 * desc.strides[4];
+}
+
 template <int N> inline int SubscriptToIndexGeneric(const NdArrayDesc<N> *desc, int *iter)
 {
   int ret_indx = 0;

--- a/runtime/compute/cker/include/cker/operation/BinaryArithmeticOps.h
+++ b/runtime/compute/cker/include/cker/operation/BinaryArithmeticOps.h
@@ -329,7 +329,7 @@ inline void BroadcastBinaryArithmeticOp(BinaryArithmeticOpParam &params, const S
                                         const float *input2_data, const Shape &output_shape,
                                         float *output_data)
 {
-  if (output_shape.DimensionsCount() > 4)
+  if (output_shape.DimensionsCount() > 5)
     throw std::runtime_error(
       std::string("cker::BroadcastBinaryArithmeticOp: Unsupported rank size : ") +
       std::to_string(output_shape.DimensionsCount()));

--- a/runtime/compute/cker/include/cker/operation/BinaryArithmeticOps.h
+++ b/runtime/compute/cker/include/cker/operation/BinaryArithmeticOps.h
@@ -329,7 +329,7 @@ inline void BroadcastBinaryArithmeticOp(BinaryArithmeticOpParam &params, const S
                                         const float *input2_data, const Shape &output_shape,
                                         float *output_data)
 {
-  if (output_shape.DimensionsCount() > 5)
+  if (output_shape.DimensionsCount() > 6)
     throw std::runtime_error(
       std::string("cker::BroadcastBinaryArithmeticOp: Unsupported rank size : ") +
       std::to_string(output_shape.DimensionsCount()));

--- a/runtime/compute/cker/include/cker/operation/reference/BinaryArithmeticOps.h
+++ b/runtime/compute/cker/include/cker/operation/reference/BinaryArithmeticOps.h
@@ -96,10 +96,10 @@ inline typename std::enable_if_t<is_quant8<T>::value> BroadcastBinaryArithmeticO
   const Shape &input2_shape, const T *input2_data, const Shape &output_shape, T *output_data,
   const std::function<T(const BinaryArithmeticOpParam &params, const T &, const T &)> &fn)
 {
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
+  NdArrayDesc<5> desc1;
+  NdArrayDesc<5> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(4, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
 
   // Comment from tensorflow lite:
   //
@@ -114,18 +114,22 @@ inline typename std::enable_if_t<is_quant8<T>::value> BroadcastBinaryArithmeticO
   // We name our variables by their Tensorflow convention, but generate C code
   // nesting loops such that the innermost loop has the smallest stride for the
   // best cache behavior.
-  for (int b = 0; b < extended_output_shape.Dims(0); ++b)
+  for (int d0 = 0; d0 < extended_output_shape.Dims(0); ++d0)
   {
-    for (int y = 0; y < extended_output_shape.Dims(1); ++y)
+    for (int d1 = 0; d1 < extended_output_shape.Dims(1); ++d1)
     {
-      for (int x = 0; x < extended_output_shape.Dims(2); ++x)
+      for (int d2 = 0; d2 < extended_output_shape.Dims(2); ++d2)
       {
-        for (int c = 0; c < extended_output_shape.Dims(3); ++c)
+        for (int d3 = 0; d3 < extended_output_shape.Dims(3); ++d3)
         {
-          output_data[Offset(extended_output_shape, b, y, x, c)] = ActivationFunctionWithMinMax<T>(
-            fn(params, input1_data[SubscriptToIndex(desc1, b, y, x, c)],
-               input2_data[SubscriptToIndex(desc2, b, y, x, c)]),
-            params.quantized_activation_min, params.quantized_activation_max);
+          for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
+          {
+            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
+              ActivationFunctionWithMinMax<T>(
+                fn(params, input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
+                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]),
+                params.quantized_activation_min, params.quantized_activation_max);
+          }
         }
       }
     }
@@ -138,10 +142,10 @@ inline void BroadcastBinaryArithmeticOpSlow(const BinaryArithmeticOpParam &param
                                             const Shape &output_shape, T *output_data,
                                             const std::function<T(const T &, const T &)> &fn)
 {
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
+  NdArrayDesc<5> desc1;
+  NdArrayDesc<5> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(4, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
 
   // Comment from tensorflow lite:
   //
@@ -156,18 +160,22 @@ inline void BroadcastBinaryArithmeticOpSlow(const BinaryArithmeticOpParam &param
   // We name our variables by their Tensorflow convention, but generate C code
   // nesting loops such that the innermost loop has the smallest stride for the
   // best cache behavior.
-  for (int b = 0; b < extended_output_shape.Dims(0); ++b)
+  for (int d0 = 0; d0 < extended_output_shape.Dims(0); ++d0)
   {
-    for (int y = 0; y < extended_output_shape.Dims(1); ++y)
+    for (int d1 = 0; d1 < extended_output_shape.Dims(1); ++d1)
     {
-      for (int x = 0; x < extended_output_shape.Dims(2); ++x)
+      for (int d2 = 0; d2 < extended_output_shape.Dims(2); ++d2)
       {
-        for (int c = 0; c < extended_output_shape.Dims(3); ++c)
+        for (int d3 = 0; d3 < extended_output_shape.Dims(3); ++d3)
         {
-          output_data[Offset(extended_output_shape, b, y, x, c)] = ActivationFunctionWithMinMax<T>(
-            fn(input1_data[SubscriptToIndex(desc1, b, y, x, c)],
-               input2_data[SubscriptToIndex(desc2, b, y, x, c)]),
-            params.quantized_activation_min, params.quantized_activation_max);
+          for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
+          {
+            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
+              ActivationFunctionWithMinMax<T>(
+                fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
+                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]),
+                params.quantized_activation_min, params.quantized_activation_max);
+          }
         }
       }
     }
@@ -180,23 +188,27 @@ inline void BroadcastBinaryArithmeticOpSlow(
   const Shape &input2_shape, const float *input2_data, const Shape &output_shape,
   float *output_data, const std::function<float(const float &, const float &)> &fn)
 {
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
+  NdArrayDesc<5> desc1;
+  NdArrayDesc<5> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(4, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
 
-  for (int b = 0; b < extended_output_shape.Dims(0); ++b)
+  for (int d0 = 0; d0 < extended_output_shape.Dims(0); ++d0)
   {
-    for (int y = 0; y < extended_output_shape.Dims(1); ++y)
+    for (int d1 = 0; d1 < extended_output_shape.Dims(1); ++d1)
     {
-      for (int x = 0; x < extended_output_shape.Dims(2); ++x)
+      for (int d2 = 0; d2 < extended_output_shape.Dims(2); ++d2)
       {
-        for (int c = 0; c < extended_output_shape.Dims(3); ++c)
+        for (int d3 = 0; d3 < extended_output_shape.Dims(3); ++d3)
         {
-          output_data[Offset(extended_output_shape, b, y, x, c)] =
-            ActivationFunctionWithMinMax(fn(input1_data[SubscriptToIndex(desc1, b, y, x, c)],
-                                            input2_data[SubscriptToIndex(desc2, b, y, x, c)]),
-                                         params.float_activation_min, params.float_activation_max);
+          for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
+          {
+            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
+              ActivationFunctionWithMinMax(
+                fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
+                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]),
+                params.float_activation_min, params.float_activation_max);
+          }
         }
       }
     }
@@ -209,22 +221,25 @@ inline void BroadcastBinaryArithmeticOpSlow(
   const Shape &input2_shape, const bool *input2_data, const Shape &output_shape, bool *output_data,
   const std::function<bool(const bool &, const bool &)> &fn)
 {
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
+  NdArrayDesc<5> desc1;
+  NdArrayDesc<5> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(4, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
 
-  for (int b = 0; b < extended_output_shape.Dims(0); ++b)
+  for (int d0 = 0; d0 < extended_output_shape.Dims(0); ++d0)
   {
-    for (int y = 0; y < extended_output_shape.Dims(1); ++y)
+    for (int d1 = 0; d1 < extended_output_shape.Dims(1); ++d1)
     {
-      for (int x = 0; x < extended_output_shape.Dims(2); ++x)
+      for (int d2 = 0; d2 < extended_output_shape.Dims(2); ++d2)
       {
-        for (int c = 0; c < extended_output_shape.Dims(3); ++c)
+        for (int d3 = 0; d3 < extended_output_shape.Dims(3); ++d3)
         {
-          output_data[Offset(extended_output_shape, b, y, x, c)] =
-            fn(input1_data[SubscriptToIndex(desc1, b, y, x, c)],
-               input2_data[SubscriptToIndex(desc2, b, y, x, c)]);
+          for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
+          {
+            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
+              fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
+                 input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]);
+          }
         }
       }
     }
@@ -237,23 +252,27 @@ inline void BroadcastBinaryArithmeticOpSlow(
   const Shape &input2_shape, const int64_t *input2_data, const Shape &output_shape,
   int64_t *output_data, const std::function<int64_t(const int64_t &, const int64_t &)> &fn)
 {
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
+  NdArrayDesc<5> desc1;
+  NdArrayDesc<5> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(4, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
 
-  for (int b = 0; b < extended_output_shape.Dims(0); ++b)
+  for (int d0 = 0; d0 < extended_output_shape.Dims(0); ++d0)
   {
-    for (int y = 0; y < extended_output_shape.Dims(1); ++y)
+    for (int d1 = 0; d1 < extended_output_shape.Dims(1); ++d1)
     {
-      for (int x = 0; x < extended_output_shape.Dims(2); ++x)
+      for (int d2 = 0; d2 < extended_output_shape.Dims(2); ++d2)
       {
-        for (int c = 0; c < extended_output_shape.Dims(3); ++c)
+        for (int d3 = 0; d3 < extended_output_shape.Dims(3); ++d3)
         {
-          output_data[Offset(extended_output_shape, b, y, x, c)] =
-            ActivationFunctionWithMinMax(fn(input1_data[SubscriptToIndex(desc1, b, y, x, c)],
-                                            input2_data[SubscriptToIndex(desc2, b, y, x, c)]),
-                                         params.int64_activation_min, params.int64_activation_max);
+          for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
+          {
+            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
+              ActivationFunctionWithMinMax(
+                fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
+                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]),
+                params.int64_activation_min, params.int64_activation_max);
+          }
         }
       }
     }

--- a/runtime/compute/cker/include/cker/operation/reference/BinaryArithmeticOps.h
+++ b/runtime/compute/cker/include/cker/operation/reference/BinaryArithmeticOps.h
@@ -31,6 +31,9 @@ namespace cker
 namespace reference
 {
 
+// Maximum dimension supported by the broadcast operation.
+constexpr int kMaxBroadcastDim = 6;
+
 template <typename T>
 inline void BinaryArithmeticOp(const BinaryArithmeticOpParam &params, const Shape &input1_shape,
                                const T *input1_data, const Shape &input2_shape,
@@ -96,10 +99,10 @@ inline typename std::enable_if_t<is_quant8<T>::value> BroadcastBinaryArithmeticO
   const Shape &input2_shape, const T *input2_data, const Shape &output_shape, T *output_data,
   const std::function<T(const BinaryArithmeticOpParam &params, const T &, const T &)> &fn)
 {
-  NdArrayDesc<5> desc1;
-  NdArrayDesc<5> desc2;
+  NdArrayDesc<kMaxBroadcastDim> desc1;
+  NdArrayDesc<kMaxBroadcastDim> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(kMaxBroadcastDim, output_shape);
 
   // Comment from tensorflow lite:
   //
@@ -124,11 +127,14 @@ inline typename std::enable_if_t<is_quant8<T>::value> BroadcastBinaryArithmeticO
         {
           for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
           {
-            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
-              ActivationFunctionWithMinMax<T>(
-                fn(params, input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
-                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]),
-                params.quantized_activation_min, params.quantized_activation_max);
+            for (int d5 = 0; d5 < extended_output_shape.Dims(5); ++d5)
+            {
+              output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4, d5)] =
+                ActivationFunctionWithMinMax<T>(
+                  fn(params, input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4, d5)],
+                     input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4, d5)]),
+                  params.quantized_activation_min, params.quantized_activation_max);
+            }
           }
         }
       }
@@ -142,10 +148,10 @@ inline void BroadcastBinaryArithmeticOpSlow(const BinaryArithmeticOpParam &param
                                             const Shape &output_shape, T *output_data,
                                             const std::function<T(const T &, const T &)> &fn)
 {
-  NdArrayDesc<5> desc1;
-  NdArrayDesc<5> desc2;
+  NdArrayDesc<kMaxBroadcastDim> desc1;
+  NdArrayDesc<kMaxBroadcastDim> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(kMaxBroadcastDim, output_shape);
 
   // Comment from tensorflow lite:
   //
@@ -170,11 +176,14 @@ inline void BroadcastBinaryArithmeticOpSlow(const BinaryArithmeticOpParam &param
         {
           for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
           {
-            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
-              ActivationFunctionWithMinMax<T>(
-                fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
-                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]),
-                params.quantized_activation_min, params.quantized_activation_max);
+            for (int d5 = 0; d5 < extended_output_shape.Dims(5); ++d5)
+            {
+              output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4, d5)] =
+                ActivationFunctionWithMinMax<T>(
+                  fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4, d5)],
+                     input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4, d5)]),
+                  params.quantized_activation_min, params.quantized_activation_max);
+            }
           }
         }
       }
@@ -188,10 +197,10 @@ inline void BroadcastBinaryArithmeticOpSlow(
   const Shape &input2_shape, const float *input2_data, const Shape &output_shape,
   float *output_data, const std::function<float(const float &, const float &)> &fn)
 {
-  NdArrayDesc<5> desc1;
-  NdArrayDesc<5> desc2;
+  NdArrayDesc<kMaxBroadcastDim> desc1;
+  NdArrayDesc<kMaxBroadcastDim> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(kMaxBroadcastDim, output_shape);
 
   for (int d0 = 0; d0 < extended_output_shape.Dims(0); ++d0)
   {
@@ -203,11 +212,14 @@ inline void BroadcastBinaryArithmeticOpSlow(
         {
           for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
           {
-            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
-              ActivationFunctionWithMinMax(
-                fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
-                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]),
-                params.float_activation_min, params.float_activation_max);
+            for (int d5 = 0; d5 < extended_output_shape.Dims(5); ++d5)
+            {
+              output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4, d5)] =
+                ActivationFunctionWithMinMax(
+                  fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4, d5)],
+                     input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4, d5)]),
+                  params.float_activation_min, params.float_activation_max);
+            }
           }
         }
       }
@@ -221,10 +233,10 @@ inline void BroadcastBinaryArithmeticOpSlow(
   const Shape &input2_shape, const bool *input2_data, const Shape &output_shape, bool *output_data,
   const std::function<bool(const bool &, const bool &)> &fn)
 {
-  NdArrayDesc<5> desc1;
-  NdArrayDesc<5> desc2;
+  NdArrayDesc<kMaxBroadcastDim> desc1;
+  NdArrayDesc<kMaxBroadcastDim> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(kMaxBroadcastDim, output_shape);
 
   for (int d0 = 0; d0 < extended_output_shape.Dims(0); ++d0)
   {
@@ -236,9 +248,12 @@ inline void BroadcastBinaryArithmeticOpSlow(
         {
           for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
           {
-            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
-              fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
-                 input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]);
+            for (int d5 = 0; d5 < extended_output_shape.Dims(5); ++d5)
+            {
+              output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4, d5)] =
+                fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4, d5)],
+                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4, d5)]);
+            }
           }
         }
       }
@@ -252,10 +267,10 @@ inline void BroadcastBinaryArithmeticOpSlow(
   const Shape &input2_shape, const int64_t *input2_data, const Shape &output_shape,
   int64_t *output_data, const std::function<int64_t(const int64_t &, const int64_t &)> &fn)
 {
-  NdArrayDesc<5> desc1;
-  NdArrayDesc<5> desc2;
+  NdArrayDesc<kMaxBroadcastDim> desc1;
+  NdArrayDesc<kMaxBroadcastDim> desc2;
   NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(5, output_shape);
+  const Shape extended_output_shape = Shape::ExtendedShape(kMaxBroadcastDim, output_shape);
 
   for (int d0 = 0; d0 < extended_output_shape.Dims(0); ++d0)
   {
@@ -267,11 +282,14 @@ inline void BroadcastBinaryArithmeticOpSlow(
         {
           for (int d4 = 0; d4 < extended_output_shape.Dims(4); ++d4)
           {
-            output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4)] =
-              ActivationFunctionWithMinMax(
-                fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4)],
-                   input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4)]),
-                params.int64_activation_min, params.int64_activation_max);
+            for (int d5 = 0; d5 < extended_output_shape.Dims(5); ++d5)
+            {
+              output_data[Offset(extended_output_shape, d0, d1, d2, d3, d4, d5)] =
+                ActivationFunctionWithMinMax(
+                  fn(input1_data[SubscriptToIndex(desc1, d0, d1, d2, d3, d4, d5)],
+                     input2_data[SubscriptToIndex(desc2, d0, d1, d2, d3, d4, d5)]),
+                  params.int64_activation_min, params.int64_activation_max);
+            }
           }
         }
       }

--- a/runtime/compute/cker/src/Mul.test.cc
+++ b/runtime/compute/cker/src/Mul.test.cc
@@ -280,7 +280,7 @@ TEST(CKer_Operation, neg_MulUnsupportedBroadcastRank)
 {
   // Unsupported rank
   {
-    // Shape: {1, 2, 2, 1, 1}
+    // Shape: {1, 2, 2, 1, 1, 1}
     std::vector<float> input1 = {10, -9, -11, 7};
     // Shape: {1}
     std::vector<float> input2 = {-3};
@@ -290,7 +290,7 @@ TEST(CKer_Operation, neg_MulUnsupportedBroadcastRank)
 
     EXPECT_ANY_THROW(
       nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::MUL>(
-        param, nnfw::cker::Shape{1, 2, 2, 1, 1}, input1.data(), nnfw::cker::Shape{1}, input2.data(),
-        nnfw::cker::Shape{1, 2, 2, 1, 1}, output.data()));
+        param, nnfw::cker::Shape{1, 2, 2, 1, 1, 1}, input1.data(), nnfw::cker::Shape{1},
+        input2.data(), nnfw::cker::Shape{1, 2, 2, 1, 1, 1}, output.data()));
   }
 }

--- a/runtime/compute/cker/src/Mul.test.cc
+++ b/runtime/compute/cker/src/Mul.test.cc
@@ -273,6 +273,28 @@ TEST(CKer_Operation, Mul)
       EXPECT_EQ(output[i], expected_output[i]);
   }
 
+  // Max supported rank
+  {
+    // Shape: {1, 2, 2, 1, 1, 1}
+    std::vector<int32_t> input1 = {10, -9, -11, 7};
+    // Shape: {1}
+    std::vector<int32_t> input2 = {-3};
+    std::vector<int32_t> expected_output = {-30, 27, 33, -21};
+    std::vector<int32_t> output(4);
+
+    nnfw::cker::BinaryArithmeticOpParam param;
+    param.broadcast_category = nnfw::cker::BroadcastableOpCategory::kGenericBroadcast;
+    param.quantized_activation_min = std::numeric_limits<int32_t>::lowest();
+    param.quantized_activation_max = std::numeric_limits<int32_t>::max();
+
+    nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::MUL>(
+      param, nnfw::cker::Shape{1, 2, 2, 1, 1, 1}, input1.data(), nnfw::cker::Shape{1},
+      input2.data(), nnfw::cker::Shape{1, 2, 2, 1, 1, 1}, output.data());
+
+    for (size_t i = 0; i < expected_output.size(); ++i)
+      EXPECT_EQ(output[i], expected_output[i]);
+  }
+
   // TODO Add other types
 }
 
@@ -280,7 +302,7 @@ TEST(CKer_Operation, neg_MulUnsupportedBroadcastRank)
 {
   // Unsupported rank
   {
-    // Shape: {1, 2, 2, 1, 1, 1}
+    // Shape: {1, 2, 2, 1, 1, 1, 1}
     std::vector<float> input1 = {10, -9, -11, 7};
     // Shape: {1}
     std::vector<float> input2 = {-3};
@@ -290,7 +312,7 @@ TEST(CKer_Operation, neg_MulUnsupportedBroadcastRank)
 
     EXPECT_ANY_THROW(
       nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::MUL>(
-        param, nnfw::cker::Shape{1, 2, 2, 1, 1, 1}, input1.data(), nnfw::cker::Shape{1},
-        input2.data(), nnfw::cker::Shape{1, 2, 2, 1, 1, 1}, output.data()));
+        param, nnfw::cker::Shape{1, 2, 2, 1, 1, 1, 1}, input1.data(), nnfw::cker::Shape{1},
+        input2.data(), nnfw::cker::Shape{1, 2, 2, 1, 1, 1, 1}, output.data()));
   }
 }


### PR DESCRIPTION
BinaryArithmetic op like add, mul, etc will support rank 6.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

for https://github.com/Samsung/ONE/issues/15221