### PR TITLE
[luci-value-test] Use venv without ver num

### DIFF
--- a/compiler/luci-value-test/CMakeLists.txt
+++ b/compiler/luci-value-test/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT CMAKE_CROSSCOMPILING)
     COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/evalverify.sh"
             "${CMAKE_CURRENT_BINARY_DIR}"
             "${ARTIFACTS_BIN_PATH}"
-            "${NNCC_OVERLAY_DIR}/venv_2_12_1"
+            "${NNCC_OVERLAY_DIR}/venv"
             "$<TARGET_FILE:luci_eval_driver>"
             ${LUCI_VALUE_TESTS}
   )
@@ -39,7 +39,7 @@ if(NOT CMAKE_CROSSCOMPILING)
       COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/evalverifytol.sh"
               "${CMAKE_CURRENT_BINARY_DIR}"
               "${ARTIFACTS_BIN_PATH}"
-              "${NNCC_OVERLAY_DIR}/venv_2_12_1"
+              "${NNCC_OVERLAY_DIR}/venv"
               "$<TARGET_FILE:luci_eval_driver>"
               ${LUCI_VALUE_TESTS_TOL}
     )


### PR DESCRIPTION
This will revise to use venv without version number.
