### PR TITLE
[nnc] Add missing header

### DIFF
--- a/compiler/nnc/include/support/CommandLine.h
+++ b/compiler/nnc/include/support/CommandLine.h
@@ -23,6 +23,7 @@
 #include <set>
 #include <type_traits>
 #include <cassert>
+#include <cstdint>
 #include <limits>
 #include <iostream>
 


### PR DESCRIPTION
This will add missing header to fix U24.04 build.
