### PR TITLE
[one-cmds/tests] Prepare for using onnx2circle

### DIFF
--- a/compiler/one-cmds/tests/one-import-onnx_002.test
+++ b/compiler/one-cmds/tests/one-import-onnx_002.test
@@ -15,9 +15,17 @@
 # limitations under the License.
 
 # test for experimental_disable_batchmatmul_unfold option
+# NOTE
+# - for onnx2circle, experimental_disable_batchmatmul_unfold is ignored
+#   and functionally works like ON as default.
+#   that is, batchatmatmul exist as-is.
+# - this test is disabled for this reason.
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
+
+echo "${filename_ext} SKIPPED"
+exit 0
 
 trap_err_onexit()
 {

--- a/compiler/one-cmds/tests/onecc_011.test
+++ b/compiler/one-cmds/tests/onecc_011.test
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # one-import-onnx
+# NOTE
+# - intermediate tflite is not generated anymore with onnx2circle
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
@@ -29,19 +31,14 @@ trap trap_err_onexit ERR
 
 configfile="onecc_011.cfg"
 outputfile="test_onnx_model.circle"
-intermfile="test_onnx_model.tflite"
 
 rm -f ${filename}.log
 rm -rf ${outputfile}
-rm -rf ${intermfile}
 
 # run test
 onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
-  trap_err_onexit
-fi
-if [[ ! -s "${intermfile}" ]]; then
   trap_err_onexit
 fi
 

--- a/compiler/one-cmds/tests/onecc_036.test
+++ b/compiler/one-cmds/tests/onecc_036.test
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # run a workflow where one-import-onnx generates intermediate files
+# NOTE
+# - intermediate tflite is not generated anymore with onnx2circle
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
@@ -29,19 +31,14 @@ trap trap_err_onexit ERR
 
 workflowfile="onecc_036.workflow.json"
 outputfile="test_onnx_model.circle"
-intermfile="test_onnx_model.tflite"
 
 rm -rf ${outputfile}
-rm -rf ${intermfile}
 rm -f ${filename}.log
 
 # run test
 onecc -W ${workflowfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
-  trap_err_onexit
-fi
-if [[ ! -s "${intermfile}" ]]; then
   trap_err_onexit
 fi
 


### PR DESCRIPTION
This will revise tests that are not valid for using onnx2circle.
