### PR TITLE
DRAFT tidy cmake version check

### DIFF
--- a/compiler/common-artifacts/CMakeLists.txt
+++ b/compiler/common-artifacts/CMakeLists.txt
@@ -5,20 +5,7 @@
 #   Ubuntu22.04; default python3.10
 #   Ubuntu24.04; default python3.12
 #   refer https://github.com/Samsung/ONE/issues/9962
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  find_package(PythonInterp 3.8 QUIET)
-  find_package(PythonLibs 3.8 QUIET)
-
-  if(NOT ${PYTHONINTERP_FOUND})
-    message(STATUS "Build common-artifacts: FAILED (Python3 is missing)")
-    return()
-  endif()
-
-  if(${PYTHON_VERSION_MINOR} LESS 8)
-    message(STATUS "Build common-artifacts: FAILED (Need Python version 3.8 or higher)")
-    return()
-  endif()
-else()
+# TODO fix indentation
   # find python 3.8 or above
   find_package(Python 3.8 COMPONENTS Interpreter QUIET)
 
@@ -46,7 +33,6 @@ else()
   endif()
 
   set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-endif()
 
 # Create python virtual environment
 set(VIRTUALENV_OVERLAY "${NNCC_OVERLAY_DIR}/venv")

--- a/compiler/dalgona/CMakeLists.txt
+++ b/compiler/dalgona/CMakeLists.txt
@@ -5,20 +5,7 @@
 #   Ubuntu24.04; default python3.12
 #   refer https://github.com/Samsung/ONE/issues/9962
 # NOTE Require same python version of common-artifacts
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  find_package(PythonInterp 3.8 QUIET)
-  find_package(PythonLibs 3.8 QUIET)
-
-  if(NOT ${PYTHONINTERP_FOUND})
-    message(STATUS "Build dalgona: FAILED (Python3 is missing)")
-    return()
-  endif()
-
-  if(${PYTHON_VERSION_MINOR} LESS 8)
-    message(STATUS "Build dalgona: FAILED (Need Python version 3.8 or higher)")
-    return()
-  endif()
-else()
+# TODO fix indentation
   # find python 3.8 or above
   find_package(Python 3.8 COMPONENTS Development QUIET)
 
@@ -34,7 +21,6 @@ else()
 
   set(PYTHON_INCLUDE_DIRS ${Python_INCLUDE_DIRS})
   set(PYTHON_LIBRARIES ${Python_LIBRARIES})
-endif()
 
 nnas_find_package(Pybind11)
 if(NOT Pybind11_FOUND)

--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -4,20 +4,7 @@
 #   Ubuntu22.04; default python3.10
 #   Ubuntu24.04; explicitly installed python3.8 (default is python3.12)
 #   refer https://github.com/Samsung/ONE/issues/9962
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  find_package(PythonInterp 3.8 QUIET)
-  find_package(PythonLibs 3.8 QUIET)
-
-  if(NOT ${PYTHONINTERP_FOUND})
-    message(STATUS "Build one-cmds: FALSE (Python3 is missing)")
-    return()
-  endif()
-
-  if(${PYTHON_VERSION_MINOR} LESS 8)
-    message(STATUS "Build one-cmds: FALSE (You need to install Python version higher than 3.8)")
-    return()
-  endif()
-else()
+# TODO fix indentation
   find_package(Python 3.8 EXACT COMPONENTS Interpreter QUIET)
   if(NOT Python_FOUND)
     find_package(Python 3.8 COMPONENTS Interpreter QUIET)
@@ -39,7 +26,6 @@ else()
   endif()
 
   set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-endif()
 
 # NOTE these files should not have extensions.
 #      below code will remove extension when copy and install.


### PR DESCRIPTION
Tidy cmake version 3.12 check now unnecessary.