### PR TITLE
[one-cmds] Revise import-onnx with model updated

### DIFF
--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -300,6 +300,7 @@ def _convert(args):
 
     onnx_to_convert_path = getattr(args, 'input_path')
     basename = os.path.basename(onnx_to_convert_path)
+    model_updated = False
 
     with open(logfile_path, 'wb') as f, tempfile.TemporaryDirectory() as tmpdir:
         # save intermediate
@@ -308,18 +309,18 @@ def _convert(args):
         # convert onnx to tf saved model
         onnx_model = onnx.load(onnx_to_convert_path)
         _sanitize_io_names(onnx_model)
+        # TODO set model_updated to True only when sanitize updates onnx_model
+        # NOTE with onnx2circle, we may not need sanitize(this needs verification)
+        model_updated = True
         if _onnx_legalizer_enabled:
             options = onnx_legalizer.LegalizeOptions
             options.unroll_rnn = oneutils.is_valid_attr(args, 'unroll_rnn')
             options.unroll_lstm = oneutils.is_valid_attr(args, 'unroll_lstm')
             onnx_legalizer.legalize(onnx_model, options)
+            model_updated = True
         if oneutils.is_valid_attr(args, 'keep_io_order'):
             _remap_io_names(onnx_model)
-            if oneutils.is_valid_attr(args, 'save_intermediate'):
-                fixed_path = os.path.join(tmpdir,
-                                          os.path.splitext(basename)[0] + '~.onnx')
-                onnx.save(onnx_model, fixed_path)
-                onnx_to_convert_path = fixed_path
+            model_updated = True
 
         run_default_import = True
         ext_alt_onnx_path = None
@@ -331,6 +332,11 @@ def _convert(args):
 
             if _force_ext(args):
                 run_default_import = False
+
+        if model_updated:
+            fixed_path = os.path.join(tmpdir, os.path.splitext(basename)[0] + '~.onnx')
+            onnx.save(onnx_model, fixed_path)
+            onnx_to_convert_path = fixed_path
 
         res_conv = -1
         if run_default_import:


### PR DESCRIPTION
This will revise one-import-onnx to save temporary file when in-memory model has been updated.
