### PR TITLE
[github] Fix run-circle-mlir-build exclude

### DIFF
--- a/.github/workflows/run-circle-mlir-build.yml
+++ b/.github/workflows/run-circle-mlir-build.yml
@@ -8,9 +8,8 @@ on:
     paths:
       - '.github/workflows/run-circle-mlir-build.yml'
       - 'circle-mlir/**'
-    paths-ignore:
-      - 'circle-mlir/infra/debian/**'
-      - 'circle-mlir/infra/docker/**'
+      - '!circle-mlir/infra/debian/**'
+      - '!circle-mlir/infra/docker/**'
   pull_request:
     branches:
       - master
@@ -18,9 +17,8 @@ on:
     paths:
       - '.github/workflows/run-circle-mlir-build.yml'
       - 'circle-mlir/**'
-    paths-ignore:
-      - 'circle-mlir/infra/debian/**'
-      - 'circle-mlir/infra/docker/**'
+      - '!circle-mlir/infra/debian/**'
+      - '!circle-mlir/infra/docker/**'
 
 defaults:
   run:


### PR DESCRIPTION
This will path exclusion using '!'.
