### PR TITLE
[dalgona-test] Use venv without ver num

### DIFF
--- a/compiler/dalgona-test/CMakeLists.txt
+++ b/compiler/dalgona-test/CMakeLists.txt
@@ -53,6 +53,6 @@ add_test(
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/TestSingleOp.sh"
           "${TEST_CONFIG}"
           "${ARTIFACTS_BIN_PATH}"
-          "${NNCC_OVERLAY_DIR}/venv_2_12_1"
+          "${NNCC_OVERLAY_DIR}/venv"
           ${DALGONA_SINGLE_OP_TEST}
 )


### PR DESCRIPTION
This will revise to use venv without version number.
