### PR TITLE
[common-artifacts] Exclude Inf_StridedSlice_002 recipe

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -110,6 +110,7 @@ tcgenerate(ReduceAny_dynamic_000) # TestDataGenerator does not support unknown d
 tcgenerate(ReduceAny_dynamic_001) # TestDataGenerator does not support unknown dimension
 tcgenerate(ReduceAny_dynamic_002) # TestDataGenerator does not support unknown dimension
 tcgenerate(ReduceAny_dynamic_003) # TestDataGenerator does not support unknown dimension
+tcgenerate(ReduceAny_dynamic_004) # TestDataGenerator does not support unknown dimension
 tcgenerate(ReduceMax_000)
 tcgenerate(ReduceMax_dynamic_000) # TestDataGenerator does not support unknown dimension
 tcgenerate(ReduceMin_000)


### PR DESCRIPTION
This commit excludes Inf_StridedSlice_002 because TestDataGenerator does not support unknown dimensions. The produced model will be tested by CircleResizer.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer m.bencer@partner.samsung.com

Issue: https://github.com/Samsung/ONE/issues/14791
Draft: https://github.com/Samsung/ONE/pull/14727