### PR TITLE
[pic] Add mio-circle08 dependency

### DIFF
--- a/compiler/pics/CMakeLists.txt
+++ b/compiler/pics/CMakeLists.txt
@@ -17,7 +17,7 @@ add_custom_command(
   OUTPUT ${CIRCLE_SCHEMA_PYTHON_DIR}
   COMMAND "$<TARGET_FILE:flatbuffers::flatc>" --python
           -o "${CMAKE_CURRENT_BINARY_DIR}" "${SCHEMA_BIN_PATH}/schema.fbs"
-  DEPENDS flatbuffers::flatc
+  DEPENDS flatbuffers::flatc mio_circle08
   COMMENT "Generate python interface for circle schema"
 )
 


### PR DESCRIPTION
This commit adds mio-circle08 dependency.
It requires to access copied file.
It will resolve random build fail issue.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>