### PR TITLE
[github] Upload changelog to github artifact

### DIFF
--- a/.github/workflows/pub-circle-int-launchpad.yml
+++ b/.github/workflows/pub-circle-int-launchpad.yml
@@ -164,10 +164,29 @@ jobs:
     needs: [ configure, debian-release ]
     if: ${{ success() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_DISTRO: jammy
     steps:
+      - name: Download tarball, ${{ env.DEFAULT_DISTRO }}
+        uses: actions/download-artifact@v4
+        with:
+          name: circle-interpreter_${{ needs.configure.outputs.version }}~${{ env.DEFAULT_DISTRO }}
+
       - name: Copy changelogs
         run: |
-          echo "TODO: Copy changelogs"
+          mkdir changelogs
+          mkdir ${{ env.DEFAULT_DISTRO }}
+          tar -axf circle-interpreter_${{ needs.configure.outputs.version }}~${{ env.DEFAULT_DISTRO }}.orig.tar.xz \
+            -C ${{ env.DEFAULT_DISTRO }}
+          cp ${{ env.DEFAULT_DISTRO }}/cirintp/debian/changelog changelogs/changelog
+
+      - name: Upload artifact, changelogs
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelogs
+          retention-days: 3
+          path: |
+            changelogs
 
   create-pr-on-success:
     needs: [ configure, create-changelog-artifact ]


### PR DESCRIPTION
This implements the creating changelog artifact of circle-interpreter debian package from the default distro jammy.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>