### PR TITLE
[one-cmds] Add dependency to directory creation

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -182,7 +182,7 @@ add_custom_command(OUTPUT ${O1_CFG_FILE_BIN}
           --constant ${O1_OPTION}
           --format cfg
           --output_path ${O1_CFG_FILE_BIN}
-  DEPENDS ${CONSTANT_EXPORTING_SCRIPT} ${CONSTANT_SCRIPT}
+  DEPENDS ${CONSTANT_EXPORTING_SCRIPT} ${CONSTANT_SCRIPT} ${ONE_PYTHON_DIR_BIN}
   COMMENT "Generate ${O1_CFG_FILE}"
 )
 


### PR DESCRIPTION
This commit adds a dependency on cfg file creation to the destination directory. 
It prevents build fail by trying to create a cfg file in a non-existing directory.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>