### PR TITLE
[github] Remove credential from run-onecc-build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -54,9 +54,6 @@ jobs:
     runs-on: one-x64-linux
     container:
       image: nnfw/one-devtools:${{ matrix.ubuntu_code }}
-      credentials:
-        username: ${{ secrets.NNFW_DOCKER_USERNAME }}
-        password: ${{ secrets.NNFW_DOCKER_TOKEN }}
       options: --user root
     env:
       NNCC_WORKSPACE : build


### PR DESCRIPTION
This will remove credential from run-onecc-build, as secret access is not possible from fork.