### PR TITLE
[CI] Use deb https:// for run-onecc-build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -61,6 +61,11 @@ jobs:
     name: onecc ubuntu ${{ matrix.ubuntu_ver }} ${{ matrix.type }} test
 
     steps:
+      - name: Temporary update to use deb https://
+        run: |
+          cd /etc/apt
+          sed -i 's|deb http://|deb https://|g' sources.list
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This will temporary update to use 'deb https://' for run-onecc-build.
