### PR TITLE
[tools/onert_run] Support output with dynamic-dimension.

### DIFF
--- a/runtime/tests/tools/onert_run/src/nnfw_util.cc
+++ b/runtime/tests/tools/onert_run/src/nnfw_util.cc
@@ -46,4 +46,14 @@ uint64_t bufsize_for(const nnfw_tensorinfo *ti)
   return elmsize[ti->dtype] * num_elems(ti);
 }
 
+uint64_t has_dynamic_dim(const nnfw_tensorinfo *ti)
+{
+  for (int32_t i = 0; i < ti->rank; ++i)
+  {
+    if (ti->dims[i] < 0)
+      return true;
+  }
+  return false;
+}
+
 } // namespace onert_run

--- a/runtime/tests/tools/onert_run/src/nnfw_util.h
+++ b/runtime/tests/tools/onert_run/src/nnfw_util.h
@@ -32,6 +32,7 @@ namespace onert_run
 {
 uint64_t num_elems(const nnfw_tensorinfo *ti);
 uint64_t bufsize_for(const nnfw_tensorinfo *ti);
+uint64_t has_dynamic_dim(const nnfw_tensorinfo *ti);
 } // end of namespace onert_run
 
 #endif // __ONERT_RUN_NNFW_UTIL_H__

--- a/runtime/tests/tools/onert_run/src/onert_run.cc
+++ b/runtime/tests/tools/onert_run/src/onert_run.cc
@@ -364,13 +364,16 @@ int main(const int argc, char **argv)
       if (args.getForceFloat())
         ti.dtype = NNFW_TYPE_TENSOR_FLOAT32;
 
-      uint64_t output_size_in_bytes = bufsize_for(&ti);
+      uint64_t output_size_in_bytes = 0;
+      auto found = output_sizes.find(i);
+      if (found != output_sizes.end())
+        output_size_in_bytes = found->second;
+      else
       {
-        auto found = output_sizes.find(i);
-        if (output_sizes.find(i) != output_sizes.end())
-        {
-          output_size_in_bytes = found->second;
-        }
+        if (has_dynamic_dim(&ti))
+          throw std::runtime_error("Cannot allocate output buffer for dynamic shape. Use "
+                                   "--output_sizes to specify output buffer sizes");
+        output_size_in_bytes = bufsize_for(&ti);
       }
       outputs[i].alloc(output_size_in_bytes, ti.dtype);
       NNPR_ENSURE_STATUS(


### PR DESCRIPTION
This commit adds dynamic-dimension check and fix the wrong allocation.
- Introduce a helper to check dynamic-dimension
- Update output buffer logic to throw if tensor has dynamic dim and advise --output_sizes

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>