### PR TITLE
[workflow] use ubuntu-22.04 for onert-micro

### DIFF
--- a/.github/workflows/run-onert-micro-unit-tests.yml
+++ b/.github/workflows/run-onert-micro-unit-tests.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   run-onert-micro-unit-tests:
     name: Run onert-micro Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Skip on draft, check on draft -> ready
     if: github.repository_owner == 'Samsung' && github.event.pull_request.draft == false
 


### PR DESCRIPTION
- ubuntu 20.04 is deprecated since 2025-04-15

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>