### PR TITLE
[infra/debian] Initial changelog for circle-interpreter

### DIFF
--- a/infra/debian/circle-interpreter/changelog
+++ b/infra/debian/circle-interpreter/changelog
@@ -1,5 +1,5 @@
-circle-interpreter (1.30.0) jammy; urgency=low
+circle-interpreter (1.30.0~202505190000~jammy) jammy; urgency=medium
 
   * First circle-interpreter Debian package release for developers.
 
- -- Saehie Park <saehie.park@gmail.com>  Mon, 23 Apr 2025 10:10:00 +0900
+ -- On-device AI developers <nnfw@samsung.com> Mon, 19 May 2025 00:00:00 +0000


### PR DESCRIPTION
This sets up the initial changelog file for the `circle-interpreter` Debian package.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>