### PR TITLE
[infra] Install clang-format-16 package anyway

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -29,10 +29,11 @@ jobs:
         with:
           python-version: '3.x'
 
-      # C format: clang-format-16 (already installed)
+      # C format: clang-format-16
       # Python format: yapf==0.43.0
       - name: Install packages
         run: |
+          sudo apt-get update && sudo apt-get install -qqy clang-format-16
           pip install yapf==0.43.0
 
       - name: Check


### PR DESCRIPTION
This commit installs the clang-format-16 package even if it is existing in runner. 
It prevents failure when runner is upgraded and clang-format-16 package is removed.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>