### PR TITLE
[infra/debian] Ignore manpage for circle-interpreter binary

### DIFF
--- a/infra/debian/circle-interpreter/circle-interpreter.lintian-overrides
+++ b/infra/debian/circle-interpreter/circle-interpreter.lintian-overrides
@@ -1,0 +1,1 @@
+circle-interpreter: binary-without-manpage


### PR DESCRIPTION
This adds a `lintian-overrides` file to suppress the warning about the missing manpage for the `circle-interpreter` binary.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>