### PR TITLE
[onert] Add `NNFW_ENABLE_INTERNAL_OUTPUT_ALLOC` config.

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -624,6 +624,10 @@ typedef enum
    * TODO: Use workspace
    */
   NNFW_PREPARE_CONFIG_PROFILE,
+  /**
+   * Enable internal allocation for model outputs instead of using external buffer
+   */
+  NNFW_ENABLE_INTERNAL_OUTPUT_ALLOC,
 } NNFW_PREPARE_CONFIG;
 
 /**

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -1942,6 +1942,9 @@ NNFW_STATUS nnfw_session::set_prepare_config(const NNFW_PREPARE_CONFIG key, cons
     case NNFW_PREPARE_CONFIG_PROFILE:
       _coptions->he_profiling_mode = true;
       break;
+    case NNFW_ENABLE_INTERNAL_OUTPUT_ALLOC:
+      _coptions->internal_output_alloc = true;
+      break;
     default:
       return NNFW_STATUS_ERROR;
   }

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -68,10 +68,12 @@ struct CompilerOptions
   int graph_dump_level; //< Graph dump level, values between 0 and 2 are valid
   std::string executor; //< Executor name to use
   ManualSchedulerOptions manual_scheduler_options; //< Options for ManualScheduler
-  bool he_scheduler;         //< HEScheduler if true, ManualScheduler otherwise
-  bool he_profiling_mode;    //< Whether HEScheduler profiling mode ON/OFF
-  bool fp16_enable;          //< Whether fp16 mode ON/OFF
-  std::string workspace_dir; //< Workspace directory path
+  bool he_scheduler;          //< HEScheduler if true, ManualScheduler otherwise
+  bool he_profiling_mode;     //< Whether HEScheduler profiling mode ON/OFF
+  bool internal_output_alloc; //< Whether to enable dynamic allocation of output buffers
+                              //  internally
+  bool fp16_enable;           //< Whether fp16 mode ON/OFF
+  std::string workspace_dir;  //< Workspace directory path
 };
 
 } // namespace onert::compiler


### PR DESCRIPTION
This commit add `NNFW_ENABLE_INTERNAL_OUTPUT_ALLOC` configuration as an external API to allow internal allocation of model output.
- Append `NNFW_ENABLE_INTERNAL_OUTPUT_ALLOC` to `NNFW_PREPARE_CONFIG`.
- Handle the new prepare config key in nnfw_session::set_prepare_config.
- Add `internal_output_alloc` field to CompilerOptions for tracking this feature.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #15342 
Draft #15455 