### PR TITLE
[common-artifacts] Introduce ONE_PYTHON_VERSION_MINOR

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -92,6 +92,11 @@ function(add_compiler_directory DIR)
     message(STATUS "Configure ${PREFIX}")
     add_subdirectory(${DIR})
     message(STATUS "Configure ${PREFIX} - Done")
+    # NOTE ONE_PYTHON_VERSION_MINOR is to provide python3.x minor version number
+    # to modules that use common artifacts.
+    if(DEFINED ONE_PYTHON_VERSION_MINOR)
+      set(ONE_PYTHON_VERSION_MINOR ${ONE_PYTHON_VERSION_MINOR} PARENT_SCOPE)
+    endif()
   endif(ENABLE)
 endfunction(add_compiler_directory)
 

--- a/compiler/common-artifacts/CMakeLists.txt
+++ b/compiler/common-artifacts/CMakeLists.txt
@@ -29,6 +29,10 @@ else()
   return()
 endif()
 
+# NOTE ONE_PYTHON_VERSION_MINOR is to provide current python3.x minor version
+# number to modules that use common artifacts.
+set(ONE_PYTHON_VERSION_MINOR ${PYTHON_VERSION_MINOR} PARENT_SCOPE)
+
 set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
 
 # Create python virtual environment


### PR DESCRIPTION
This will introduce ONE_PYTHON_VERSION_MINOR for modules using
common-artifacts virtual-env to utilize python 3.x minior version numnber.
