### PR TITLE
[onert] Fix wrong assertion

### DIFF
--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -125,7 +125,6 @@ public:
    */
   bool hasUnspecifiedDims() const
   {
-    assert(_dimensions.size() > 0);
     return (std::find(_dimensions.begin(), _dimensions.end(), kUnspecifiedDim) !=
             _dimensions.end());
   }


### PR DESCRIPTION
This commit removes an unnecessary assertion from `Shape::hasUnspecifiedDims()`.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>