### PR TITLE
[infra/debian] Revise rules for circle-interpreter

### DIFF
--- a/infra/debian/circle-interpreter/rules
+++ b/infra/debian/circle-interpreter/rules
@@ -1,40 +1,37 @@
 #!/usr/bin/make -f
 
-export NNCC_WORKSPACE=build/debian
-export NNCC_INSTALL_PREFIX=$(CURDIR)/debian/tmp/usr/
+export NNCC_INSTALL_PREFIX=$(CURDIR)
+export DEBIAN_PREFIX=$(CURDIR)/debian/tmp
 
 %:
 	dh $@
 
 override_dh_auto_clean:
-	# skip clean
+	# Nothing to clean
+	true
 
 override_dh_auto_configure:
-	CIRCLEINT_ITEMS="angkor;cwrap;pepper-str;pepper-strcast;pepper-csv2vec;pp"
-	CIRCLEINT_ITEMS="${CIRCLEINT_ITEMS};oops;loco;logo-core;logo;locop"
-	CIRCLEINT_ITEMS="${CIRCLEINT_ITEMS};hermes;hermes-std;safemain;mio-circle08"
-	CIRCLEINT_ITEMS="${CIRCLEINT_ITEMS};luci-compute;luci;luci-interpreter"
-	CIRCLEINT_ITEMS="${CIRCLEINT_ITEMS};foder;arser;vconone;circle-interpreter"
-
-	./nncc configure \
-		-DENABLE_STRICT_BUILD=ON \
-		-DENABLE_TEST=OFF \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DEXTERNALS_BUILD_THREADS=4 \
-		-DCMAKE_INSTALL_PREFIX=${NNCC_INSTALL_PREFIX} \
-		-DBUILD_WHITELIST="${CIRCLEINT_ITEMS}"
+	# No configure step needed
+	true
 
 override_dh_auto_build:
-	./nncc build -j4
+	# No build step needed
+	true
 
 override_dh_auto_test:
-	# skip test
+	# No test step needed
+	true
 
 override_dh_auto_install:
-	cmake --build ${NNCC_WORKSPACE} -- install
+	# copy the bin file
+	mkdir -p ${DEBIAN_PREFIX}/bin
+	cp ${NNCC_INSTALL_PREFIX}/circle-interpreter ${DEBIAN_PREFIX}/bin/
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 
+override_dh_strip:
+	dh_strip --no-automatic-dbgsym
+
 override_dh_builddeb:
-	dh_builddeb -- -Zgzip
+	dh_builddeb


### PR DESCRIPTION
This removes the ONE build scripts, as the `circle-interpreter` and its related binaries will be built in the GitHub workflow.

This is necessary because Debian builds on Launchpad do not support fetching external code, such as TensorFlow, during the build process.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>