### PR TITLE
[cirle-mlir] Disable gtest, gmock installing

### DIFF
--- a/circle-mlir/CMakeLists.txt
+++ b/circle-mlir/CMakeLists.txt
@@ -29,7 +29,8 @@ include(TestCoverage)
 # enable ctest
 include(CTest)
 
-# enable googletest
+# enable googletest but do not install
+set(INSTALL_GTEST OFF)
 include(GTestHelper)
 include(GoogleTest)
 


### PR DESCRIPTION
This will disable gtest and gmock from installing with '--install' command.
