### PR TITLE
[onert] Replace input filters with `getUsedInputSet()`

### DIFF
--- a/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
+++ b/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
@@ -139,7 +139,7 @@ protected:
     for (const auto &op_ind : _data.op_order)
     {
       const auto &op = graph()->operations().at(op_ind);
-      auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+      auto op_inputs = op.getUsedInputSet();
       auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
 
       // Define outputs

--- a/runtime/onert/backend/train/BackendContext.cc
+++ b/runtime/onert/backend/train/BackendContext.cc
@@ -56,8 +56,7 @@ void AddBackPropInitializers(const ir::train::TrainableGraph &tgraph, TensorRegi
     // The function added latest is executed first in a sequence during backwarding.
     std::vector<BackPropTensor *> back_props;
     const auto &op = tgraph.operation(op_index);
-    for (const auto &back_prop_index :
-         op.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+    for (const auto &back_prop_index : op.getUsedInputSet())
     {
       assert(op.isRequiredForBackward());
       if (unvisited.contains(back_prop_index))
@@ -89,8 +88,7 @@ getBackwardTensorList(const ir::train::TrainableGraph &tgraph,
     const auto &trainable_op = tgraph.operation(op_index);
     assert(trainable_op.isRequiredForBackward());
     // This assumes that back-propagated tensors of loss outputs are not used
-    for (const auto &ind :
-         trainable_op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (const auto &ind : trainable_op.getUsedInputSet())
     {
       if (external_operands.contains(ind))
         continue;

--- a/runtime/onert/backend/train/TensorPlanner.cc
+++ b/runtime/onert/backend/train/TensorPlanner.cc
@@ -84,7 +84,7 @@ void TensorPlanner::planNonConstTensors(TensorBuilder *tensor_builder)
   for (const auto &op_index : order)
   {
     const auto &op = _tgraph.operations().at(op_index);
-    auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_inputs = op.getUsedInputSet();
     auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
 
     // Define outputs
@@ -151,7 +151,7 @@ void TensorPlanner::planNonConstTensors(TensorBuilder *tensor_builder)
   for (const auto &op_index : border)
   {
     const auto &op = _tgraph.operations().at(op_index);
-    auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_inputs = op.getUsedInputSet();
     auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
 
     for (const auto &index : op_inputs + op_outputs)
@@ -315,7 +315,7 @@ void TensorPlanner::planBackPropTensors(TensorBuilder *tensor_builder)
   for (const auto &op_ind : border)
   {
     const auto &op = _tgraph.operations().at(op_ind);
-    auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_inputs = op.getUsedInputSet();
     auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
 
     // Allocate back-propagated tensors in first def
@@ -415,7 +415,7 @@ void TensorPlanner::planGradientTensors(TensorBuilder *tensor_builder)
     std::vector<ir::train::TrainingOperandIndex> cur_seq;
     const auto &op = _tgraph.operations().at(op_index);
     const auto backwarding_op_index = ir::train::TrainingOperationIndex{op_index, false};
-    auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_inputs = op.getUsedInputSet();
 
     // Only inputs can be candidates for def of backwarding tensors
     for (const auto &input : op_inputs)
@@ -487,7 +487,7 @@ ir::OperandIndexSequence TensorPlanner::getOutgoingBackPropSeq(const ir::Operati
   ir::OperandIndexSequence ret;
 
   const auto &op = _tgraph.operation(op_index);
-  for (const auto &input : (op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED))
+  for (const auto &input : op.getUsedInputSet())
   {
     if (_external_operands.contains(input))
       continue;

--- a/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
@@ -94,7 +94,7 @@ void planTensors(const std::shared_ptr<T_TensorBuilder> &tensor_builder, const i
   for (const auto &op_ind : op_order)
   {
     const auto &op = graph.operations().at(op_ind);
-    auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_inputs = op.getUsedInputSet();
     auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
 
     // Define outputs

--- a/runtime/onert/core/include/ir/IOperation.h
+++ b/runtime/onert/core/include/ir/IOperation.h
@@ -39,6 +39,7 @@ struct IOperation
   virtual void replaceInputs(const OperandIndex &from, const OperandIndex &to) = 0;
   virtual void replaceOutputs(const OperandIndex &from, const OperandIndex &to) = 0;
   virtual const OperandIndexSequence &getInputs() const = 0;
+  virtual OperandIndexSequence getUsedInputSet() const = 0;
   virtual const OperandIndexSequence &getOutputs() const = 0;
 };
 

--- a/runtime/onert/core/include/ir/Operation.h
+++ b/runtime/onert/core/include/ir/Operation.h
@@ -50,6 +50,7 @@ public:
   void replaceOutputs(const OperandIndex &from, const OperandIndex &to) override;
   OperandIndexSequence &getInputs() { return _inputs; }
   const OperandIndexSequence &getInputs() const override { return _inputs; }
+  OperandIndexSequence getUsedInputSet() const override;
   const OperandIndexSequence &getOutputs() const override { return _outputs; }
   // It's for only input/output tensors but const data.
   void setInputs(const OperandIndexSequence &indexes);

--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -125,6 +125,7 @@ public:
    */
   bool hasUnspecifiedDims() const
   {
+    assert(_dimensions.size() > 0);
     return (std::find(_dimensions.begin(), _dimensions.end(), kUnspecifiedDim) !=
             _dimensions.end());
   }

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -440,7 +440,7 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
     for (const auto &op_ind : order)
     {
       const auto &op = graph.operations().at(op_ind);
-      auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+      auto op_inputs = op.getUsedInputSet();
       auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
 
       for (const auto &ind : op_inputs)
@@ -813,7 +813,7 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
     for (const auto &op_ind : order)
     {
       const auto &op = graph.operations().at(op_ind);
-      auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+      auto op_inputs = op.getUsedInputSet();
       auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
 
       for (const auto &ind : op_inputs)

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -914,7 +914,7 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
     VERBOSE(Fp32ToFp16Converter) << "Delete Node " << first_node_ind << std::endl;
 
     // Uses
-    for (const auto &ind : first_node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (const auto &ind : first_node.getUsedInputSet())
     {
       auto &obj = operands.at(ind);
       obj.removeUse(first_node_ind);

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -61,7 +61,7 @@ void StaticShapeInferer::infer()
 
     // Automatically mark any input with a dynamic dimension (-1)
     // so its shape is computed at execution time.
-    for (const auto &idx : op.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+    for (const auto &idx : op.getUsedInputSet())
     {
       auto &input = _lowered_subg->graph().operands().at(idx);
       const auto &shape = input.info().shape();
@@ -111,7 +111,7 @@ void StaticShapeInferer::infer()
 bool StaticShapeInferer::checkDynamicInput(const ir::IOperation &op)
 {
   const auto &operands = _lowered_subg->graph().operands();
-  for (auto &&input_idx : op.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+  for (auto &&input_idx : op.getUsedInputSet())
   {
     if (operands.at(input_idx).info().isDynamic())
     {

--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -26,7 +26,7 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::I
 {
   const auto backend = _lowered_graph.lower_info().operation.at(node_index);
 
-  for (const auto &input : node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+  for (const auto &input : node.getUsedInputSet())
   {
     auto &object = _graph.operands().at(input);
 

--- a/runtime/onert/core/src/compiler/pass/ConstantLoweringPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantLoweringPass.cc
@@ -29,7 +29,7 @@ void ConstantLoweringPass::callback(const ir::OperationIndex &node_index, ir::IO
   const auto backend = _lowered_graph.lower_info().operation.at(node_index);
 
   // Now this runtime does not support the node making output of operation as constant
-  for (const auto &input : node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+  for (const auto &input : node.getUsedInputSet())
   {
     auto &object = _graph.operands().at(input);
     if (object.isConstant())

--- a/runtime/onert/core/src/compiler/train/StaticBackwardShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/train/StaticBackwardShapeInferer.cc
@@ -56,7 +56,7 @@ void StaticBackwardShapeInferer::dump()
 bool StaticBackwardShapeInferer::checkDynamicInput(const ir::IOperation &op)
 {
   const auto &operands = _lowered_subg->graph().operands();
-  for (const auto &input_idx : op.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+  for (const auto &input_idx : op.getUsedInputSet())
   {
     if (operands.at(input_idx).info().isDynamic())
     {

--- a/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.cc
@@ -25,7 +25,7 @@ namespace onert::compiler::train::pass
 void TrainableConstantInsertionPass::callback(const ir::OperationIndex &node_index,
                                               ir::IOperation &node)
 {
-  for (const auto &input : node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+  for (const auto &input : node.getUsedInputSet())
   {
     auto &object = _graph.operands().at(input);
 

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -42,7 +42,7 @@ OperandIndex Graph::addOperand(OperandIndex index, std::unique_ptr<Operand> &&op
 
 bool Graph::checkOperandsForOperation(const IOperation &operation)
 {
-  auto inputs = operation.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
+  auto inputs = operation.getUsedInputSet();
   auto outputs = operation.getOutputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
   for (auto &&input : inputs)
     if (!operands().exist(input))
@@ -55,7 +55,7 @@ bool Graph::checkOperandsForOperation(const IOperation &operation)
 
 void Graph::linkOperandToOperation(OperationIndex index, const IOperation &operation)
 {
-  auto inputs = operation.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
+  auto inputs = operation.getUsedInputSet();
   auto outputs = operation.getOutputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
 
   for (auto &&input : inputs)

--- a/runtime/onert/core/src/ir/Operation.cc
+++ b/runtime/onert/core/src/ir/Operation.cc
@@ -50,6 +50,11 @@ void Operation::setOutputs(const OperandIndexSequence &indexes)
   _outputs = indexes;
 }
 
+OperandIndexSequence Operation::getUsedInputSet() const
+{
+  return _inputs | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
+}
+
 void Operation::replaceInputs(const OperandIndex &from, const OperandIndex &to)
 {
   _inputs.replace(from, to);

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -54,7 +54,7 @@ void disableUnusedBackwardNodes(const UseDefChains &training_usedefs, TrainableG
       });
 
     // NOTE Backward op does not define any incoming operand in backwarding
-    const auto &inputs = node.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
+    const auto &inputs = node.getUsedInputSet();
     const bool is_backward_op_def =
       std::any_of(inputs.begin(), inputs.end(), [&](const OperandIndex &input) {
         const auto training_op_index = TrainingOperationIndex{op_index, false};
@@ -288,7 +288,7 @@ std::vector<ir::OperationIndex> TrainableGraph::btopolSortOperations() const
       return;
     unvisited.remove(index);
 
-    for (const auto &input : op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (const auto &input : op.getUsedInputSet())
     {
       const auto &operand = operands().at(input);
       const auto &def = operand.getDef();

--- a/runtime/onert/core/src/ir/train/UseDefGenerator.cc
+++ b/runtime/onert/core/src/ir/train/UseDefGenerator.cc
@@ -81,7 +81,7 @@ void UseDefGenerator::visit(const train::operation::BinaryArithmetic &node)
     insertUse(out_forwarding_index, backwarding_op_index);
   }
 
-  for (const auto &in_index : node.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+  for (const auto &in_index : node.getUsedInputSet())
   {
     // Insert use of forwarding inputs
     const auto in_forwarding_index = TrainingOperandIndex{in_index, true};
@@ -185,7 +185,7 @@ void UseDefGenerator::visit(const train::operation::ElementwiseActivation &node)
   insertUse(out_forwarding_index, backwarding_op_index);
 
   // Set def of backwarding(backprop) inputs
-  for (const auto &in_index : node.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+  for (const auto &in_index : node.getUsedInputSet())
   {
     const auto outgoing_index = TrainingOperandIndex{in_index, false};
     insertBackPropDef(outgoing_index, backwarding_op_index);
@@ -236,7 +236,7 @@ void UseDefGenerator::visit(const train::operation::Loss &node)
   const auto &op_index = _node_to_idx.at(&node);
   const auto backwarding_op_index = TrainingOperationIndex{op_index, false};
 
-  for (const auto &in_index : node.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+  for (const auto &in_index : node.getUsedInputSet())
   {
     // Insert use of forwarding inputs
     const auto in_forwarding_index = TrainingOperandIndex{in_index, true};


### PR DESCRIPTION
This commit replaces input filters with `getUsedInputSet()`
- Replace all occurrences of `op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED` with `op.getUsedInputSet()`
- Add `virtual OperandIndexSequence getUsedInputSet() const` to `ir::IOperation`
- Implement `getUsedInputSet()` in `Operation` to return `_inputs | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED`
- Add `assert(_dimensions.size() > 0)` in `Shape::hasUnspecifiedDims()` to prevent empty dimension lists

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>