### PR TITLE
[circledump] Dump MX quantization parameters

### DIFF
--- a/compiler/circledump/src/Dump.cpp
+++ b/compiler/circledump/src/Dump.cpp
@@ -190,6 +190,16 @@ void dump_sub_graph(std::ostream &os, mio::circle::Reader &reader)
 
         os << std::endl;
       }
+
+      if (q_params->details_type() == circle::QuantizationDetails_MXQuantization)
+      {
+        const auto &mx_params = q_params->details_as_MXQuantization();
+        std::string strquantiz = "    MX Quantization: ";
+        os << strquantiz;
+        os << "axis (" << mx_params->axis() << ")" << std::endl;
+
+        os << std::endl;
+      }
     }
 
     if (const auto &s_params = tensor->sparsity())


### PR DESCRIPTION
This dumps MX quantization parameters.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/15258
Draft PR: https://github.com/Samsung/ONE/pull/15259