### PR TITLE
[onert] Use PkgConfig cmake module to find TRIXEngine

### DIFF
--- a/runtime/onert/backend/trix/CMakeLists.txt
+++ b/runtime/onert/backend/trix/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(LIB_ONERT_BACKEND_TRIX onert_backend_trix)
 
-nnfw_find_package(TRIXEngine QUIET 2.5.0)
+find_package(PkgConfig REQUIRED)
+# TRIXEngine version is required to higher than 2.5.0
+pkg_check_modules(TRIXEngine QUIET IMPORTED_TARGET npu-engine>2.5.0)
+
 if(NOT TRIXEngine_FOUND)
   message(STATUS "ONERT backend: Failed to find TRIXEngine")
   return()
@@ -12,7 +15,7 @@ file(GLOB_RECURSE SOURCES "*.cc")
 add_library(${LIB_ONERT_BACKEND_TRIX} SHARED ${SOURCES})
 
 target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE onert_core)
-target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE trix_engine)
+target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE PkgConfig::TRIXEngine)
 target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE nnfw_common)
 target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE nnfw_coverage)
 

--- a/runtime/onert/loader/trix/CMakeLists.txt
+++ b/runtime/onert/loader/trix/CMakeLists.txt
@@ -2,7 +2,10 @@ if (NOT BUILD_TRIX_LOADER)
   return()
 endif ()
 
-nnfw_find_package(TRIXEngine QUIET 2.5.0)
+find_package(PkgConfig REQUIRED)
+# TRIXEngine version is required to higher than 2.5.0
+pkg_check_modules(TRIXEngine QUIET IMPORTED_TARGET npu-engine>2.5.0)
+
 if(TRIXEngine_FOUND)
   message(STATUS "ONERT frontend: Found TRIXEngine")
   list(APPEND SOURCES TrixLoader.cc)
@@ -18,6 +21,6 @@ set_target_properties(tvn_loader PROPERTIES
   INSTALL_RPATH "$ORIGIN:$ORIGIN/..")
 target_link_libraries(tvn_loader PRIVATE onert_core)
 target_link_libraries(tvn_loader PRIVATE nnfw_common nnfw_coverage)
-target_link_libraries(tvn_loader PRIVATE trix_engine)
+target_link_libraries(tvn_loader PRIVATE PkgConfig::TRIXEngine)
 
 install(TARGETS tvn_loader DESTINATION lib/nnfw/loader)


### PR DESCRIPTION
This commit replaces the use of the private cmake with the PkgConfig module. It will prevent a potential build failure caused by varying library paths.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>