### PR TITLE
[github] Enable root privilege for container usage

### DIFF
--- a/.github/workflows/pub-circle-int-launchpad.yml
+++ b/.github/workflows/pub-circle-int-launchpad.yml
@@ -73,6 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: nnfw/one-devtools:${{ matrix.ubuntu_code }}
+      options: --user root
       credentials:
         username: ${{ secrets.NNFW_DOCKER_USERNAME }}
         password: ${{ secrets.NNFW_DOCKER_TOKEN }}


### PR DESCRIPTION
This grants root privileges when a job runs inside a Docker container.
Without this setting, permission errors may occur when accessing the temporary path.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>