### PR TITLE
[infra/debian] Revise copyright file for circle-interpreter

### DIFF
--- a/infra/debian/circle-interpreter/copyright
+++ b/infra/debian/circle-interpreter/copyright
@@ -11,4 +11,3 @@ License: Apache-2.0
  On Debian systems, the full text of the Apache License Version 2.0
  can be found in:
  /usr/share/common-licenses/Apache-2.0
-

--- a/infra/debian/circle-interpreter/copyright
+++ b/infra/debian/circle-interpreter/copyright
@@ -1,3 +1,14 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: circle-interpreter
+Source: https://github.com/Samsung/ONE
+Comment: These binaries are built from the ONE project.
+
 Files: *
-License: Proprietary
-Copyright (c) <2025> <Samsung Electronics Co.,Ltd.>
+Copyright: 2025 Samsung Electronics., Ltd.
+License: Apache-2.0
+ This package is licensed under the Apache License, Version 2.0.
+ .
+ On Debian systems, the full text of the Apache License Version 2.0
+ can be found in:
+ /usr/share/common-licenses/Apache-2.0
+


### PR DESCRIPTION
This updates the `copyright` file for the `circle-interpreter` Debian package.

The format was referenced from the official Debian documentation: 
https://www.debian.org/doc/packaging-manuals/copyright-format/1.0

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>