### PR TITLE
[circle-mlir/infra] Update changelog for onnx2circle

### DIFF
--- a/circle-mlir/infra/debian/onnx2circle/changelog
+++ b/circle-mlir/infra/debian/onnx2circle/changelog
@@ -1,3 +1,9 @@
+onnx2circle (0.3.0~202506050531~jammy) jammy; urgency=medium
+
+  * Revised Mul to Div
+
+ -- On-device AI developers <nnfw@samsung.com>  Thu, 05 Jun 2025 05:41:50 +0000
+
 onnx2circle (0.3.0~202505290100~jammy) jammy; urgency=medium
 
   * Reflects updates to bundled llvm-project and onnx-mlir components


### PR DESCRIPTION
This updates the changelog for onnx2circle_0.3.0~202506050531.
This PR includes updated changelog after successful debian build.
It is auto-generated PR from github workflow.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>