### PR TITLE
[record-minmax] Call closedir

### DIFF
--- a/compiler/record-minmax/src/DirectoryIterator.cpp
+++ b/compiler/record-minmax/src/DirectoryIterator.cpp
@@ -46,6 +46,8 @@ DirectoryIterator::DirectoryIterator(const std::string &dir_path, luci::Module *
     _entries.emplace_back(entry);
   }
 
+  closedir(dir);
+
   auto input_nodes = loco::input_nodes(module->graph());
   for (auto input_node : input_nodes)
   {


### PR DESCRIPTION
This commit calls closedir to prevent memory leakage.

This is from static analysis tool.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>