### PR TITLE
[github] Clean up build-circle-intp workflow

### DIFF
--- a/.github/workflows/build-circle-intp.yml
+++ b/.github/workflows/build-circle-intp.yml
@@ -1,4 +1,4 @@
-name: Build circle-interpreter
+name: Build circle-interpreter debian package
 
 on:
   # TODO turn on schedule
@@ -17,93 +17,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  onecc-test:
+  configure:
     if: github.repository_owner == 'Samsung'
-    strategy:
-      matrix:
-        ubuntu_code: [ focal, jammy ]
-        include:
-          - ubuntu_code: focal
-            ubuntu_ver: 2004
-            # TODO update comment ID, these are experimental IDs of issue #14669
-            comment_id: 2658267907
-          - ubuntu_code: jammy
-            ubuntu_ver: 2204
-            comment_id: 2658268060
+    name: Set current date and time
     runs-on: ubuntu-latest
-    container:
-      image: nnfw/one-devtools:${{ matrix.ubuntu_code }}
-      options: --user root
-    env:
-      NNCC_WORKSPACE : build
-      NNCC_INSTALL_PREFIX : install
-    name: circle-interpreter ubuntu ${{ matrix.ubuntu_ver }}
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install required packages
+      - name: Set date and time
         run: |
-          apt-get update
-          apt-get install curl
+          echo "TODO: Setting date and time"
+
+  debian-release:
+    needs: configure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare, set distro versions
+        run: |
+          echo "TODO: Prepare and set distro versions"
 
       - name: Build without test
         run: |
-          CIR_INTP_ITEMS="angkor;cwrap;pepper-str;pepper-strcast;pepper-csv2vec;pp"
-          CIR_INTP_ITEMS="${CIR_INTP_ITEMS};oops;loco;logo-core;logo;locop"
-          CIR_INTP_ITEMS="${CIR_INTP_ITEMS};hermes;hermes-std;safemain;mio-circle08"
-          CIR_INTP_ITEMS="${CIR_INTP_ITEMS};luci-compute;luci;luci-interpreter"
-          CIR_INTP_ITEMS="${CIR_INTP_ITEMS};foder;arser;vconone;circle-interpreter"
-          echo ${CIR_INTP_ITEMS}
-
-          ./nncc configure \
-            -DENABLE_STRICT_BUILD=ON \
-            -DENABLE_TEST=OFF \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DEXTERNALS_BUILD_THREADS=$(nproc) \
-            -DCMAKE_INSTALL_PREFIX=${NNCC_INSTALL_PREFIX} \
-            -DBUILD_WHITELIST="${CIR_INTP_ITEMS}"
-          ./nncc build -j$(nproc)
-          cmake --build ${NNCC_WORKSPACE} -- install
+          echo "TODO: Build without test
 
       - name: Gather files
         run: |
-          cd ${NNCC_WORKSPACE}
-          mkdir -p cirintp
-          cp -v ./${NNCC_INSTALL_PREFIX}/bin/circle-interpreter ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libloco.so ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libluci_env.so ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libluci_import.so ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libluci_interpreter.so ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libluci_lang.so ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libluci_logex.so ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libluci_log.so ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libluci_plan.so ./cirintp/.
-          cp -v ./${NNCC_INSTALL_PREFIX}/lib/libluci_profile.so ./cirintp/.
+          echo "TODO: Gather files"
 
       - name: Upload Artifact
-        id: step-upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: circle_intp_${{ matrix.ubuntu_ver }}
-          # TODO enable retention-days, default is 90
-          # retention-days: 3
-          path: |
-            ${{ env.NNCC_WORKSPACE }}/cirintp/
-
-      # refer https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#update-an-issue-comment
-      # TODO update comment id from experiment to official
-      # TODO enable update URL when key is available
-      - name: Update URL
-        if: false
         run: |
-          echo "Artifact URL is ${{ steps.step-upload.outputs.artifact-url }}"
-          COMMENT_ADDR=https://api.github.com/repos/Samsung/ONE/issues/comments/${{ matrix.comment_id }}
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.COMMENT_UPDATE_KEY }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            ${COMMENT_ADDR} \
-            -d '{"body":"${{ steps.step-upload.outputs.artifact-url }}"}'
+          echo "TODO: Upload Artifact"
+
+  create-pr-on-success:
+    name: Create changelog update PR on success
+    needs: debian-release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create PR branch and commit changelog
+      run: |
+        echo "TODO: Create PR branch and commit changelog"


### PR DESCRIPTION
This removes all outdated content and restructures the workflow with initial jobs:
`configure`, `debian-release`, and `create-pr-on-success`.

The detailed steps will be completed in the following PRs.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>