### PR TITLE
[infra/debian] Revise circle-interpreter.install script

### DIFF
--- a/infra/debian/circle-interpreter/circle-interpreter.install
+++ b/infra/debian/circle-interpreter/circle-interpreter.install
@@ -1,13 +1,11 @@
 # {FILES_TO_INSTALL} {DEST_DIR}
-# bin
-usr/bin/circle-interpreter usr/share/cirint/bin/
 # lib
-usr/lib/libloco.so usr/share/cirint/bin/
-usr/lib/libluci_env.so usr/share/cirint/bin/
-usr/lib/libluci_import.so usr/share/cirint/bin/
-usr/lib/libluci_interpreter.so usr/share/cirint/bin/
-usr/lib/libluci_lang.so usr/share/cirint/bin/
-usr/lib/libluci_logex.so usr/share/cirint/bin/
-usr/lib/libluci_log.so usr/share/cirint/bin/
-usr/lib/libluci_plan.so usr/share/cirint/bin/
-usr/lib/libluci_profile.so usr/share/cirint/bin/
+libloco.so usr/share/cirint/bin/
+libluci_env.so usr/share/cirint/bin/
+libluci_import.so usr/share/cirint/bin/
+libluci_interpreter.so usr/share/cirint/bin/
+libluci_lang.so usr/share/cirint/bin/
+libluci_logex.so usr/share/cirint/bin/
+libluci_log.so usr/share/cirint/bin/
+libluci_plan.so usr/share/cirint/bin/
+libluci_profile.so usr/share/cirint/bin/


### PR DESCRIPTION
Install the shared library files for `circle-interpreter` by copying them.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>