### PR TITLE
[onert] Initialize Tensor size to 0 for dynamic shapes

### DIFF
--- a/runtime/onert/core/include/backend/basic/Tensor.h
+++ b/runtime/onert/core/include/backend/basic/Tensor.h
@@ -36,8 +36,10 @@ public:
   virtual ~Tensor();
 
 public:
+  // Initialize _size to 0 because actual buffer size may be unknown until inference for dynamic
+  // shapes including unknown dimensions
   Tensor(const ir::OperandInfo &info, DynamicMemoryManager *dynamic_mem_mgr)
-    : IPortableTensor(info), _buffer(nullptr), _size(info.total_size()), _num_references(0),
+    : IPortableTensor(info), _buffer(nullptr), _size(0), _num_references(0),
       _dynamic_mem_mgr(dynamic_mem_mgr), _allocator(nullptr)
   {
     // DO NOTHING


### PR DESCRIPTION
This commit initialize Tensor size to 0 for dynamic shapes. instead of total size.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>