### PR TITLE
[CI] Remove python pkgs install from run-onecc-build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -78,12 +78,6 @@ jobs:
           apt-get -qqy install python3.10 python3.10-dev python3.10-venv
           python3.10 -m ensurepip --upgrade
 
-      # dalgona uses pybind11, but pybind11 cannot bind packages in virtualenv.
-      # So we need to install packages for dalgona-test globally.
-      - name: Install required packages
-        run: |
-          python3 -m pip install numpy h5py==3.11.0 flatbuffers==23.5.26
-
       - name: Caching externals
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This will remove installing python packages from run-onecc-build workflow.
These are not necessary anymore.
