### PR TITLE
[github] Fix test log path of run-onecc-build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -147,6 +147,8 @@ jobs:
       - name: Upload log
         uses: actions/upload-artifact@v4
         if: failure()
+        env:
+          NNCC_INSTALL_PATH : ${{ env.NNCC_WORKSPACE }}/${{ env.NNCC_INSTALL_PREFIX }}
         with:
           name: fail-${{ matrix.ubuntu_code }}-${{ matrix.type }}
           path: |


### PR DESCRIPTION
This will fix test log path of run-onecc-build workflow.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>