### PR TITLE
[infra/debian] Update changelog for circle-interpreter

### DIFF
--- a/infra/debian/circle-interpreter/changelog
+++ b/infra/debian/circle-interpreter/changelog
@@ -1,3 +1,9 @@
+circle-interpreter (1.30.0~202505191026~jammy) jammy; urgency=medium
+
+  * The first debian package release to the Launchpad.
+
+ -- On-device AI developers <nnfw@samsung.com>  Mon, 19 May 2025 10:36:00 +0000
+
 circle-interpreter (1.30.0~202505190000~jammy) jammy; urgency=medium
 
   * First circle-interpreter Debian package release for developers.


### PR DESCRIPTION
This updates the changelog for circle-interpreter_1.30.0~202505191026.
This PR includes updated changelog after successful debian build.
It is auto-generated PR from github workflow.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>