### PR TITLE
[onert] Change tensor size initialization

### DIFF
--- a/runtime/onert/core/include/backend/basic/Tensor.h
+++ b/runtime/onert/core/include/backend/basic/Tensor.h
@@ -36,14 +36,7 @@ public:
   virtual ~Tensor();
 
 public:
-  // Initialize _size to 0 because actual buffer size may be unknown until inference for dynamic
-  // shapes including unknown dimensions
-  Tensor(const ir::OperandInfo &info, DynamicMemoryManager *dynamic_mem_mgr)
-    : IPortableTensor(info), _buffer(nullptr), _size(0), _num_references(0),
-      _dynamic_mem_mgr(dynamic_mem_mgr), _allocator(nullptr)
-  {
-    // DO NOTHING
-  }
+  Tensor(const ir::OperandInfo &info, DynamicMemoryManager *dynamic_mem_mgr);
 
 public:
   // Only one of two method 'setBuffer' must be called once

--- a/runtime/onert/core/src/backend/basic/Tensor.cc
+++ b/runtime/onert/core/src/backend/basic/Tensor.cc
@@ -24,6 +24,17 @@ namespace onert::backend::basic
 
 Tensor::~Tensor() {}
 
+// Initialize _size to 0 because actual buffer size may be unknown until inference for dynamic
+// shapes including unknown dimensions
+// Otherwise, it should be initialized to total size of operand info
+Tensor::Tensor(const ir::OperandInfo &info, DynamicMemoryManager *dynamic_mem_mgr)
+  : IPortableTensor(info), _buffer(nullptr),
+    _size(info.shape().hasUnspecifiedDims() ? 0 : info.total_size()), _num_references(0),
+    _dynamic_mem_mgr(dynamic_mem_mgr), _allocator(nullptr)
+{
+  // DO NOTHING
+}
+
 void Tensor::setShape(const ir::Shape &new_shape) { _info.shape(new_shape); }
 
 bool Tensor::applyShape(const ir::Shape &new_shape)


### PR DESCRIPTION
This commit updates tensor constructor to initialize size when shape does not have unspecified dimension.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>