### PR TITLE
[github] Implement configure job for the versioning

### DIFF
--- a/.github/workflows/pub-onnx2circle-launchpad.yml
+++ b/.github/workflows/pub-onnx2circle-launchpad.yml
@@ -39,15 +39,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO implement the configure job
   configure:
     if: github.repository_owner == 'Samsung'
     name: Set current date and time
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-datetime.outputs.version }}
+      br_version: ${{ steps.set-datetime.outputs.br_version }}
     steps:
       - name: Set date and time
+        id: set-datetime
         run: |
-          echo "Set date and time"
+          base_version="${{ inputs.o2c_version }}"
+          is_release="${{ inputs.is_release }}"
+          if [[ "$is_release" == "true" ]]; then
+            version="${base_version}"
+            br_version="${base_version}"
+          else
+            release_date=$(date +%Y%m%d%H%M)
+            version="${base_version}~${release_date}"
+            br_version="${base_version}-${release_date}"
+          fi
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "br_version=${br_version}" >> $GITHUB_OUTPUT
 
   # TODO implement the debian-release job
   debian-release:


### PR DESCRIPTION
This replaces the placeholder `configure` job with an actual implementation
that generates the Debian version for the `onnx2circle` package.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>