### PR TITLE
[q-implant-qparam-test] Use venv without ver num

### DIFF
--- a/compiler/q-implant-qparam-test/CMakeLists.txt
+++ b/compiler/q-implant-qparam-test/CMakeLists.txt
@@ -16,7 +16,7 @@ add_test(NAME q-implant-qparam-test
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/q_implant_qparam_test.sh"
           "${CMAKE_CURRENT_BINARY_DIR}"
           "${ARTIFACTS_BIN_PATH}"
-          "${NNCC_OVERLAY_DIR}/venv_2_12_1"
+          "${NNCC_OVERLAY_DIR}/venv"
           "$<TARGET_FILE:q-implant>"
           "$<TARGET_FILE:circle-tensordump>"
           ${Q_IMPLANT_TESTS}


### PR DESCRIPTION
This will revise to use venv without version number.
