### PR TITLE
[infra/debian] Fix the trailer line of changelog

### DIFF
--- a/infra/debian/circle-interpreter/changelog
+++ b/infra/debian/circle-interpreter/changelog
@@ -8,4 +8,4 @@ circle-interpreter (1.30.0~202505190000~jammy) jammy; urgency=medium
 
   * First circle-interpreter Debian package release for developers.
 
- -- On-device AI developers <nnfw@samsung.com> Mon, 19 May 2025 00:00:00 +0000
+ -- On-device AI developers <nnfw@samsung.com>  Mon, 19 May 2025 00:00:00 +0000


### PR DESCRIPTION
This fixes the trailer line in the changelog file for the `circle-interpreter` Debian package.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>