### PR TITLE
[infra/onert] Move runtime root cmake

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -37,7 +37,7 @@ endif
 # the toolchain file, only for cross build
 ifeq ($(CROSS_BUILD),1)
 	TOOLCHAIN_FILE=cmake/buildtool/cross/toolchain_$(TARGET_ARCH_LC)-$(TARGET_OS).cmake
-	OPTIONS+= -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)
+	OPTIONS+= -DCMAKE_TOOLCHAIN_FILE=../infra/nnfw/$(TOOLCHAIN_FILE)
 	OPTIONS_NNCC+= -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE)
 endif
 

--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -5,7 +5,7 @@ include(CMakeDependentOption)
 # note: this should be placed before default setting for option setting priority
 #       (platform specific setting have higher priority)
 #
-include("cmake/options/options_${TARGET_PLATFORM}.cmake" OPTIONAL)
+include("${CMAKE_CURRENT_LIST_DIR}/options/options_${TARGET_PLATFORM}.cmake" OPTIONAL)
 
 #
 # Default build configuration for project

--- a/infra/nnfw/cmake/buildtool/config/config_aarch64-android.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_aarch64-android.cmake
@@ -1,4 +1,4 @@
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # SIMD for aarch64
 set(FLAGS_COMMON ${FLAGS_COMMON}

--- a/infra/nnfw/cmake/buildtool/config/config_aarch64-linux.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_aarch64-linux.cmake
@@ -5,7 +5,7 @@
 message(STATUS "Building for AARCH64 Linux")
 
 # include linux common
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # addition for aarch64-linux
 set(FLAGS_COMMON ${FLAGS_COMMON}

--- a/infra/nnfw/cmake/buildtool/config/config_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_aarch64-tizen.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
 
 # TODO : add and use option_tizen if something uncommon comes up
 # include linux common
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # addition for aarch64-tizen
 set(FLAGS_COMMON ${FLAGS_COMMON}

--- a/infra/nnfw/cmake/buildtool/config/config_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7hl-tizen.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
 
 # TODO : add and use option_tizen if something uncommon comes up
 # include linux common
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # addition for arm-linux
 set(FLAGS_COMMON ${FLAGS_COMMON}

--- a/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
 
 # TODO : add and use option_tizen if something uncommon comes up
 # include linux common
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # addition for arm-linux
 set(MFPU_OPTION "-mfpu=neon-vfpv4")

--- a/infra/nnfw/cmake/buildtool/config/config_i686-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_i686-tizen.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
 
 # TODO : add and use option_tizen if something uncommon comes up
 # include linux common
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # addition for i686-tizen
 set(FLAGS_COMMON ${FLAGS_COMMON}

--- a/infra/nnfw/cmake/buildtool/config/config_riscv64-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_riscv64-tizen.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
 
 # TODO : add and use option_tizen if something uncommon comes up
 # include linux common
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # addition for riscv64-tizen
 set(FLAGS_COMMON ${FLAGS_COMMON}

--- a/infra/nnfw/cmake/buildtool/config/config_x86_64-linux.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_x86_64-linux.cmake
@@ -4,7 +4,7 @@
 message(STATUS "Building for x86-64 Linux")
 
 # include linux common
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # SIMD for x86
 set(FLAGS_COMMON ${FLAGS_COMMON}

--- a/infra/nnfw/cmake/buildtool/config/config_x86_64-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_x86_64-tizen.cmake
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
 
 # TODO : add and use option_tizen if something uncommon comes up
 # include linux common
-include("cmake/buildtool/config/config_linux.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # addition for aarch64-tizen
 set(FLAGS_COMMON ${FLAGS_COMMON}

--- a/infra/nnfw/command/configure
+++ b/infra/nnfw/command/configure
@@ -3,4 +3,4 @@
 import "build.configuration"
 
 # Require cmake version >= 3.13 to use '-S' & '-B' option
-cmake -S "${NNFW_PROJECT_PATH}"/infra/nnfw -B ${BUILD_PATH} "$@"
+cmake -S "${NNFW_PROJECT_PATH}"/runtime -B ${BUILD_PATH} "$@"

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 ### CMAKE_BUILD_TYPE_LC: Build type lower case
 string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_LC)
 
-set(NNAS_PROJECT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." CACHE
+set(NNAS_PROJECT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." CACHE
   INTERNAL "Where to find nnas top-level source directory"
 )
 
@@ -43,7 +43,7 @@ endmacro(nnfw_include)
 #  nnfw_find_package(Eigen REQUIRED): Load settings but stop with error when failed
 macro(nnfw_find_package PREFIX)
   find_package(${PREFIX} CONFIG NO_DEFAULT_PATH
-    PATHS ${CMAKE_SOURCE_DIR}/cmake/packages
+    PATHS ${NNAS_PROJECT_SOURCE_DIR}/infra/nnfw/cmake/packages
     ${ARGN}
   )
 endmacro(nnfw_find_package)
@@ -63,7 +63,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 nnfw_include(IdentifyPlatform)
 
 # Configuration flags
-include("cmake/CfgOptionFlags.cmake")
+include("${NNAS_PROJECT_SOURCE_DIR}/infra/nnfw/cmake/CfgOptionFlags.cmake")
 # and besides CfgOptionFlags.cmake that can be given outside
 #   COVERAGE_BUILD: build boolean flag that enables converage test
 #   ROOTFS_DIR: rootfs path for cross building
@@ -73,7 +73,7 @@ include("cmake/CfgOptionFlags.cmake")
 # apply compilation flags
 # NOTE This should be placed after cmake/CfgOptionFlags.cmake files include
 #      because compile flag setting can be decided using option (ex. ENABLE_COVERAGE)
-include("cmake/ApplyCompileFlags.cmake")
+include("${NNAS_PROJECT_SOURCE_DIR}/infra/nnfw/cmake/ApplyCompileFlags.cmake")
 
 nnfw_find_package(GTest QUIET)
 
@@ -115,10 +115,10 @@ if(ENABLE_TEST)
   target_include_directories(arser INTERFACE ${NNAS_PROJECT_SOURCE_DIR}/compiler/arser/include/)
 endif(ENABLE_TEST)
 
-add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/runtime/3rdparty 3rdparty)
-add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/runtime/compute compute)
-add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/runtime/contrib contrib)
-add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/runtime/libs libs)
-add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/runtime/onert onert)
-add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/runtime/tests tests)
-add_subdirectory(${NNAS_PROJECT_SOURCE_DIR}/runtime/tools tools)
+add_subdirectory(3rdparty)
+add_subdirectory(compute)
+add_subdirectory(contrib)
+add_subdirectory(libs)
+add_subdirectory(onert)
+add_subdirectory(tests)
+add_subdirectory(tools)


### PR DESCRIPTION
This commit moves runtime root cmake into `runtime` directory.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/15231
Draft: https://github.com/Samsung/ONE/pull/15235