### PR TITLE
[one-cmds] Add numpy to one-prepare-venv

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -63,6 +63,7 @@ VER_ONNX_TF=1.10.0
 VER_PYDOT=1.4.2
 VER_TORCH="2.1.2+cpu"
 VER_PROTOBUF=4.23.3
+VER_NUMPY=1.24.3
 
 echo "Setting version for '$DISTRIB_CODENAME'"
 if [[ "$DISTRIB_CODENAME" == "bionic" ]]; then
@@ -116,5 +117,6 @@ PYTHON_PACKAGES+="onnx-tf==${VER_ONNX_TF} "
 PYTHON_PACKAGES+="protobuf==${VER_PROTOBUF} "
 PYTHON_PACKAGES+="fsspec==2024.6.1 "
 PYTHON_PACKAGES+="pydot==${VER_PYDOT} "
+PYTHON_PACKAGES+="numpy==${VER_NUMPY} "
 
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade ${PYTHON_PACKAGES} ${TORCH_SOURCE_OPTION}


### PR DESCRIPTION
This will add numpy as default install package in one-prepare-venv.
