### PR TITLE
[record-minmax-ts-test] Use venv without ver num

### DIFF
--- a/compiler/record-minmax-thread-safety-test/CMakeLists.txt
+++ b/compiler/record-minmax-thread-safety-test/CMakeLists.txt
@@ -63,6 +63,6 @@ add_test(
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/testall.sh"
         "${TEST_CONFIG}"
         "${ARTIFACTS_BIN_PATH}"
-        "${NNCC_OVERLAY_DIR}/venv_2_12_1"
+        "${NNCC_OVERLAY_DIR}/venv"
         ${RECORD_MINMAX_THREAD_SAFETY_TEST}
 )


### PR DESCRIPTION
This will revise to use venv without version number.
