### PR TITLE
[infra/debian] Revise the path of circle-interpreter to be installed

### DIFF
--- a/infra/debian/circle-interpreter/circle-interpreter.install
+++ b/infra/debian/circle-interpreter/circle-interpreter.install
@@ -1,13 +1,13 @@
 # {FILES_TO_INSTALL} {DEST_DIR}
 # bin
-bin/circle-interpreter usr/share/cirint/bin/
+bin/circle-interpreter usr/share/circletools/bin/
 # lib
-libloco.so usr/share/cirint/bin/
-libluci_env.so usr/share/cirint/bin/
-libluci_import.so usr/share/cirint/bin/
-libluci_interpreter.so usr/share/cirint/bin/
-libluci_lang.so usr/share/cirint/bin/
-libluci_logex.so usr/share/cirint/bin/
-libluci_log.so usr/share/cirint/bin/
-libluci_plan.so usr/share/cirint/bin/
-libluci_profile.so usr/share/cirint/bin/
+libloco.so usr/share/circletools/bin/
+libluci_env.so usr/share/circletools/bin/
+libluci_import.so usr/share/circletools/bin/
+libluci_interpreter.so usr/share/circletools/bin/
+libluci_lang.so usr/share/circletools/bin/
+libluci_logex.so usr/share/circletools/bin/
+libluci_log.so usr/share/circletools/bin/
+libluci_plan.so usr/share/circletools/bin/
+libluci_profile.so usr/share/circletools/bin/

--- a/infra/debian/circle-interpreter/circle-interpreter.links
+++ b/infra/debian/circle-interpreter/circle-interpreter.links
@@ -1,2 +1,2 @@
 # bin
-usr/share/cirint/bin/circle-interpreter usr/bin/circle-interpreter
+usr/share/circletools/bin/circle-interpreter usr/bin/circle-interpreter


### PR DESCRIPTION
This will revise the path from `cirint` to `circletools` of `circle-interpreter` installation path.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>