### PR TITLE
[one-cmds] Install onnx2circle through env-var

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -91,6 +91,26 @@ foreach(ONE_COMMAND IN ITEMS ${ONE_COMMAND_FILES})
 
 endforeach(ONE_COMMAND)
 
+# if ONE_ONNX2CIRCLE_PATH is set, install that file to bin folder
+if(DEFINED ENV{ONE_ONNX2CIRCLE_PATH})
+  message(STATUS "ONNX2CIRCLE from env-var $ENV{ONE_ONNX2CIRCLE_PATH}")
+  install(FILES $ENV{ONE_BLD_ONNX2CIRCLE_PATH}
+          PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                      GROUP_READ GROUP_EXECUTE
+                      WORLD_READ WORLD_EXECUTE
+          DESTINATION bin)
+else()
+  set(ONNX2CIRCLE_PATH "circle-mlir/build/install/bin/onnx2circle")
+  if (EXISTS ${ONNX2CIRCLE_PATH})
+    message(STATUS "ONNX2CIRCLE from ${ONNX2CIRCLE_PATH}")
+    install(FILES ${ONNX2CIRCLE_PATH}
+            PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                        GROUP_READ GROUP_EXECUTE
+                        WORLD_READ WORLD_EXECUTE
+            DESTINATION bin)
+  endif()
+endif()
+
 set(ONE_UTILITY_FILES
     one-build.template.cfg
     onecc.template.cfg


### PR DESCRIPTION
This will enable to install onnx2circle through env-var if set,
or install from circle-mlir folder if exist.
