### PR TITLE
[onert] Remove Graph::Phase

### DIFF
--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -30,13 +30,6 @@ namespace onert::ir
 
 class Graph : public IGraph
 {
-private:
-  enum class Phase
-  {
-    BUILDING,
-    MODEL
-  };
-
 public:
   explicit Graph(void);
   explicit Graph(const Graph &);


### PR DESCRIPTION
This commit removes unused enum class Graph::Phase.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>