### PR TITLE
DRAFT check run-onecc-build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -77,12 +77,6 @@ jobs:
           add-apt-repository ppa:deadsnakes/ppa
           apt-get -qqy install python3.10 python3.10-dev python3.10-venv
 
-      # dalgona uses pybind11, but pybind11 cannot bind packages in virtualenv.
-      # So we need to install packages for dalgona-test globally.
-      - name: Install required packages
-        run: |
-          python3 -m pip install numpy h5py==3.11.0 flatbuffers==23.5.26
-
       - name: Caching externals
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
on-going draft to check run-onecc-build without python packages for dalgona.