### PR TITLE
[onert] Support dynamic shapes in DepthwiseConv2D

### DIFF
--- a/runtime/onert/core/include/exec/DynamicShapeInferer.h
+++ b/runtime/onert/core/include/exec/DynamicShapeInferer.h
@@ -52,6 +52,7 @@ public:
   void visit(const ir::operation::Comparison &op) override;
   void visit(const ir::operation::Concat &op) override;
   void visit(const ir::operation::Conv2D &op) override;
+  void visit(const ir::operation::DepthwiseConv2D &op) override;
   void visit(const ir::operation::ElementwiseActivation &op) override;
   void visit(const ir::operation::ElementwiseBinary &op) override;
   void visit(const ir::operation::ElementwiseUnary &op) override;

--- a/runtime/onert/core/src/exec/DynamicShapeInferer.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInferer.cc
@@ -337,6 +337,31 @@ void DynamicShapeInferer::visit(const ir::operation::Conv2D &op)
   assert(output->buffer() != nullptr);
 }
 
+void DynamicShapeInferer::visit(const ir::operation::DepthwiseConv2D &op)
+{
+  // check if input is not dynamic
+  auto input_ind = op.getInputs().at(ir::operation::DepthwiseConv2D::INPUT);
+  auto input = _tensor_registry->getITensor(input_ind);
+
+  auto ker_ind = op.getInputs().at(ir::operation::DepthwiseConv2D::KERNEL);
+  auto ker = _tensor_registry->getITensor(ker_ind);
+
+  if ((!input->is_dynamic()) && (!ker->is_dynamic()))
+    return;
+
+  ir::Shape input_shape = input->getShape();
+  ir::Shape ker_shape = ker->getShape();
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape output_shape =
+    shape_inference::inferDepthwiseConv2DShape(input_shape, ker_shape, op.param());
+
+  output->applyShape(output_shape);
+  assert(output->buffer() != nullptr);
+}
+
 void DynamicShapeInferer::visit(const ir::operation::ElementwiseActivation &op)
 {
   handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::ElementwiseActivation::INPUT));


### PR DESCRIPTION
This commit extends `DepthwiseConv2D` operator to support dynamic input and output shapes.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>