### PR TITLE
[infra/onert] Use runtime source config

### DIFF
--- a/infra/nnfw/CMakeLists.txt
+++ b/infra/nnfw/CMakeLists.txt
@@ -48,14 +48,6 @@ macro(nnfw_find_package PREFIX)
   )
 endmacro(nnfw_find_package)
 
-# Common 'find_package()' wrapper to find in infra/cmake/packages folder
-macro(nnas_find_package PREFIX)
-  find_package(${PREFIX} CONFIG NO_DEFAULT_PATH
-    PATHS ${NNAS_PROJECT_SOURCE_DIR}/infra/cmake/packages
-    ${ARGN}
-  )
-endmacro(nnas_find_package)
-
 # C++17 feature requires 9.1 or later for stable usage
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
   message(FATAL "Runtime build requires GNU Compiler version 9.1 or later.")

--- a/infra/nnfw/cmake/packages/EigenConfig.cmake
+++ b/infra/nnfw/cmake/packages/EigenConfig.cmake
@@ -1,14 +1,14 @@
 function(_Eigen_import)
-  nnas_find_package(TensorFlowEigenSource EXACT 2.16.1 QUIET)
+  nnfw_find_package(EigenSource QUIET)
 
-  if(NOT TensorFlowEigenSource_FOUND)
+  if(NOT EigenSource_FOUND)
     set(Eigen_FOUND FALSE PARENT_SCOPE)
     return()
-  endif(NOT TensorFlowEigenSource_FOUND)
+  endif(NOT EigenSource_FOUND)
 
   if(NOT TARGET eigen)
     add_library(eigen INTERFACE)
-    target_include_directories(eigen SYSTEM INTERFACE "${TensorFlowEigenSource_DIR}")
+    target_include_directories(eigen SYSTEM INTERFACE "${EigenSource_DIR}")
     # Add EIGEN_MPL2_ONLY to remove license issue posibility
     target_compile_definitions(eigen INTERFACE EIGEN_MPL2_ONLY)
     # Some used Eigen functions makes deprecated declarations warning

--- a/infra/nnfw/cmake/packages/EigenSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/EigenSourceConfig.cmake
@@ -1,0 +1,21 @@
+function(_EigenSource_import)
+  if(NOT DOWNLOAD_EIGEN)
+    set(EigenSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_EIGEN)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  # Exact version used by TensorFlow v2.16.1.
+  # See tensorflow/third_party/eigen3/workspace.bzl.
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://gitlab.com")
+  envoption(EIGEN_URL ${EXTERNAL_DOWNLOAD_SERVER}/libeigen/eigen/-/archive/aa6964bf3a34fd607837dd8123bc42465185c4f8/eigen-aa6964bf3a34fd607837dd8123bc42465185c4f8.tar.gz)
+
+  ExternalSource_Download(EIGEN DIRNAME TENSORFLOW-2.16.1-EIGEN ${EIGEN_URL})
+
+  set(EigenSource_DIR ${EIGEN_SOURCE_DIR} PARENT_SCOPE)
+  set(EigenSource_FOUND TRUE PARENT_SCOPE)
+endfunction(_EigenSource_import)
+
+_EigenSource_import()

--- a/infra/nnfw/cmake/packages/FlatBuffersConfig.cmake
+++ b/infra/nnfw/cmake/packages/FlatBuffersConfig.cmake
@@ -6,7 +6,7 @@ function(_FlatBuffers_import)
       return()
     endif(Flatbuffers_FOUND)
 
-    nnas_find_package(FlatBuffersSource EXACT 23.5.26 QUIET)
+    nnfw_find_package(FlatBuffersSource QUIET)
 
     if(NOT FlatBuffersSource_FOUND)
       set(FlatBuffers_FOUND FALSE PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/FlatBuffersSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/FlatBuffersSourceConfig.cmake
@@ -1,0 +1,22 @@
+function(_FlatBuffersSource_import)
+  if(NOT DOWNLOAD_FLATBUFFERS)
+    set(FlatBuffersSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_FLATBUFFERS)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  envoption(FLATBUFFERS_23_5_26_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/flatbuffers/archive/v23.5.26.tar.gz)
+  ExternalSource_Download(FLATBUFFERS
+    DIRNAME FLATBUFFERS-23.5.26
+    CHECKSUM MD5=2ef00eaaa86ab5e9ad5eafe09c2e7b60
+    URL ${FLATBUFFERS_23_5_26_URL}
+  )
+
+  set(FlatBuffersSource_DIR ${FLATBUFFERS_SOURCE_DIR} PARENT_SCOPE)
+  set(FlatBuffersSource_FOUND TRUE PARENT_SCOPE)
+endfunction(_FlatBuffersSource_import)
+
+_FlatBuffersSource_import()

--- a/infra/nnfw/cmake/packages/Fp16Config.cmake
+++ b/infra/nnfw/cmake/packages/Fp16Config.cmake
@@ -1,5 +1,5 @@
 function(_Fp16_Build)
-  nnas_find_package(Fp16Source QUIET)
+  nnfw_find_package(Fp16Source QUIET)
 
   # NOTE This line prevents multiple definitions of target
   if(TARGET fp16)

--- a/infra/nnfw/cmake/packages/Fp16SourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/Fp16SourceConfig.cmake
@@ -1,0 +1,21 @@
+function(_Fp16Source_import)
+  if(NOT ${DOWNLOAD_FP16})
+    set(Fp16Source_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_FP16})
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  # fp16 commit in xnnpack (tflite v2.16.1)
+  envoption(FP16_URL ${EXTERNAL_DOWNLOAD_SERVER}/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.tar.gz)
+  ExternalSource_Download(FP16
+    DIRNAME FP16
+    URL ${FP16_URL})
+
+  set(Fp16Source_DIR ${FP16_SOURCE_DIR} PARENT_SCOPE)
+  set(Fp16Source_FOUND TRUE PARENT_SCOPE)
+endfunction(_Fp16Source_import)
+
+_Fp16Source_import()

--- a/infra/nnfw/cmake/packages/GEMMLowpConfig.cmake
+++ b/infra/nnfw/cmake/packages/GEMMLowpConfig.cmake
@@ -1,16 +1,16 @@
 function(_GEMMLowp_import)
-  nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.16.1 QUIET)
+  nnfw_find_package(GEMMLowpSource QUIET)
 
-  if(NOT TensorFlowGEMMLowpSource_FOUND)
+  if(NOT GEMMLowpSource_FOUND)
     set(GEMMLowp_FOUND FALSE PARENT_SCOPE)
     return()
-  endif(NOT TensorFlowGEMMLowpSource_FOUND)
+  endif(NOT GEMMLowpSource_FOUND)
 
   if(NOT TARGET gemmlowp)
     find_package(Threads REQUIRED)
 
     add_library(gemmlowp INTERFACE)
-    target_include_directories(gemmlowp SYSTEM INTERFACE ${TensorFlowGEMMLowpSource_DIR})
+    target_include_directories(gemmlowp SYSTEM INTERFACE ${GEMMLowpSource_DIR})
     target_link_libraries(gemmlowp INTERFACE ${LIB_PTHREAD})
   endif(NOT TARGET gemmlowp)
 

--- a/infra/nnfw/cmake/packages/GEMMLowpSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/GEMMLowpSourceConfig.cmake
@@ -1,0 +1,21 @@
+function(_GEMMLowpSource_import)
+  if(NOT DOWNLOAD_GEMMLOWP)
+    set(GEMMLowpSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_GEMMLOWP)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  # Exact version used by TensorFlow v2.16.1.
+  # See tensorflow/third_party/gemmlowp/workspace.bzl.
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  envoption(TGEMMLOWP_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/gemmlowp/archive/16e8662c34917be0065110bfcd9cc27d30f52fdf.zip)
+
+  ExternalSource_Download(GEMMLOWP DIRNAME TENSORFLOW-2.16.1-GEMMLOWP ${TGEMMLOWP_URL})
+
+  set(GEMMLowpSource_DIR ${GEMMLOWP_SOURCE_DIR} PARENT_SCOPE)
+  set(GEMMLowpSource_FOUND TRUE PARENT_SCOPE)
+endfunction(_GEMMLowpSource_import)
+
+_GEMMLowpSource_import()

--- a/infra/nnfw/cmake/packages/GTestConfig.cmake
+++ b/infra/nnfw/cmake/packages/GTestConfig.cmake
@@ -1,5 +1,5 @@
 if(${DOWNLOAD_GTEST})
-  nnas_find_package(GTestSource QUIET)
+  nnfw_find_package(GTestSource QUIET)
 
   if(NOT GTestSource_FOUND)
     set(GTest_FOUND FALSE)

--- a/infra/nnfw/cmake/packages/GTestSourceConfig copy.cmake
+++ b/infra/nnfw/cmake/packages/GTestSourceConfig copy.cmake
@@ -1,0 +1,19 @@
+function(_GTestSource_import)
+  if(NOT DOWNLOAD_GTEST)
+    set(GTestSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_GTEST)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  envoption(GTEST_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/googletest/archive/release-1.12.1.tar.gz)
+
+  ExternalSource_Download(GTEST ${GTEST_URL})
+
+  set(GTestSource_DIR ${GTEST_SOURCE_DIR} PARENT_SCOPE)
+  set(GTestSource_FOUND TRUE PARENT_SCOPE)
+endfunction(_GTestSource_import)
+
+_GTestSource_import()

--- a/infra/nnfw/cmake/packages/GTestSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/GTestSourceConfig.cmake
@@ -1,0 +1,19 @@
+function(_GTestSource_import)
+  if(NOT DOWNLOAD_GTEST)
+    set(GTestSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_GTEST)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  envoption(GTEST_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/googletest/archive/release-1.12.1.tar.gz)
+
+  ExternalSource_Download(GTEST ${GTEST_URL})
+
+  set(GTestSource_DIR ${GTEST_SOURCE_DIR} PARENT_SCOPE)
+  set(GTestSource_FOUND TRUE PARENT_SCOPE)
+endfunction(_GTestSource_import)
+
+_GTestSource_import()

--- a/infra/nnfw/cmake/packages/NEON2SSESourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/NEON2SSESourceConfig.cmake
@@ -1,0 +1,20 @@
+function(_NEON2SSESource_import)
+  if(NOT DOWNLOAD_NEON2SSE)
+    set(NEON2SSESource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_NEON2SSE)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  # NOTE TensorFlow 2.16.1 downloads NEON2SSE from the following URL
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  envoption(NEON2SSE_URL ${EXTERNAL_DOWNLOAD_SERVER}/intel/ARM_NEON_2_x86_SSE/archive/a15b489e1222b2087007546b4912e21293ea86ff.tar.gz)
+
+  ExternalSource_Download(NEON2SSE ${NEON2SSE_URL})
+
+  set(NEON2SSESource_DIR ${NEON2SSE_SOURCE_DIR} PARENT_SCOPE)
+  set(NEON2SSESource_FOUND TRUE PARENT_SCOPE)
+endfunction(_NEON2SSESource_import)
+
+_NEON2SSESource_import()

--- a/infra/nnfw/cmake/packages/Pybind11Config.cmake
+++ b/infra/nnfw/cmake/packages/Pybind11Config.cmake
@@ -1,5 +1,5 @@
 function(_Pybind11_Build)
-  nnas_find_package(Pybind11Source QUIET)
+  nnfw_find_package(Pybind11Source QUIET)
 
   if(NOT Pybind11Source_FOUND)
     set(Pybind11_FOUND FALSE)

--- a/infra/nnfw/cmake/packages/Pybind11SourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/Pybind11SourceConfig.cmake
@@ -1,0 +1,19 @@
+function(_Pybind11Source_import)
+  if(NOT DOWNLOAD_PYBIND11)
+    set(Pybind11Source_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_PYBIND11)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  envoption(PYBIND11_URL ${EXTERNAL_DOWNLOAD_SERVER}/pybind/pybind11/archive/v2.11.1.tar.gz)
+
+  ExternalSource_Download(PYBIND11 ${PYBIND11_URL})
+
+  set(Pybind11Source_DIR ${PYBIND11_SOURCE_DIR} PARENT_SCOPE)
+  set(Pybind11Source_FOUND TRUE PARENT_SCOPE)
+endfunction(_Pybind11Source_import)
+
+_Pybind11Source_import()

--- a/infra/nnfw/cmake/packages/Ruy/CMakeLists.txt
+++ b/infra/nnfw/cmake/packages/Ruy/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(RUY_BASE ${TensorFlowRuySource_DIR}/ruy)
+set(RUY_BASE ${RuySource_DIR}/ruy)
 
 #
 # Ruy library
@@ -22,7 +22,7 @@ if(PROFILE_RUY)
   list(APPEND RUY_PROFILER_SRCS "${RUY_BASE}/profiler/treeview.cc")
 endif(PROFILE_RUY)
 
-list(APPEND RUY_INCLUDES "${TensorFlowRuySource_DIR}")
+list(APPEND RUY_INCLUDES "${RuySource_DIR}")
 
 add_library(ruy STATIC ${RUY_SRCS})
 target_include_directories(ruy SYSTEM PUBLIC ${RUY_INCLUDES})

--- a/infra/nnfw/cmake/packages/RuyConfig.cmake
+++ b/infra/nnfw/cmake/packages/RuyConfig.cmake
@@ -5,14 +5,14 @@ function(_Ruy_Build)
     return()
   endif(TARGET ruy)
 
-  nnas_find_package(TensorFlowRuySource EXACT 2.16.1 QUIET)
+  nnfw_find_package(RuySource QUIET)
   nnfw_find_package(CpuInfo QUIET)
 
-  if(NOT TensorFlowRuySource_FOUND)
+  if(NOT RuySource_FOUND)
     message(STATUS "RUY: Source not found")
     set(Ruy_FOUND FALSE PARENT_SCOPE)
     return()
-  endif(NOT TensorFlowRuySource_FOUND)
+  endif(NOT RuySource_FOUND)
 
   if (NOT CpuInfo_FOUND)
     message(STATUS "RUY: CPUINFO not found")

--- a/infra/nnfw/cmake/packages/RuySourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/RuySourceConfig.cmake
@@ -1,0 +1,21 @@
+function(_RuySource_import)
+  if(NOT DOWNLOAD_RUY)
+    set(RuySource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_RUY)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  # Exact version used by TensorFlow v2.16.1.
+  # See tensorflow/third_party/ruy/workspace.bzl
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  envoption(RUY_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/ruy/archive/3286a34cc8de6149ac6844107dfdffac91531e72.zip)
+
+  ExternalSource_Download(RUY DIRNAME TENSORFLOW-2.16.1-RUY ${RUY_URL})
+
+  set(RuySource_DIR ${RUY_SOURCE_DIR} PARENT_SCOPE)
+  set(RuySource_FOUND TRUE PARENT_SCOPE)
+endfunction(_RuySource_import)
+
+_RuySource_import()

--- a/infra/nnfw/cmake/packages/TensorFlowLite/CMakeLists.txt
+++ b/infra/nnfw/cmake/packages/TensorFlowLite/CMakeLists.txt
@@ -173,7 +173,7 @@ endif()
 # include headers
 list(APPEND TFLITE_INCLUDE_DIRS "${TSL_SOURCE_DIR}")
 list(APPEND TFLITE_INCLUDE_DIRS "${TensorFlowSource_DIR}")
-list(APPEND TFLITE_INCLUDE_DIRS "${TensorFlowGEMMLowpSource_DIR}")
+list(APPEND TFLITE_INCLUDE_DIRS "${GEMMLowpSource_DIR}")
 list(APPEND TFLITE_INCLUDE_DIRS "${Fp16Source_DIR}/include")
 #list(APPEND TFLITE_INCLUDE_DIRS "${Pybind11Source_DIR}/include")
 list(APPEND TFLITE_INCLUDE_DIRS "${CpuInfoSource_DIR}")

--- a/infra/nnfw/cmake/packages/TensorFlowLiteConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowLiteConfig.cmake
@@ -16,7 +16,7 @@ if(BUILD_TENSORFLOW_LITE)
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
-  nnas_find_package(TensorFlowSource EXACT 2.16.1 QUIET)
+  nnfw_find_package(TensorFlowSource QUIET)
   return_unless(TensorFlowSource_FOUND)
 
   # Below urls come from https://github.com/tensorflow/tensorflow/blob/v2.16.1/tensorflow/workspace2.bzl
@@ -28,8 +28,8 @@ if(BUILD_TENSORFLOW_LITE)
   return_unless(Farmhash_FOUND)
   nnfw_find_package(FlatBuffers EXACT 23.5.26 QUIET)
   return_unless(FlatBuffers_FOUND)
-  nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.16.1 QUIET)
-  return_unless(TensorFlowGEMMLowpSource_FOUND)
+  nnfw_find_package(GEMMLowpSource QUIET)
+  return_unless(GEMMLowpSource_FOUND)
   nnfw_find_package(OouraFFT QUIET)
   return_unless(OouraFFT_FOUND)
   nnfw_find_package(Ruy QUIET)
@@ -38,7 +38,7 @@ if(BUILD_TENSORFLOW_LITE)
   return_unless(MLDtypesSource_FOUND)
 
   # TensorFlow Lite requires FP16 library's header only
-  nnas_find_package(Fp16Source QUIET)
+  nnfw_find_package(Fp16Source QUIET)
   return_unless(Fp16Source_FOUND)
 
   # PThreadpool
@@ -48,11 +48,11 @@ if(BUILD_TENSORFLOW_LITE)
   # TensorFlow Lite requires Pybind11 library's header only
   # But Pybind11 requires python3-dev package
   # TODO Enable below by installing package on build system
-  #nnas_find_package(Pybind11Source QUIET)
+  #nnfw_find_package(Pybind11Source QUIET)
   #return_unless(Pybind11Source_FOUND)
 
   # Optional packages
-  nnas_find_package(NEON2SSESource QUIET)
+  nnfw_find_package(NEON2SSESource QUIET)
 
   nnas_include(ExternalProjectTools)
   add_extdirectory("${CMAKE_CURRENT_LIST_DIR}/TensorFlowLite" tflite-2.16.1)

--- a/infra/nnfw/cmake/packages/TensorFlowSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowSourceConfig.cmake
@@ -1,0 +1,19 @@
+function(_TensorFlowSource_import)
+  if(NOT DOWNLOAD_TENSORFLOW)
+    set(TensorFlowSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT DOWNLOAD_TENSORFLOW)
+
+  nnas_include(ExternalSourceTools)
+  nnas_include(OptionTools)
+
+  envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
+  envoption(TENSORFLOW_2_16_1_URL ${EXTERNAL_DOWNLOAD_SERVER}/tensorflow/tensorflow/archive/v2.16.1.tar.gz)
+
+  ExternalSource_Download(TENSORFLOW DIRNAME TENSORFLOW-2.16.1 ${TENSORFLOW_2_16_1_URL})
+
+  set(TensorFlowSource_DIR ${TENSORFLOW_SOURCE_DIR} PARENT_SCOPE)
+  set(TensorFlowSource_FOUND TRUE PARENT_SCOPE)
+endfunction(_TensorFlowSource_import)
+
+_TensorFlowSource_import()

--- a/runtime/contrib/android_benchmark_app/CMakeLists.txt
+++ b/runtime/contrib/android_benchmark_app/CMakeLists.txt
@@ -55,7 +55,7 @@ target_link_libraries(android_benchmark_native nnfw_lib_tflite)
 target_link_libraries(android_benchmark_native nnfw_lib_misc)
 target_link_libraries(android_benchmark_native log)
 
-nnas_find_package(FlatBuffersSource EXACT 2.0 REQUIRED)
+nnfw_find_package(FlatBuffersSource REQUIRED)
 target_include_directories(android_benchmark_native PUBLIC ${FlatBuffersSource_DIR}/include .)
 
 add_custom_target(android-benchmark-apk ALL


### PR DESCRIPTION
This commit copies cmake source config to use runtime's own config.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/15231
Draft: #15235