### PR TITLE
[github] Implement job to create PR

### DIFF
--- a/.github/workflows/pub-onnx2circle-launchpad.yml
+++ b/.github/workflows/pub-onnx2circle-launchpad.yml
@@ -212,15 +212,63 @@ jobs:
     needs: [ configure, create-changelog-artifact ]
     if: ${{ success() && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
+    env:
+      BR_VERSION: ${{ needs.configure.outputs.br_version }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
+      - name: Prepare, set distro versions
+        id: prepare
+        run: |
+          VERSION="${{ needs.configure.outputs.version }}"
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "Seungho Henry Park"
+          git config --global user.email "shs.park@samsung.com"
+
+      - name: Download tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: changelogs
+
       - name: Update the changelog file
         run: |
-          echo "Update the changelog file"
+          cp changelog circle-mlir/infra/debian/onnx2circle/
 
       - name: Create PR branch and commit changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Create PR branch and commit changelog"
+          BRANCH=auto/update-o2c-changelog-${BR_VERSION}
+          git checkout -b ${BRANCH}
+          git add circle-mlir/infra/debian/onnx2circle/changelog
+          git commit -m "[circle-mlir/infra] Update changelog for onnx2circle" \
+            -m "This updates the changelog for onnx2circle_${{ steps.prepare.outputs.VERSION }}." \
+            -m "It is auto-generated PR from github workflow." \
+            -m "" \
+            -m "ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>"
+          git push origin ${BRANCH}
 
       - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.SHSPARK_GITHUB_TOKEN }}
         run: |
-          echo "Create PR"
+          BRANCH=auto/update-o2c-changelog-${BR_VERSION}
+          gh pr create \
+            --title "[circle-mlir/infra] Update changelog for onnx2circle" \
+            --body "$(cat <<EOF
+          This updates the changelog for onnx2circle_${{ steps.prepare.outputs.VERSION }}.
+          This PR includes updated changelog after successful debian build.
+          It is auto-generated PR from github workflow.
+
+          ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>
+          EOF
+          )" \
+            --head "${BRANCH}" \
+            --base "master"


### PR DESCRIPTION
This adds steps to create a pull request that updates the changelog,
after the `onnx2circle` Debian package is uploaded to Launchpad.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>