### PR TITLE
[infra] Update onert external cache usage

### DIFF
--- a/.github/workflows/build-pub-dev-docker.yml
+++ b/.github/workflows/build-pub-dev-docker.yml
@@ -75,11 +75,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: externals
-          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
-            external-onert-
-            external-
 
       - name: Download rootfs for cross build
         uses: dawidd6/action-download-artifact@v7
@@ -124,11 +122,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: externals
-          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
-            external-onert-
-            external-
 
       - name: Build
         run: make -f Makefile.template
@@ -156,11 +152,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: externals
-          key: external-onert-ndk-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onert-ndk-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-ndk-
-            external-onert-
-            external-
 
       - name: Build onert
         run: make -f Makefile.template
@@ -191,11 +185,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: externals
-          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
-            external-onert-
-            external-
 
       - name: Build onert
         run: |

--- a/.github/workflows/run-onert-android-build.yml
+++ b/.github/workflows/run-onert-android-build.yml
@@ -61,11 +61,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: externals
-          key: external-onert-ndk-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onert-ndk-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-ndk-
-            external-onert-
-            external-
 
       # numpy: test build
       # scons: arm compute library build

--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -70,11 +70,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: externals
-          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
-            external-onert-
-            external-
 
       - name: Download rootfs for cross build
         uses: dawidd6/action-download-artifact@v7

--- a/.github/workflows/run-onert-native-build.yml
+++ b/.github/workflows/run-onert-native-build.yml
@@ -72,11 +72,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: externals
-          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
-            external-onert-
-            external-
+
       - name: Build onert
         run: |
           make -f Makefile.template


### PR DESCRIPTION
This commit updates onert external cache key usage
- Don't use hash in infra/cmake. It is not used on onert build any more
- Remove restore-key 'external': block sharing between runtime and compiler
- Remove restore-key 'external-onert': block sharing between different ubuntu version

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>