### PR TITLE
[circle-mlir/infra] Fix numpy version to 1.24.3

### DIFF
--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -38,7 +38,7 @@ fi
 VER_TORCH=2.4.1+cpu
 VER_ONNX=1.17.0
 VER_ONNXRUNTIME=1.18.0
-VER_NUMPY=1.24.4
+VER_NUMPY=1.24.3
 
 PIP_TRUSTED_HOST="--trusted-host pypi.org "
 PIP_TRUSTED_HOST+="--trusted-host pypi.python.org "


### PR DESCRIPTION
This will fix to use numpy 1.24.3.
