### PR TITLE
[onert/python] Introduce NNFW exception bindings

### DIFF
--- a/runtime/onert/api/python/include/nnfw_exception_bindings.h
+++ b/runtime/onert/api/python/include/nnfw_exception_bindings.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_API_PYTHON_NNFW_EXCEPTION_BINDINGS_H__
+#define __ONERT_API_PYTHON_NNFW_EXCEPTION_BINDINGS_H__
+
+#include <pybind11/pybind11.h>
+
+namespace onert::api::python
+{
+
+namespace py = pybind11;
+
+// Declare binding exceptions
+void bind_nnfw_exceptions(py::module_ &m);
+
+} // namespace onert::api::python
+
+#endif // __ONERT_API_PYTHON_NNFW_EXCEPTION_BINDINGS_H__

--- a/runtime/onert/api/python/include/nnfw_exceptions.h
+++ b/runtime/onert/api/python/include/nnfw_exceptions.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_API_PYTHON_NNFW_EXCEPTIONS_H__
+#define __ONERT_API_PYTHON_NNFW_EXCEPTIONS_H__
+
+#include <stdexcept>
+#include <string>
+
+namespace onert::api::python
+{
+
+// Base for all NNFW errors
+struct NnfwError : public std::runtime_error
+{
+  explicit NnfwError(const std::string &msg) : std::runtime_error(msg) {}
+};
+
+struct NnfwUnexpectedNullError : public NnfwError
+{
+  using NnfwError::NnfwError;
+};
+struct NnfwInvalidStateError : public NnfwError
+{
+  using NnfwError::NnfwError;
+};
+struct NnfwOutOfMemoryError : public NnfwError
+{
+  using NnfwError::NnfwError;
+};
+struct NnfwInsufficientOutputError : public NnfwError
+{
+  using NnfwError::NnfwError;
+};
+struct NnfwDeprecatedApiError : public NnfwError
+{
+  using NnfwError::NnfwError;
+};
+
+} // namespace onert::api::python
+
+#endif // __ONERT_API_PYTHON_NNFW_EXCEPTIONS_H__

--- a/runtime/onert/api/python/package/common/basesession.py
+++ b/runtime/onert/api/python/package/common/basesession.py
@@ -2,6 +2,7 @@ from typing import List
 import numpy as np
 
 from ..native.libnnfw_api_pybind import infer, tensorinfo
+from ..native.libnnfw_api_pybind.exception import OnertError
 
 
 def num_elems(tensor_info):
@@ -57,18 +58,29 @@ class BaseSession:
         """
         Retrieve tensorinfo for all input tensors.
 
+        Raises:
+            OnertError: If the underlying C-API call fails.
+
         Returns:
             list[tensorinfo]: A list of tensorinfo objects for each input.
         """
         num_inputs: int = self.session.input_size()
         infos: List[tensorinfo] = []
         for i in range(num_inputs):
-            infos.append(self.session.input_tensorinfo(i))
+            try:
+                infos.append(self.session.input_tensorinfo(i))
+            except ValueError:
+                raise
+            except Exception as e:
+                raise OnertError(f"Failed to get input tensorinfo #{i}: {e}") from e
         return infos
 
     def get_outputs_tensorinfo(self) -> List[tensorinfo]:
         """
         Retrieve tensorinfo for all output tensors.
+
+        Raises:
+            OnertError: If the underlying C-API call fails.
 
         Returns:
             list[tensorinfo]: A list of tensorinfo objects for each output.
@@ -76,15 +88,25 @@ class BaseSession:
         num_outputs: int = self.session.output_size()
         infos: List[tensorinfo] = []
         for i in range(num_outputs):
-            infos.append(self.session.output_tensorinfo(i))
+            try:
+                infos.append(self.session.output_tensorinfo(i))
+            except ValueError:
+                raise
+            except Exception as e:
+                raise OnertError(f"Failed to get output tensorinfo #{i}: {e}") from e
         return infos
 
     def set_inputs(self, size, inputs_array=[]):
         """
         Set the input tensors for the session.
+
         Args:
             size (int): Number of input tensors.
             inputs_array (list): List of numpy arrays for the input data.
+
+        Raises:
+            ValueError: If session uninitialized.
+            OnertError:  If any C-API call fails.
         """
         if self.session is None:
             raise ValueError(
@@ -93,7 +115,12 @@ class BaseSession:
 
         self.inputs = []
         for i in range(size):
-            input_tensorinfo = self.session.input_tensorinfo(i)
+            try:
+                input_tensorinfo = self.session.input_tensorinfo(i)
+            except ValueError:
+                raise
+            except Exception as e:
+                raise OnertError(f"Failed to get input tensorinfo #{i}: {e}") from e
 
             if len(inputs_array) > i:
                 input_array = np.array(inputs_array[i], dtype=input_tensorinfo.dtype)
@@ -104,14 +131,25 @@ class BaseSession:
                 input_array = np.zeros((num_elems(input_tensorinfo)),
                                        dtype=input_tensorinfo.dtype)
 
-            self.session.set_input(i, input_array)
+            try:
+                self.session.set_input(i, input_array)
+            except ValueError:
+                raise
+            except Exception as e:
+                raise OnertError(f"Failed to set input #{i}: {e}") from e
+
             self.inputs.append(input_array)
 
     def set_outputs(self, size):
         """
         Set the output tensors for the session.
+
         Args:
             size (int): Number of output tensors.
+
+	    Raises:
+            ValueError: If session uninitialized.
+            OnertError:  If any C-API call fails.
         """
         if self.session is None:
             raise ValueError(
@@ -120,12 +158,35 @@ class BaseSession:
 
         self.outputs = []
         for i in range(size):
-            output_tensorinfo = self.session.output_tensorinfo(i)
+            try:
+                output_tensorinfo = self.session.output_tensorinfo(i)
+            except ValueError:
+                raise
+            except Exception as e:
+                raise OnertError(f"Failed to get output tensorinfo #{i}: {e}") from e
             output_array = np.zeros((num_elems(output_tensorinfo)),
                                     dtype=output_tensorinfo.dtype)
-            self.session.set_output(i, output_array)
+
+            try:
+                self.session.set_output(i, output_array)
+            except ValueError:
+                raise
+            except Exception as e:
+                raise OnertError(f"Failed to set output #{i}: {e}") from e
+
             self.outputs.append(output_array)
 
 
 def tensorinfo():
-    return infer.nnfw_tensorinfo()
+    """
+    Shortcut to create a fresh tensorinfo instance.
+    Raises:
+        OnertError: If the C-API call fails.
+    """
+
+    try:
+        return infer.nnfw_tensorinfo()
+    except OnertError:
+        raise
+    except Exception as e:
+        raise OnertError(f"Failed to create tensorinfo: {e}") from e

--- a/runtime/onert/api/python/package/infer/session.py
+++ b/runtime/onert/api/python/package/infer/session.py
@@ -5,6 +5,7 @@ import warnings
 from contextlib import contextmanager
 
 from ..native.libnnfw_api_pybind import infer, tensorinfo
+from ..native.libnnfw_api_pybind.exception import OnertError
 from ..common.basesession import BaseSession
 
 
@@ -60,48 +61,63 @@ class session(BaseSession):
 
         # Check if the session is prepared. If not, call prepare() and set_outputs() once.
         if not self._prepared:
-            with self._time_block(metrics, 'prepare_time_ms', measure):
-                # On first call, fix any -1 dims to real input shapes and validate
-                original_infos = self.get_inputs_tensorinfo()
-                fixed_infos = []
-                for idx, info in enumerate(original_infos):
-                    input_shape = inputs_array[idx].shape
-                    new_dims = []
-                    static_dim_changed = False
-                    # only the first `info.rank` entries matter
-                    for j, d in enumerate(info.dims[:info.rank]):
-                        if d == -1:
-                            # replace dynamic dim with actual incoming shape
-                            new_dims.append(input_shape[j])
-                        elif d == input_shape[j]:
-                            # static dim must match the provided array
-                            new_dims.append(d)
-                        else:
-                            static_dim_changed = True
+            try:
+                with self._time_block(metrics, 'prepare_time_ms', measure):
+                    # On first call, fix any -1 dims to real input shapes and validate
+                    original_infos = self.get_inputs_tensorinfo()
+                    fixed_infos = []
+                    for idx, info in enumerate(original_infos):
+                        input_shape = inputs_array[idx].shape
+                        new_dims = []
+                        static_dim_changed = False
+                        # only the first `info.rank` entries matter
+                        for j, d in enumerate(info.dims[:info.rank]):
+                            if d == -1:
+                                # replace dynamic dim with actual incoming shape
+                                new_dims.append(input_shape[j])
+                            elif d == input_shape[j]:
+                                # static dim must match the provided array
+                                new_dims.append(d)
+                            else:
+                                static_dim_changed = True
 
-                    if static_dim_changed:
-                        warnings.warn(
-                            f"infer() called with input {idx}'s shape={input_shape}, "
-                            f"which differs from model’s expected shape={tuple(info.dims)}. "
-                            "Ensure this is intended.", UserWarning)
+                        if static_dim_changed:
+                            warnings.warn(
+                                f"infer() called with input {idx}'s shape={input_shape}, "
+                                f"which differs from model's expected shape={tuple(info.dims)}. "
+                                "Ensure this is intended.", UserWarning)
 
-                    info.dims = new_dims
-                    fixed_infos.append(info)
+                        info.dims = new_dims
+                        fixed_infos.append(info)
 
-                # Update tensorinfo to optimize using it
-                self._update_inputs_tensorinfo(fixed_infos)
+                    # Update tensorinfo to optimize using it
+                    self._update_inputs_tensorinfo(fixed_infos)
 
-                self.session.prepare()
-                self.set_outputs(self.session.output_size())
-                self._prepared = True
+                    self.session.prepare()
+                    self.set_outputs(self.session.output_size())
+                    self._prepared = True
+            except ValueError:
+                raise
+            except Exception as e:
+                raise OnertError(f"Session preparation failed: {e}") from e
 
         # Configure input buffers using the current session's input size and provided data.
-        with self._time_block(metrics, 'io_time_ms', measure):
-            self.set_inputs(expected_input_size, inputs_array)
+        try:
+            with self._time_block(metrics, 'io_time_ms', measure):
+                self.set_inputs(expected_input_size, inputs_array)
+        except ValueError:
+            raise
+        except Exception as e:
+            raise OnertError(f"Failed to bind inputs: {e}") from e
 
         # Execute the inference.
-        with self._time_block(metrics, 'run_time_ms', measure):
-            self.session.run()
+        try:
+            with self._time_block(metrics, 'run_time_ms', measure):
+                self.session.run()
+        except ValueError:
+            raise
+        except Exception as e:
+            raise OnertError(f"Inference execution failed: {e}") from e
 
         # TODO: Support dynamic shapes for outputs.
 
@@ -118,6 +134,8 @@ class session(BaseSession):
         Raises:
             ValueError: If the number of new_infos does not match the session's input size,
                         or if any tensorinfo contains a negative dimension.
+
+            OnertError: If the underlying C-API call fails.
         """
         num_inputs: int = self.session.input_size()
         if len(new_infos) != num_inputs:
@@ -130,7 +148,13 @@ class session(BaseSession):
                 raise ValueError(
                     f"Input tensorinfo at index {i} contains negative dimension(s): "
                     f"{info.dims[:info.rank]}")
-            self.session.set_input_tensorinfo(i, info)
+            try:
+                self.session.set_input_tensorinfo(i, info)
+            except ValueError:
+                # re-raise ValueError directly
+                raise
+            except Exception as e:
+                raise Oner
 
     @contextmanager
     def _time_block(self, metrics: Dict[str, float], key: str, mesure: bool):

--- a/runtime/onert/api/python/src/bindings/nnfw_api_wrapper_pybind.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_api_wrapper_pybind.cc
@@ -16,11 +16,13 @@
 
 #include <pybind11/pybind11.h>
 
+#include "nnfw_exception_bindings.h"
 #include "nnfw_session_bindings.h"
 #include "nnfw_tensorinfo_bindings.h"
 #include "nnfw_traininfo_bindings.h"
 
 using namespace onert::api::python;
+namespace py = pybind11;
 
 PYBIND11_MODULE(libnnfw_api_pybind, m)
 {
@@ -33,6 +35,10 @@ PYBIND11_MODULE(libnnfw_api_pybind, m)
   // Currently, the `infer` session is the same as common.
   auto infer = m.def_submodule("infer", "Inference submodule");
   infer.attr("nnfw_session") = m.attr("nnfw_session");
+
+  // Bind our NNFW-status exceptions
+  auto ex = m.def_submodule("exception", "NNFW-status Exception");
+  bind_nnfw_exceptions(ex);
 
   // Bind experimental `NNFW_SESSION` class
   auto experimental = m.def_submodule("experimental", "Experimental submodule");

--- a/runtime/onert/api/python/src/bindings/nnfw_exception_bindings.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_exception_bindings.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nnfw_exception_bindings.h"
+
+#include "nnfw_exceptions.h"
+
+#include <pybind11/pybind11.h>
+
+namespace onert::api::python
+{
+
+namespace py = pybind11;
+
+void bind_nnfw_exceptions(py::module_ &m)
+{
+  // register base first
+  py::register_exception<NnfwError>(m, "OnertError", PyExc_RuntimeError);
+
+  // derived exceptions, each inheriting from NnfwError in Python as well
+  py::register_exception<NnfwUnexpectedNullError>(m, "OnertUnexpectedNullError",
+                                                  m.attr("OnertError").cast<py::object>());
+  py::register_exception<NnfwInvalidStateError>(m, "OnertInvalidStateError",
+                                                m.attr("OnertError").cast<py::object>());
+  py::register_exception<NnfwOutOfMemoryError>(m, "OnertOutOfMemoryError",
+                                               m.attr("OnertError").cast<py::object>());
+  py::register_exception<NnfwInsufficientOutputError>(m, "OnertInsufficientOutputError",
+                                                      m.attr("OnertError").cast<py::object>());
+  py::register_exception<NnfwDeprecatedApiError>(m, "OnertDeprecatedApiError",
+                                                 m.attr("OnertError").cast<py::object>());
+}
+
+} // namespace onert::api::python

--- a/runtime/onert/api/python/src/wrapper/nnfw_api_wrapper.cc
+++ b/runtime/onert/api/python/src/wrapper/nnfw_api_wrapper.cc
@@ -15,6 +15,7 @@
  */
 
 #include "nnfw_api_wrapper.h"
+#include "nnfw_exceptions.h"
 
 #include <iostream>
 
@@ -28,85 +29,54 @@ void ensure_status(NNFW_STATUS status)
   switch (status)
   {
     case NNFW_STATUS::NNFW_STATUS_NO_ERROR:
-      break;
+      return;
     case NNFW_STATUS::NNFW_STATUS_ERROR:
-      std::cout << "[ERROR]\tNNFW_STATUS_ERROR\n";
-      exit(1);
+      throw NnfwError("NNFW_STATUS_ERROR");
     case NNFW_STATUS::NNFW_STATUS_UNEXPECTED_NULL:
-      std::cout << "[ERROR]\tNNFW_STATUS_UNEXPECTED_NULL\n";
-      exit(1);
+      throw NnfwUnexpectedNullError("NNFW_STATUS_UNEXPECTED_NULL");
     case NNFW_STATUS::NNFW_STATUS_INVALID_STATE:
-      std::cout << "[ERROR]\tNNFW_STATUS_INVALID_STATE\n";
-      exit(1);
+      throw NnfwInvalidStateError("NNFW_STATUS_INVALID_STATE");
     case NNFW_STATUS::NNFW_STATUS_OUT_OF_MEMORY:
-      std::cout << "[ERROR]\tNNFW_STATUS_OUT_OF_MEMORY\n";
-      exit(1);
+      throw NnfwOutOfMemoryError("NNFW_STATUS_OUT_OF_MEMORY");
     case NNFW_STATUS::NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE:
-      std::cout << "[ERROR]\tNNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE\n";
-      exit(1);
+      throw NnfwInsufficientOutputError("NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE");
     case NNFW_STATUS::NNFW_STATUS_DEPRECATED_API:
-      std::cout << "[ERROR]\tNNFW_STATUS_DEPRECATED_API\n";
-      exit(1);
+      throw NnfwDeprecatedApiError("NNFW_STATUS_DEPRECATED_API");
+    default:
+      throw NnfwError("NNFW_UNKNOWN_ERROR");
   }
 }
 
 NNFW_LAYOUT getLayout(const char *layout)
 {
-  if (!strcmp(layout, "NCHW"))
-  {
+  if (std::strcmp(layout, "NCHW") == 0)
     return NNFW_LAYOUT::NNFW_LAYOUT_CHANNELS_FIRST;
-  }
-  else if (!strcmp(layout, "NHWC"))
-  {
+  else if (std::strcmp(layout, "NHWC") == 0)
     return NNFW_LAYOUT::NNFW_LAYOUT_CHANNELS_LAST;
-  }
-  else if (!strcmp(layout, "NONE"))
-  {
+  else if (std::strcmp(layout, "NONE") == 0)
     return NNFW_LAYOUT::NNFW_LAYOUT_NONE;
-  }
   else
-  {
-    std::cout << "[ERROR]\tLAYOUT_TYPE\n";
-    exit(1);
-  }
+    throw NnfwError(std::string("Unknown layout type: '") + layout + "'");
 }
 
 NNFW_TYPE getType(const char *type)
 {
-  if (!strcmp(type, "float32"))
-  {
+  if (std::strcmp(type, "float32") == 0)
     return NNFW_TYPE::NNFW_TYPE_TENSOR_FLOAT32;
-  }
-  else if (!strcmp(type, "int32"))
-  {
+  else if (std::strcmp(type, "int32") == 0)
     return NNFW_TYPE::NNFW_TYPE_TENSOR_INT32;
-  }
-  else if (!strcmp(type, "uint8"))
-  {
+  else if (std::strcmp(type, "bool") == 0)
     return NNFW_TYPE::NNFW_TYPE_TENSOR_UINT8;
-    // return NNFW_TYPE::NNFW_TYPE_TENSOR_QUANT8_ASYMM;
-  }
-  else if (!strcmp(type, "bool"))
-  {
+  else if (std::strcmp(type, "bool") == 0)
     return NNFW_TYPE::NNFW_TYPE_TENSOR_BOOL;
-  }
-  else if (!strcmp(type, "int64"))
-  {
+  else if (std::strcmp(type, "int64") == 0)
     return NNFW_TYPE::NNFW_TYPE_TENSOR_INT64;
-  }
-  else if (!strcmp(type, "int8"))
-  {
+  else if (std::strcmp(type, "int8") == 0)
     return NNFW_TYPE::NNFW_TYPE_TENSOR_QUANT8_ASYMM_SIGNED;
-  }
-  else if (!strcmp(type, "int16"))
-  {
+  else if (std::strcmp(type, "int16") == 0)
     return NNFW_TYPE::NNFW_TYPE_TENSOR_QUANT16_SYMM_SIGNED;
-  }
   else
-  {
-    std::cout << "[ERROR] String to NNFW_TYPE Failure\n";
-    exit(1);
-  }
+    throw NnfwError(std::string("Cannot convert string to NNFW_TYPE: '") + type + "'");
 }
 
 const char *getStringType(NNFW_TYPE type)
@@ -129,8 +99,8 @@ const char *getStringType(NNFW_TYPE type)
     case NNFW_TYPE::NNFW_TYPE_TENSOR_QUANT16_SYMM_SIGNED:
       return "int16";
     default:
-      std::cout << "[ERROR] NNFW_TYPE to String Failure\n";
-      exit(1);
+      throw NnfwError(std::string("Cannot convert NNFW_TYPE enum to string (value=") +
+                      std::to_string(static_cast<int>(type)) + ")");
   }
 }
 


### PR DESCRIPTION
This commit introduces NNFW exception bindings and comprehensive error handling.
- Add `nnfw_exception_bindings.h` and `nnfw_exceptions.h` to define C++ exception types for NNFW errors
- Bind all `NnfwError` subclasses into the Python module under a new exception submodule
- Update `nnfw_api_wrapper` to replace `exit(1)` calls with throwing the corresponding NnfwError exceptions
- Refactor `getLayout`, `getType` and `getStringType` to throw `NnfwError` on invalid inputs instead of exiting
- In Python wrappers (`BaseSession`, `session`, and convenience functions), catch generic errors and rethrow them as `OnertError` with context
- Ensure all C-API calls in Python raise `OnertError` on failure, improving robustness and traceback clarity

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>