### PR TITLE
[mir] Disable nncc_common option

### DIFF
--- a/compiler/mir/CMakeLists.txt
+++ b/compiler/mir/CMakeLists.txt
@@ -29,7 +29,8 @@ set(MIR_SOURCES
 add_library(mir STATIC ${MIR_SOURCES})
 target_include_directories(mir PUBLIC include)
 target_link_libraries(mir PUBLIC adtidas)
-target_link_libraries(mir PRIVATE nncc_common)
+# to prevent _GLIBCXX17_DEPRECATED warning as error
+# target_link_libraries(mir PRIVATE nncc_common)
 target_link_libraries(mir PUBLIC nncc_coverage)
 
 set_target_properties(mir PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/compiler/mir/src/mir_caffe2_importer/CMakeLists.txt
+++ b/compiler/mir/src/mir_caffe2_importer/CMakeLists.txt
@@ -25,4 +25,6 @@ set(MIR_CAFFE2_IMPORTER_SOURCES
 add_library(mir_caffe2_importer STATIC ${MIR_CAFFE2_IMPORTER_SOURCES})
 set_target_properties(mir_caffe2_importer PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(mir_caffe2_importer PUBLIC ../../include/mir_caffe2_importer)
-target_link_libraries(mir_caffe2_importer PUBLIC mir PRIVATE caffe2proto nncc_common)
+target_link_libraries(mir_caffe2_importer PUBLIC mir PRIVATE caffe2proto)
+# to prevent _GLIBCXX17_DEPRECATED warning as error
+# target_link_libraries(mir_caffe2_importer PRIVATE nncc_common)

--- a/compiler/mir/src/mir_caffe_importer/CMakeLists.txt
+++ b/compiler/mir/src/mir_caffe_importer/CMakeLists.txt
@@ -13,4 +13,6 @@ set(MIR_CAFFE_IMPORTER_SOURCES
 add_library(mir_caffe_importer STATIC ${MIR_CAFFE_IMPORTER_SOURCES})
 set_target_properties(mir_caffe_importer PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(mir_caffe_importer PUBLIC ../../include/mir_caffe_importer)
-target_link_libraries(mir_caffe_importer PUBLIC mir PRIVATE caffeproto nncc_common)
+target_link_libraries(mir_caffe_importer PUBLIC mir PRIVATE caffeproto)
+# to prevent _GLIBCXX17_DEPRECATED warning as error
+# target_link_libraries(mir_caffe_importer PRIVATE nncc_common)

--- a/compiler/mir/src/mir_onnx_importer/CMakeLists.txt
+++ b/compiler/mir/src/mir_onnx_importer/CMakeLists.txt
@@ -116,7 +116,9 @@ add_library(mir_onnx_importer STATIC ${MIR_ONNX_IMPORTER_SOURCES})
 set_target_properties(mir_onnx_importer PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(mir_onnx_importer PUBLIC ../../include/mir_onnx_importer)
 target_include_directories(mir_onnx_importer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(mir_onnx_importer PUBLIC mir mir_onnx_proto PRIVATE mir_interpreter nncc_common)
+target_link_libraries(mir_onnx_importer PUBLIC mir mir_onnx_proto PRIVATE mir_interpreter)
+# to prevent _GLIBCXX17_DEPRECATED warning as error
+# target_link_libraries(mir_onnx_importer PRIVATE nncc_common)
 
 if(NOT ENABLE_TEST)
   return()


### PR DESCRIPTION
This will disable nncc_common option to prevent _GLIBCXX17_DEPRECATED warning as error.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>