### PR TITLE
[circle-mlir] Add install to Makefile

### DIFF
--- a/circle-mlir/Makefile.sample
+++ b/circle-mlir/Makefile.sample
@@ -24,6 +24,8 @@ CIRCLEMLIR_EXTS_REL?=build/externals/release
 CIRCLEMLIR_PY3_ROOT?=$(PYTHON3_PATH)
 CIRCLEMLIR_BUILD_JOBS?=4
 
+ONE_COMPILER_INSTALL?=$(CURDIR)/../build/install
+
 .PHONY: help all overlay \
 	prep cfg debug test clean \
 	prepr cfgr rel testr cleanr \
@@ -42,6 +44,7 @@ help:
 	@echo "make cfgr     : configure circle-mlir for release build"
 	@echo "make rel      : build for release"
 	@echo "make testr    : test for release"
+	@echo "make install  : install release build to (ONE)/build/install"
 	@echo "make cleanr   : clean release build"
 	@echo "make prepcov  : prepare submodules for coverage test (needed only once)"
 	@echo "make cfgcov   : configure circle-mlir for debug build with coverage test"
@@ -149,6 +152,9 @@ rel:
 testr:
 	CTEST_OUTPUT_ON_FAILURE=1 \
 	cmake --build $(CIRCLEMLIR_BUILD_REL) --verbose -- test
+
+install:
+	cmake --install $(CIRCLEMLIR_BUILD_REL) --prefix $(ONE_COMPILER_INSTALL)
 
 cleanr:
 	rm -f $(CIRCLEMLIR_BUILD_REL)/CMakeCache.txt

--- a/circle-mlir/README.md
+++ b/circle-mlir/README.md
@@ -99,6 +99,13 @@ Test build
 make testr
 ```
 
+Install tools into `(ONE)/build/install`
+```
+make install
+```
+- `onnx2circle` is going to be the default converter of `one-import-onnx` tool
+- this will install `onnx2circle` to `build/install` of compiler
+
 ### Docker build
 
 You can build within Docker image, with pre-built `externals`.


### PR DESCRIPTION
This will add install to Makefile to install release artifacts to (ONE)/build/install.
