### PR TITLE
[onert] Replace output filters with `getUsedOutputSet()`

### DIFF
--- a/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
+++ b/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
@@ -140,7 +140,7 @@ protected:
     {
       const auto &op = graph()->operations().at(op_ind);
       auto op_inputs = op.getUsedInputSet();
-      auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+      auto op_outputs = op.getUsedOutputSet();
 
       // Define outputs
       for (const auto &ind : op_outputs)

--- a/runtime/onert/backend/train/TensorPlanner.cc
+++ b/runtime/onert/backend/train/TensorPlanner.cc
@@ -85,7 +85,7 @@ void TensorPlanner::planNonConstTensors(TensorBuilder *tensor_builder)
   {
     const auto &op = _tgraph.operations().at(op_index);
     auto op_inputs = op.getUsedInputSet();
-    auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_outputs = op.getUsedOutputSet();
 
     // Define outputs
     for (const auto &output : op_outputs)
@@ -152,7 +152,7 @@ void TensorPlanner::planNonConstTensors(TensorBuilder *tensor_builder)
   {
     const auto &op = _tgraph.operations().at(op_index);
     auto op_inputs = op.getUsedInputSet();
-    auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_outputs = op.getUsedOutputSet();
 
     for (const auto &index : op_inputs + op_outputs)
     {
@@ -316,7 +316,7 @@ void TensorPlanner::planBackPropTensors(TensorBuilder *tensor_builder)
   {
     const auto &op = _tgraph.operations().at(op_ind);
     auto op_inputs = op.getUsedInputSet();
-    auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_outputs = op.getUsedOutputSet();
 
     // Allocate back-propagated tensors in first def
     for (const auto &outgoing : op_inputs)

--- a/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
@@ -95,7 +95,7 @@ void planTensors(const std::shared_ptr<T_TensorBuilder> &tensor_builder, const i
   {
     const auto &op = graph.operations().at(op_ind);
     auto op_inputs = op.getUsedInputSet();
-    auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+    auto op_outputs = op.getUsedOutputSet();
 
     // Define outputs
     for (const auto &ind : op_outputs)

--- a/runtime/onert/core/include/ir/IOperation.h
+++ b/runtime/onert/core/include/ir/IOperation.h
@@ -41,6 +41,7 @@ struct IOperation
   virtual const OperandIndexSequence &getInputs() const = 0;
   virtual OperandIndexSequence getUsedInputSet() const = 0;
   virtual const OperandIndexSequence &getOutputs() const = 0;
+  virtual OperandIndexSequence getUsedOutputSet() const = 0;
 };
 
 } // namespace onert::ir

--- a/runtime/onert/core/include/ir/Operation.h
+++ b/runtime/onert/core/include/ir/Operation.h
@@ -52,6 +52,7 @@ public:
   const OperandIndexSequence &getInputs() const override { return _inputs; }
   OperandIndexSequence getUsedInputSet() const override;
   const OperandIndexSequence &getOutputs() const override { return _outputs; }
+  OperandIndexSequence getUsedOutputSet() const override;
   // It's for only input/output tensors but const data.
   void setInputs(const OperandIndexSequence &indexes);
   void setOutputs(const OperandIndexSequence &indexes);

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -441,7 +441,7 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
     {
       const auto &op = graph.operations().at(op_ind);
       auto op_inputs = op.getUsedInputSet();
-      auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+      auto op_outputs = op.getUsedOutputSet();
 
       for (const auto &ind : op_inputs)
       {
@@ -814,7 +814,7 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
     {
       const auto &op = graph.operations().at(op_ind);
       auto op_inputs = op.getUsedInputSet();
-      auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+      auto op_outputs = op.getUsedOutputSet();
 
       for (const auto &ind : op_inputs)
       {

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -923,7 +923,7 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
     }
 
     // Def
-    for (const auto &ind : first_node.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (const auto &ind : first_node.getUsedOutputSet())
     {
       auto &obj = operands.at(ind);
       assert(obj.getDef() == first_node_ind);

--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -80,8 +80,7 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::I
   }
 
   // Now this runtime does not support the node making output as constant
-  for ([[maybe_unused]] const auto &output :
-       node.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+  for ([[maybe_unused]] const auto &output : node.getUsedOutputSet())
   {
     assert(!_graph.operands().at(output).isConstant());
   }

--- a/runtime/onert/core/src/compiler/train/StaticBackwardShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/train/StaticBackwardShapeInferer.cc
@@ -70,7 +70,7 @@ bool StaticBackwardShapeInferer::checkDynamicInput(const ir::IOperation &op)
 void StaticBackwardShapeInferer::checkOutput(const ir::IOperation &op)
 {
   const auto &bwd_operands = _lowered_subg->trainable_graph().backward_operands();
-  for (const auto &output_idx : op.getOutputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+  for (const auto &output_idx : op.getUsedOutputSet())
   {
     if (!bwd_operands.exist(output_idx))
     {

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -43,7 +43,7 @@ OperandIndex Graph::addOperand(OperandIndex index, std::unique_ptr<Operand> &&op
 bool Graph::checkOperandsForOperation(const IOperation &operation)
 {
   auto inputs = operation.getUsedInputSet();
-  auto outputs = operation.getOutputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
+  auto outputs = operation.getUsedOutputSet();
   for (auto &&input : inputs)
     if (!operands().exist(input))
       return false;
@@ -56,7 +56,7 @@ bool Graph::checkOperandsForOperation(const IOperation &operation)
 void Graph::linkOperandToOperation(OperationIndex index, const IOperation &operation)
 {
   auto inputs = operation.getUsedInputSet();
-  auto outputs = operation.getOutputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
+  auto outputs = operation.getUsedOutputSet();
 
   for (auto &&input : inputs)
     operands().at(input).insertUse(index);
@@ -192,7 +192,7 @@ std::vector<ir::OperationIndex> Graph::topolSortOperations() const
       return;
     unvisited.remove(index);
 
-    for (const auto &output : op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (const auto &output : op.getUsedOutputSet())
     {
       const auto &operand = operands().at(output);
       for (const auto &use : operand.getUses())

--- a/runtime/onert/core/src/ir/Operation.cc
+++ b/runtime/onert/core/src/ir/Operation.cc
@@ -55,6 +55,11 @@ OperandIndexSequence Operation::getUsedInputSet() const
   return _inputs | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
 }
 
+OperandIndexSequence Operation::getUsedOutputSet() const
+{
+  return _outputs | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
+}
+
 void Operation::replaceInputs(const OperandIndex &from, const OperandIndex &to)
 {
   _inputs.replace(from, to);

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -223,7 +223,7 @@ void TrainableGraph::validateTopologicalOrder(std::vector<ir::OperationIndex> or
 
     uint32_t p = position[index];
 
-    for (const auto &output : op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (const auto &output : op.getUsedOutputSet())
     {
       const auto &operand = operands().at(output);
       for (const auto &use : operand.getUses())


### PR DESCRIPTION
This replaces all occurrences of `op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED` with `op.getUsedOutputSet()`.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com