### PR TITLE
[infra] Remove duplicate complie options

### DIFF
--- a/infra/nncc/cmake/buildtool/config/config_armv7l-tizen.cmake
+++ b/infra/nncc/cmake/buildtool/config/config_armv7l-tizen.cmake
@@ -14,8 +14,6 @@ include("cmake/buildtool/config/config_linux.cmake")
 
 # addition for arm-linux
 set(FLAGS_COMMON ${FLAGS_COMMON}
-    "-mtune=cortex-a8"
-    "-mfloat-abi=softfp"
     "-funsafe-math-optimizations"
     )
 


### PR DESCRIPTION
For tizen build, 'mtune' and 'mfloat' are already predefined.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>