### PR TITLE
[infra/nncc] Revise cmake minumum to 3.16

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 project(nncc)
 


### PR DESCRIPTION
This will revise cmake minimum required to 3.16.
