### PR TITLE
[circle-mlir] Bump onnx2circle version to 0.3.0

### DIFF
--- a/.github/workflows/pub-onnx2circle-launchpad.yml
+++ b/.github/workflows/pub-onnx2circle-launchpad.yml
@@ -10,7 +10,7 @@ on:
       o2c_version:
         description: 'The version of onnx2circle'
         required: true
-        default: '0.2.0'
+        default: '0.3.0'
       o2c_description:
         description: 'Description of changelog for onnx2circle'
         required: true

--- a/circle-mlir/circle-mlir/tools/onnx2circle/src/onnx2circle.cpp
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/src/onnx2circle.cpp
@@ -198,7 +198,7 @@ int convertToCircle(const O2Cparam &param)
 } // namespace onnx2circle
 
 // NOTE sync version number with 'infra/debian/*/changelog' for upgrade
-const char *__version = "0.2.0";
+const char *__version = "0.3.0";
 
 int entry(const O2Cparam &param)
 {


### PR DESCRIPTION
This updates the version of `onnx2circle` from `0.2.0` to `0.3.0`,
as it now includes updated versions of `llvm-project` and `onnx-mlir`.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>