### PR TITLE
[onert] Add `nnfw_get_output` C API for Python bindings

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_internal.h
+++ b/runtime/onert/api/nnfw/include/nnfw_internal.h
@@ -46,4 +46,28 @@ NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer,
  */
 NNFW_STATUS nnfw_train_export_circleplus(nnfw_session *session, const char *file_path);
 
+/**
+ * @brief Python-binding-only API to retrieve a read-only output buffer and its tensor info
+ *
+ * After nnfw_run has been called, the session has already resized or allocated the internal output
+ * buffer to match the latest output dimensions. This API simply retrieves that internal buffer
+ * pointer and the corresponding tensor info without performing any allocation itself.
+ *
+ * Note: this function is intended for Python binding only. The buffer is managed internally by the
+ * session and must not be modified by the caller. In Python, wrap the pointer as a NumPy array and
+ * set array.flags.writeable = False to enforce read-only access.
+ *
+ * Important: To use this API, you must call
+ * nnfw_set_prepare_config(session, NNFW_ENABLE_INTERNAL_OUTPUT_ALLOC, "true")
+ * before calling nnfw_prepare().
+ *
+ * @param[in]    session     The session object
+ * @param[in]    index       Output tensor index
+ * @param[out]   out_info    nnfw_tensorinfo to be filled with the latest shape/type information
+ * @param[out]   out_buffer  Pointer to a const buffer managed by the session
+ * @return       NNFW_STATUS_NO_ERROR on success, otherwise an error code
+ */
+NNFW_STATUS nnfw_get_output(nnfw_session *session, uint32_t index, nnfw_tensorinfo *out_info,
+                            const void **out_buffer);
+
 #endif // __NNFW_INTERNAL_H__

--- a/runtime/onert/api/nnfw/src/nnfw_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_internal.cc
@@ -50,3 +50,10 @@ NNFW_STATUS nnfw_train_export_circleplus(nnfw_session *session, const char *path
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->train_export_circleplus(path);
 }
+
+NNFW_STATUS nnfw_get_output(nnfw_session *session, uint32_t index, nnfw_tensorinfo *out_info,
+                            const void **out_buffer)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->get_output(index, out_info, out_buffer);
+}

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -828,6 +828,32 @@ NNFW_STATUS nnfw_session::register_custom_operation(const std::string &id,
   return NNFW_STATUS_NO_ERROR;
 }
 
+NNFW_STATUS nnfw_session::get_output(uint32_t index, nnfw_tensorinfo *ti, const void **out_buffer)
+{
+  if (ti == nullptr)
+  {
+    std::cerr << "Error during nnfw_session::get_output : tensor info is null" << std::endl;
+    return NNFW_STATUS_UNEXPECTED_NULL;
+  }
+
+  if (out_buffer == nullptr)
+  {
+    std::cerr << "Error during nnfw_session::get_output : output buffer is null" << std::endl;
+    return NNFW_STATUS_UNEXPECTED_NULL;
+  }
+
+  if (!isStateFinishedRun())
+  {
+    std::cerr << "Error during nnfw_session::get_output : invalid state" << std::endl;
+    return NNFW_STATUS_INVALID_STATE;
+  }
+
+  // TODO Get output tensorinfo and buffer
+  (void)index;
+
+  return NNFW_STATUS_NO_ERROR;
+}
+
 NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
 {
   if (!isStateModelLoaded())

--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -139,6 +139,7 @@ public:
   NNFW_STATUS set_config(const char *key, const char *value);
   NNFW_STATUS get_config(const char *key, char *value, size_t value_size);
   NNFW_STATUS load_circle_from_buffer(uint8_t *buffer, size_t size);
+  NNFW_STATUS get_output(uint32_t index, nnfw_tensorinfo *out_info, const void **out_buffer);
 
   //
   // Experimental API


### PR DESCRIPTION
This commit adds `nnfw_get_output` API as nnfw internal api for Python bindings.
- Implement `nnfw_get_output` to retrieve the output buffer and tensor info after `nnfw_run`.
- Update `nnfw_session` to include the `get_output` method.
- Add necessary error handling for invalid state and null pointers.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>


---

For #15342 
Draft #15455 