### PR TITLE
[circle-resizer] Expose cmd interface

### DIFF
--- a/compiler/circle-resizer/README.md
+++ b/compiler/circle-resizer/README.md
@@ -1,3 +1,19 @@
 # circle-resizer
 
-_circle-resizer_ provides capabilities to change the shapes of models inputs.
+_circle-resizer_ is a command-line tool designed to change the shapes of models inputs in `.circle` format.
+
+The basic syntax of `circle-resizer` is:
+```bash
+./circle-resizer --input_path <input_model.circle> --output_path <output_model.circle> --input_shapes <shapes>
+```
+
+## Arguments:
+- `--input_path`: Path to the input .circle model file (required).
+- `--output_path`: Path to save the resized .circle model (required).
+- `--input_shapes`: Comma-separated list of new input shapes in the format [dim1,dim2,...]. Example for two inputs: [1,2,3],[4,5] (required).
+- `--version`: Display version information and exit.
+
+## Example Command
+```bash
+./circle-resizer --input_path model.circle --output_path resized_model.circle --input_shapes [1,3,224,224],[10]
+```

--- a/compiler/circle-resizer/app/CMakeLists.txt
+++ b/compiler/circle-resizer/app/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(circle_resizer CircleResizer.cpp)
+target_link_libraries(circle_resizer PRIVATE circle_resizer_core)
 target_link_libraries(circle_resizer PRIVATE arser)
 target_link_libraries(circle_resizer PRIVATE safemain)
 target_link_libraries(circle_resizer PRIVATE vconone)

--- a/compiler/circle-resizer/app/CircleResizer.cpp
+++ b/compiler/circle-resizer/app/CircleResizer.cpp
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
+#include "ModelEditor.h"
+#include "ShapeParser.h"
+
 #include <arser/arser.h>
 #include <vconone/vconone.h>
 
 #include <iostream>
-#include <stdexcept>
+#include <memory>
+#include <string>
+
+using namespace circle_resizer;
 
 namespace
 {
@@ -29,11 +35,37 @@ void print_version()
   std::cout << vconone::get_copyright() << std::endl;
 }
 
+void list_shapes(const std::vector<Shape> &shapes)
+{
+  for (size_t idx = 0; idx < shapes.size(); ++idx)
+  {
+    std::cout << idx << " -> " << shapes[idx] << std::endl;
+  }
+}
+
 } // namespace
 
 int entry(const int argc, char **argv)
 {
   arser::Arser arser("circle-resizer provides capabilities to change inputs of the models");
+
+  arser.add_argument("--input_path")
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .required(true)
+    .help("Path to the input model (.circle)");
+
+  arser.add_argument("--output_path")
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .required(true)
+    .help("Path to the resized model (.circle)");
+
+  arser.add_argument("--input_shapes")
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .required(true)
+    .help("New inputs shapes in the comma separated format. An example for 2 inputs: [1,2],[3,4].");
 
   arser.add_argument("--version")
     .nargs(0)
@@ -45,10 +77,34 @@ int entry(const int argc, char **argv)
   try
   {
     arser.parse(argc, argv);
+
+    const auto input_path = arser.get<std::string>("--input_path");
+
+    auto circle_model = std::make_shared<CircleModel>(input_path);
+    ModelEditor resizer(circle_model);
+
+    std::cout << "Shapes of inputs before resizing:" << std::endl;
+    list_shapes(circle_model->input_shapes());
+
+    std::cout << "Shapes of outputs before resizing:" << std::endl;
+    list_shapes(circle_model->output_shapes());
+
+    const auto output_path = arser.get<std::string>("--output_path");
+    const auto new_input_shapes_str = arser.get<std::string>("--input_shapes");
+    resizer.resize_inputs(parse_shapes(new_input_shapes_str));
+
+    std::cout << "Shapes of inputs after resizing:" << std::endl;
+    list_shapes(circle_model->input_shapes());
+
+    std::cout << "Shapes of outputs after resizing:" << std::endl;
+    list_shapes(circle_model->output_shapes());
+
+    circle_model->save(output_path);
+    std::cout << "Resizing complete, the model saved to: " << output_path << std::endl;
   }
   catch (const std::runtime_error &err)
   {
-    std::cerr << err.what() << std::endl;
+    std::cerr << "Exception during resizing: " << err.what() << std::endl;
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;


### PR DESCRIPTION
This commit exposes a command line interface for circle-resizer application. README.md was updated to the current capabilities.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Draft: https://github.com/Samsung/ONE/pull/14727