### PR TITLE
[github] Introduce matrix strategy

### DIFF
--- a/.github/workflows/pub-circle-int-launchpad.yml
+++ b/.github/workflows/pub-circle-int-launchpad.yml
@@ -65,7 +65,17 @@ jobs:
 
   debian-release:
     needs: configure
+    strategy:
+      matrix:
+        # TODO activate noble
+        ubuntu_code: [ focal, jammy ]
+    name: circle-interpreter ubuntu ${{ matrix.ubuntu_code }}
     runs-on: ubuntu-latest
+    container:
+      image: nnfw/one-devtools:${{ matrix.ubuntu_code }}
+      credentials:
+        username: ${{ secrets.NNFW_DOCKER_USERNAME }}
+        password: ${{ secrets.NNFW_DOCKER_TOKEN }}
     steps:
       - name: Prepare, set distro versions
         run: |


### PR DESCRIPTION
This introduces a matrix strategy to support multiple distributions for the `circle-interpreter` Debian release on Launchpad.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>