### PR TITLE
[coco] Add missing header

### DIFF
--- a/compiler/coco/core/include/coco/IR/Op.h
+++ b/compiler/coco/core/include/coco/IR/Op.h
@@ -27,6 +27,7 @@
 #include "coco/IR/Part.h"
 #include "coco/IR/Entity.h"
 
+#include <cstdint>
 #include <set>
 
 #include <stdexcept>


### PR DESCRIPTION
This will add missing header to fix U24.04 build.
