### PR TITLE
[CI] add ensurepip to run-onecc-build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           add-apt-repository ppa:deadsnakes/ppa
           apt-get -qqy install python3.10 python3.10-dev python3.10-venv
+          python3.10 -m ensurepip --upgrade
 
       # dalgona uses pybind11, but pybind11 cannot bind packages in virtualenv.
       # So we need to install packages for dalgona-test globally.


### PR DESCRIPTION
This will add to ensure pip in run-onecc-build workflow.
