### PR TITLE
[infra/debian] Fix missing binary file copy in install script

### DIFF
--- a/infra/debian/circle-interpreter/circle-interpreter.install
+++ b/infra/debian/circle-interpreter/circle-interpreter.install
@@ -1,4 +1,6 @@
 # {FILES_TO_INSTALL} {DEST_DIR}
+# bin
+bin/circle-interpreter usr/share/cirint/bin/
 # lib
 libloco.so usr/share/cirint/bin/
 libluci_env.so usr/share/cirint/bin/


### PR DESCRIPTION
This fixes the `circle-interpreter` install script, which was missing the step to copy the binary file.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>