### PR TITLE
[moco] Do not use reference for dangling variable

### DIFF
--- a/compiler/moco/import/src/Nodes/Const.cpp
+++ b/compiler/moco/import/src/Nodes/Const.cpp
@@ -144,7 +144,7 @@ bool ConstGraphBuilder::validate(const tensorflow::NodeDef &node) const
   if (!plier::tf::has_attrs(node, {"dtype", "value"}))
     return false;
 
-  const auto &input_tensor = plier::tf::get_tensor_attr(node, "value");
+  const auto input_tensor = plier::tf::get_tensor_attr(node, "value");
   const auto &input_shape = input_tensor.tensor_shape();
   const auto &input_dims = input_shape.dim();
 
@@ -183,7 +183,7 @@ void ConstGraphBuilder::build(const tensorflow::NodeDef &node, GraphBuilderConte
   const_node->dtype(dtype);
 
   // import shape and value
-  const auto &input_tensor = plier::tf::get_tensor_attr(node, "value");
+  const auto input_tensor = plier::tf::get_tensor_attr(node, "value");
   const auto &input_shape = input_tensor.tensor_shape();
   const auto &input_dims = input_shape.dim();
   assert(input_shape.dim_size() <= 6);

--- a/compiler/moco/import/src/Nodes/Placeholder.cpp
+++ b/compiler/moco/import/src/Nodes/Placeholder.cpp
@@ -49,7 +49,7 @@ void PlaceholderGraphBuilder::build(const tensorflow::NodeDef &node,
   SymbolTable *tensor_names = context->tensor_names();
 
   loco::DataType dtype = plier::tf::as_loco_datatype(plier::tf::get_datatype_attr(node, "dtype"));
-  const auto &shape = plier::tf::get_shape_attr(node, "shape");
+  const auto shape = plier::tf::get_shape_attr(node, "shape");
   // TODO handle for unknown rank
   assert(!shape.unknown_rank());
   int64_t num_dims = shape.dim_size();


### PR DESCRIPTION
This will fix not to use reference for dangling variable inside callee.
