### PR TITLE
[nnkit] Add missing header

### DIFF
--- a/compiler/nnkit/actions/HDF5/Common.h
+++ b/compiler/nnkit/actions/HDF5/Common.h
@@ -17,6 +17,7 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
+#include <cstdint>
 #include <string>
 
 /**


### PR DESCRIPTION
This will add missing header to fix U24.04 build.
