### PR TITLE
[one-cmds] Tidy cmake version check for python

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -4,20 +4,7 @@
 #   Ubuntu22.04; default python3.10
 #   Ubuntu24.04; explicitly installed python3.8 (default is python3.12)
 #   refer https://github.com/Samsung/ONE/issues/9962
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  find_package(PythonInterp 3.8 QUIET)
-  find_package(PythonLibs 3.8 QUIET)
-
-  if(NOT ${PYTHONINTERP_FOUND})
-    message(STATUS "Build one-cmds: FALSE (Python3 is missing)")
-    return()
-  endif()
-
-  if(${PYTHON_VERSION_MINOR} LESS 8)
-    message(STATUS "Build one-cmds: FALSE (You need to install Python version higher than 3.8)")
-    return()
-  endif()
-else()
+# TODO fix indentation
   find_package(Python 3.8 EXACT COMPONENTS Interpreter QUIET)
   if(NOT Python_FOUND)
     find_package(Python 3.8 COMPONENTS Interpreter QUIET)
@@ -39,7 +26,6 @@ else()
   endif()
 
   set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-endif()
 
 # NOTE these files should not have extensions.
 #      below code will remove extension when copy and install.


### PR DESCRIPTION
This will tidy cmake version check for python installation.
cmake is now required to be 3.16.
