### PR TITLE
[luci-interpreter] Fix delete for array

### DIFF
--- a/compiler/luci-interpreter/src/kernels/GRU.cpp
+++ b/compiler/luci-interpreter/src/kernels/GRU.cpp
@@ -74,8 +74,8 @@ void GRU::evalFloat() const
     reinterpret_cast<float *>(output_hidden_data), getTensorShape(input()),
     getTensorShape(output()), getTensorShape(hidden_input()), getTensorShape(hidden_hidden()));
 
-  delete output_hidden_data;
-  delete output_input_data;
+  delete[] output_hidden_data;
+  delete[] output_input_data;
 }
 
 } // namespace kernels


### PR DESCRIPTION
This will fix delete to use array, as this fails in gcc-13, U24.04.
