### PR TITLE
[infra] Use docker build to test Dockerfile update

### DIFF
--- a/.github/workflows/build-dev-docker.yml
+++ b/.github/workflows/build-dev-docker.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          ./nnas build-docker-image --codename ${{ matrix.version }} --tag one-test
+          docker build --file infra/docker/${{ matrix.version }}/Dockerfile --tag one-test .
 
       - name: Test onert build
         env:
@@ -107,7 +107,7 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          ./nnas build-docker-image --codename android-sdk --tag one-test
+          docker build --file infra/docker/android-sdk/Dockerfile --tag one-test .
 
       - name: Test onert build
         env:


### PR DESCRIPTION
This commit changes build command to test Dockerfile update from `build-docker-image` custom command to `docker build` commend directly.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>