### PR TITLE
[circle-mlir/infra] Create debian rules and related files

### DIFF
--- a/circle-mlir/infra/debian/onnx2circle/onnx2circle.install
+++ b/circle-mlir/infra/debian/onnx2circle/onnx2circle.install
@@ -1,0 +1,3 @@
+# {FILES_TO_INSTALL} {DEST_DIR}
+# bin
+bin/onnx2circle usr/share/circletools/bin/

--- a/circle-mlir/infra/debian/onnx2circle/onnx2circle.links
+++ b/circle-mlir/infra/debian/onnx2circle/onnx2circle.links
@@ -1,0 +1,2 @@
+# bin
+usr/share/circletools/bin/onnx2circle usr/bin/onnx2circle

--- a/circle-mlir/infra/debian/onnx2circle/onnx2circle.links
+++ b/circle-mlir/infra/debian/onnx2circle/onnx2circle.links
@@ -1,2 +1,0 @@
-# bin
-usr/share/circletools/bin/onnx2circle usr/bin/onnx2circle

--- a/circle-mlir/infra/debian/onnx2circle/rules
+++ b/circle-mlir/infra/debian/onnx2circle/rules
@@ -1,0 +1,37 @@
+#!/usr/bin/make -f
+
+export NNCC_INSTALL_PREFIX=$(CURDIR)
+export DEBIAN_PREFIX=$(CURDIR)/debian/tmp
+
+%:
+	dh $@
+
+override_dh_auto_clean:
+	# Nothing to clean
+	true
+
+override_dh_auto_configure:
+	# No configure step needed
+	true
+
+override_dh_auto_build:
+	# No build step needed
+	true
+
+override_dh_auto_test:
+	# No test step needed
+	true
+
+override_dh_auto_install:
+	# copy the bin file
+	mkdir -p ${DEBIAN_PREFIX}/bin
+	cp ${NNCC_INSTALL_PREFIX}/onnx2circle ${DEBIAN_PREFIX}/bin/
+
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+
+override_dh_strip:
+	dh_strip --no-automatic-dbgsym
+
+override_dh_builddeb:
+	dh_builddeb


### PR DESCRIPTION
This adds the rules and its related files for the `onnx2circle` Debian package installation.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>