### PR TITLE
[luci-ref-value-py-test] Use venv without ver num

### DIFF
--- a/compiler/luci-ref-value-py-test/CMakeLists.txt
+++ b/compiler/luci-ref-value-py-test/CMakeLists.txt
@@ -2,7 +2,7 @@ if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)
 
-set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_12_1")
+set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv")
 set(TEST_LIST_FILE "test.lst")
 
 nncc_find_resource(TensorFlowLiteRecipes)


### PR DESCRIPTION
This will revise to use venv without version number.
