### PR TITLE
[infra/onert] Rename nnas_include to nnfw_include

### DIFF
--- a/infra/nnfw/CMakeLists.txt
+++ b/infra/nnfw/CMakeLists.txt
@@ -30,9 +30,9 @@ set(EXT_OVERLAY_DIR ${NNFW_OVERLAY_DIR})
 # EXT_OVERLAY_DIR is higher priority than ROOTFS_DIR on cross build
 list(INSERT CMAKE_FIND_ROOT_PATH 0 "${EXT_OVERLAY_DIR}")
 
-macro(nnas_include PREFIX)
+macro(nnfw_include PREFIX)
   include("${NNAS_PROJECT_SOURCE_DIR}/infra/nnfw/cmake/modules/${PREFIX}.cmake")
-endmacro(nnas_include)
+endmacro(nnfw_include)
 
 # Runtime 'find_package()' wrapper to find in cmake/packages folder
 #
@@ -60,7 +60,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # identify platform: HOST_PLATFORM, TARGET_PLATFORM and related
 # note: this should be placed before flags and options setting
-nnas_include(IdentifyPlatform)
+nnfw_include(IdentifyPlatform)
 
 # Configuration flags
 include("cmake/CfgOptionFlags.cmake")
@@ -106,7 +106,7 @@ if(ENABLE_COVERAGE)
   target_link_libraries(nnfw_coverage INTERFACE gcov)
 endif(ENABLE_COVERAGE)
 
-nnas_include(AddSubdirectories)
+nnfw_include(AddSubdirectories)
 
 # Add arser for test driver
 # TODO: Better way to handle this

--- a/infra/nnfw/cmake/modules/ExternalSourceTools.cmake
+++ b/infra/nnfw/cmake/modules/ExternalSourceTools.cmake
@@ -3,7 +3,7 @@
 #
 function(ExternalSource_Download PREFIX)
   include(CMakeParseArguments)
-  nnas_include(StampTools)
+  nnfw_include(StampTools)
 
   cmake_parse_arguments(ARG "" "DIRNAME;URL;CHECKSUM;PATCH" "" ${ARGN})
 

--- a/infra/nnfw/cmake/packages/ARMComputeSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/ARMComputeSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_ARMComputeSource_import)
     return()
   endif(NOT ${DOWNLOAD_ARMCOMPUTE})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(ARMCOMPUTE_URL ${EXTERNAL_DOWNLOAD_SERVER}/ARM-software/ComputeLibrary/archive/v24.07.tar.gz)

--- a/infra/nnfw/cmake/packages/AbseilConfig.cmake
+++ b/infra/nnfw/cmake/packages/AbseilConfig.cmake
@@ -8,7 +8,7 @@ function(_Abseil_import)
   endif(NOT AbseilSource_FOUND)
 
   if(NOT TARGET abseil)
-    nnas_include(ExternalProjectTools)
+    nnfw_include(ExternalProjectTools)
 
     # NOTE Turn off abseil testing
     set(BUILD_TESTING OFF)

--- a/infra/nnfw/cmake/packages/AbseilSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/AbseilSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_AbseilSource_import)
     return()
   endif(NOT DOWNLOAD_ABSEIL)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   # NOTE TensorFlow 2.16.1 downloads abseil from the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")

--- a/infra/nnfw/cmake/packages/CpuInfoConfig.cmake
+++ b/infra/nnfw/cmake/packages/CpuInfoConfig.cmake
@@ -14,7 +14,7 @@ function(_CpuInfo_Build)
     return()
   endif(NOT CpuInfoSource_FOUND)
 
-  nnas_include(ExternalProjectTools)
+  nnfw_include(ExternalProjectTools)
 
   # Set build option
   # - Static (position independent)

--- a/infra/nnfw/cmake/packages/CpuInfoSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/CpuInfoSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_CpuInfoSource_import)
     return()
   endif(NOT ${DOWNLOAD_CPUINFO})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   # CPUINFO commit for RISC-V bug fix

--- a/infra/nnfw/cmake/packages/Egl_HeadersSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/Egl_HeadersSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_Egl_HeadersSource_import)
     return()
   endif(NOT DOWNLOAD_EGL_HEADERS)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(EGL_HEADERS_URL ${EXTERNAL_DOWNLOAD_SERVER}/KhronosGroup/EGL-Registry/archive/649981109e263b737e7735933c90626c29a306f2.zip)

--- a/infra/nnfw/cmake/packages/EigenSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/EigenSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_EigenSource_import)
     return()
   endif(NOT DOWNLOAD_EIGEN)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   # Exact version used by TensorFlow v2.16.1.
   # See tensorflow/third_party/eigen3/workspace.bzl.

--- a/infra/nnfw/cmake/packages/FarmhashConfig.cmake
+++ b/infra/nnfw/cmake/packages/FarmhashConfig.cmake
@@ -7,7 +7,7 @@ function(_Farmhash_import)
   endif(NOT FarmhashSource_FOUND)
 
   if(NOT TARGET farmhash)
-    nnas_include(ExternalProjectTools)
+    nnfw_include(ExternalProjectTools)
     add_extdirectory("${CMAKE_CURRENT_LIST_DIR}/Farmhash" farmhash)
   endif(NOT TARGET farmhash)
 

--- a/infra/nnfw/cmake/packages/FarmhashSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/FarmhashSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_FarmhashSource_import)
     return()
   endif(NOT DOWNLOAD_FARMHASH)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   # NOTE TensorFlow 2.16.1 downloads farmhash from the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")

--- a/infra/nnfw/cmake/packages/FlatBuffersSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/FlatBuffersSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_FlatBuffersSource_import)
     return()
   endif(NOT DOWNLOAD_FLATBUFFERS)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(FLATBUFFERS_23_5_26_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/flatbuffers/archive/v23.5.26.tar.gz)

--- a/infra/nnfw/cmake/packages/Fp16SourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/Fp16SourceConfig.cmake
@@ -4,8 +4,8 @@ function(_Fp16Source_import)
     return()
   endif(NOT ${DOWNLOAD_FP16})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   # fp16 commit in xnnpack (tflite v2.16.1)

--- a/infra/nnfw/cmake/packages/FxdivSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/FxdivSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_FxdivSource_import)
     return()
   endif(NOT ${DOWNLOAD_FXDIV})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   # fxdiv commit in tflite v2.16.1

--- a/infra/nnfw/cmake/packages/GEMMLowpSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/GEMMLowpSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_GEMMLowpSource_import)
     return()
   endif(NOT DOWNLOAD_GEMMLOWP)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   # Exact version used by TensorFlow v2.16.1.
   # See tensorflow/third_party/gemmlowp/workspace.bzl.

--- a/infra/nnfw/cmake/packages/GTestConfig.cmake
+++ b/infra/nnfw/cmake/packages/GTestConfig.cmake
@@ -7,7 +7,7 @@ if(${DOWNLOAD_GTEST})
   endif(NOT GTestSource_FOUND)
 
   if(NOT TARGET gtest_main)
-    nnas_include(ExternalProjectTools)
+    nnfw_include(ExternalProjectTools)
     add_extdirectory(${GTestSource_DIR} gtest EXCLUDE_FROM_ALL)
   endif(NOT TARGET gtest_main)
 

--- a/infra/nnfw/cmake/packages/GTestSourceConfig copy.cmake
+++ b/infra/nnfw/cmake/packages/GTestSourceConfig copy.cmake
@@ -4,8 +4,8 @@ function(_GTestSource_import)
     return()
   endif(NOT DOWNLOAD_GTEST)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(GTEST_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/googletest/archive/release-1.12.1.tar.gz)

--- a/infra/nnfw/cmake/packages/GTestSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/GTestSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_GTestSource_import)
     return()
   endif(NOT DOWNLOAD_GTEST)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(GTEST_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/googletest/archive/release-1.12.1.tar.gz)

--- a/infra/nnfw/cmake/packages/MLDtypesSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/MLDtypesSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_MLDtypesSource_import)
     return()
   endif(NOT DOWNLOAD_MLDTYPES)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(MLDTYPES_URL ${EXTERNAL_DOWNLOAD_SERVER}/jax-ml/ml_dtypes/archive/2ca30a2b3c0744625ae3d6988f5596740080bbd0/ml_dtypes-2ca30a2b3c0744625ae3d6988f5596740080bbd0.tar.gz)

--- a/infra/nnfw/cmake/packages/NEON2SSESourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/NEON2SSESourceConfig.cmake
@@ -4,8 +4,8 @@ function(_NEON2SSESource_import)
     return()
   endif(NOT DOWNLOAD_NEON2SSE)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   # NOTE TensorFlow 2.16.1 downloads NEON2SSE from the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")

--- a/infra/nnfw/cmake/packages/NoniusSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/NoniusSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_NoniusSource_import)
     return()
   endif(NOT ${DOWNLOAD_NONIUS})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(NONIUS_URL ${EXTERNAL_DOWNLOAD_SERVER}/libnonius/nonius/archive/v1.2.0-beta.1.tar.gz)

--- a/infra/nnfw/cmake/packages/OouraFFTSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/OouraFFTSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_OouraFFTSource_import)
     return()
   endif(NOT DOWNLOAD_OOURAFFT)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   # NOTE TensorFlow 2.3 downloads OOURAFFT from the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")

--- a/infra/nnfw/cmake/packages/Opencl_HeadersSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/Opencl_HeadersSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_Opencl_HeadersSource_import)
     return()
   endif(NOT DOWNLOAD_OPENCL_HEADERS)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(OPENCL_HEADERS_URL ${EXTERNAL_DOWNLOAD_SERVER}/KhronosGroup/OpenCL-Headers/archive/v2021.04.29.tar.gz)

--- a/infra/nnfw/cmake/packages/Opengl_HeadersSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/Opengl_HeadersSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_Opengl_HeadersSource_import)
     return()
   endif(NOT DOWNLOAD_OPENGL_HEADERS)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(OPENGL_HEADERS_URL ${EXTERNAL_DOWNLOAD_SERVER}/KhronosGroup/OpenGL-Registry/archive/0cb0880d91581d34f96899c86fc1bf35627b4b81.zip)

--- a/infra/nnfw/cmake/packages/PsimdSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/PsimdSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_PsimdSource_import)
     return()
   endif(NOT ${DOWNLOAD_PSIMD})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   # psimd commit in xnnpack 8b283aa30a31

--- a/infra/nnfw/cmake/packages/PthreadpoolSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/PthreadpoolSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_PthreadpoolSource_import)
     return()
   endif(NOT ${DOWNLOAD_PTHREADPOOL})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   # pthreadpool commit in xnnpack (tflite v2.16.1)

--- a/infra/nnfw/cmake/packages/Pybind11Config.cmake
+++ b/infra/nnfw/cmake/packages/Pybind11Config.cmake
@@ -7,7 +7,7 @@ function(_Pybind11_Build)
   endif(NOT Pybind11Source_FOUND)
 
   if(NOT TARGET pybind11)
-    nnas_include(ExternalProjectTools)
+    nnfw_include(ExternalProjectTools)
     add_extdirectory(${Pybind11Source_DIR} pybind11 EXCLUDE_FROM_ALL)
   endif(NOT TARGET pybind11)
 

--- a/infra/nnfw/cmake/packages/Pybind11SourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/Pybind11SourceConfig.cmake
@@ -4,8 +4,8 @@ function(_Pybind11Source_import)
     return()
   endif(NOT DOWNLOAD_PYBIND11)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(PYBIND11_URL ${EXTERNAL_DOWNLOAD_SERVER}/pybind/pybind11/archive/v2.13.6.tar.gz)

--- a/infra/nnfw/cmake/packages/RuySourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/RuySourceConfig.cmake
@@ -4,8 +4,8 @@ function(_RuySource_import)
     return()
   endif(NOT DOWNLOAD_RUY)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   # Exact version used by TensorFlow v2.16.1.
   # See tensorflow/third_party/ruy/workspace.bzl

--- a/infra/nnfw/cmake/packages/TensorFlowGpuConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowGpuConfig.cmake
@@ -42,7 +42,7 @@ function(_Build_TfliteGpuDelagate_)
   return_unless(FlatBuffers_FOUND)
 
   if(NOT TARGET TensorFlowGpu)
-    nnas_include(ExternalProjectTools)
+    nnfw_include(ExternalProjectTools)
     add_extdirectory("${CMAKE_CURRENT_LIST_DIR}/TensorFlowLiteGpu" TensorFlowLiteGpu)
   endif()
   set(TensorFlowSource_DIR ${TensorFlowSource_DIR} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/TensorFlowLiteConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowLiteConfig.cmake
@@ -13,8 +13,8 @@ if(BUILD_TENSORFLOW_LITE)
   endif(NOT ${VAR})
   endmacro(return_unless)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   nnfw_find_package(TensorFlowSource QUIET)
   return_unless(TensorFlowSource_FOUND)
@@ -54,7 +54,7 @@ if(BUILD_TENSORFLOW_LITE)
   # Optional packages
   nnfw_find_package(NEON2SSESource QUIET)
 
-  nnas_include(ExternalProjectTools)
+  nnfw_include(ExternalProjectTools)
   add_extdirectory("${CMAKE_CURRENT_LIST_DIR}/TensorFlowLite" tflite-2.16.1)
 
   set(TensorFlowLite_FOUND TRUE)

--- a/infra/nnfw/cmake/packages/TensorFlowSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_TensorFlowSource_import)
     return()
   endif(NOT DOWNLOAD_TENSORFLOW)
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(TENSORFLOW_2_16_1_URL ${EXTERNAL_DOWNLOAD_SERVER}/tensorflow/tensorflow/archive/v2.16.1.tar.gz)

--- a/infra/nnfw/cmake/packages/VulkanSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/VulkanSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_VulkanSource_import)
     return()
   endif(NOT ${DOWNLOAD_VULKAN})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(VULKAN_URL ${EXTERNAL_DOWNLOAD_SERVER}/KhronosGroup/Vulkan-Headers/archive/ec2db85225ab410bc6829251bef6c578aaed5868.tar.gz)

--- a/infra/nnfw/cmake/packages/XnnpackSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/XnnpackSourceConfig.cmake
@@ -4,8 +4,8 @@ function(_XnnpackSource_import)
     return()
   endif(NOT ${DOWNLOAD_XNNPACK})
 
-  nnas_include(ExternalSourceTools)
-  nnas_include(OptionTools)
+  nnfw_include(ExternalSourceTools)
+  nnfw_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   # xnnpack latest commit (2024.05.20)


### PR DESCRIPTION
This commit renames nnas_include macro to nnfw_include. 
It prevents mistakes using the compiler cmake config on runtime build.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #15231
Draft: #15235