### PR TITLE
[infra/onert] Move flatbuffer host build cmake

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -148,7 +148,7 @@ $(WORKSPACE):
 	mkdir -p $@
 
 prepare_buildtool_internal: $(WORKSPACE)
-	cmake -S infra/buildtool -B $(BUILDTOOL_WORKSPACE)/obj -DBUILDTOOL_PATH=$(BUILDTOOL_PATH)
+	cmake -S runtime/infra/buildtool -B $(BUILDTOOL_WORKSPACE)/obj -DBUILDTOOL_PATH=$(BUILDTOOL_PATH)
 	cmake --build $(BUILDTOOL_WORKSPACE)/obj/ -j$(NPROCS)
 prepare_nncc_internal: $(WORKSPACE)
 ifeq (,$(findstring android,$(TARGET_OS)))

--- a/runtime/infra/buildtool/CMakeLists.txt
+++ b/runtime/infra/buildtool/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 3.16.3)
 
 project(nnas_buildtool)
 
-set(NNAS_PROJECT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." CACHE
+set(ONERT_PROJECT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." CACHE
   INTERNAL "Where to find nnas top-level source directory"
 )
-set(NNAS_EXTERNALS_DIR
-  "${NNAS_PROJECT_SOURCE_DIR}/externals" CACHE
+set(ONERT_EXTERNALS_DIR
+  "${ONERT_PROJECT_SOURCE_DIR}/externals" CACHE
   INTERNAL "Where to download external dependencies"
 )
 
@@ -14,11 +14,11 @@ if(NOT DEFINED BUILDTOOL_PATH)
   message(FATAL_ERROR "BUILDTOOL_PATH is not defined")
 endif()
 
-macro(nnas_include PREFIX)
-  include("${NNAS_PROJECT_SOURCE_DIR}/infra/cmake/modules/${PREFIX}.cmake")
-endmacro(nnas_include)
+macro(nnfw_include PREFIX)
+  include("${ONERT_PROJECT_SOURCE_DIR}/infra/cmake/modules/${PREFIX}.cmake")
+endmacro(nnfw_include)
 
-nnas_include(OptionTools)
+nnfw_include(OptionTools)
 envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
 # Sync with traditional external download tool: server login
 # TODO Migrate external download tool
@@ -31,17 +31,15 @@ else()
   envoption(EXTERNAL_SERVER_PASSWORD "")
 endif()
 
-set(FLATBUFFERS_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/flatbuffers/archive/v23.5.26.tar.gz)
+set(FLATBUFFERS_URL https://github.com/google/flatbuffers/archive/v23.5.26.tar.gz)
 
 # Download and build Flatbuffers 23.5.26
 include(ExternalProject)
 ExternalProject_Add(flatbuffers-23.5.26
   URL ${FLATBUFFERS_URL}
-  HTTP_USERNAME ${EXTERNAL_SERVER_USERNAME}
-  HTTP_PASSWORD ${EXTERNAL_SERVER_PASSWORD}
   PREFIX  ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers
-  SOURCE_DIR  ${NNAS_EXTERNALS_DIR}/FLATBUFFERS-23.5.26
-  STAMP_DIR ${NNAS_EXTERNALS_DIR}/external-stamp
+  SOURCE_DIR  ${ONERT_EXTERNALS_DIR}/FLATBUFFERS-23.5.26
+  STAMP_DIR ${ONERT_EXTERNALS_DIR}/external-stamp
   INSTALL_DIR ${BUILDTOOL_PATH}
   CMAKE_ARGS  -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${BUILDTOOL_PATH}
               -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF
@@ -49,8 +47,8 @@ ExternalProject_Add(flatbuffers-23.5.26
 
 # Sync with traditional external download tool - stamp
 # TODO Migrate external download tool
-nnas_include(StampTools)
-set(STAMP_PATH "${NNAS_EXTERNALS_DIR}/FLATBUFFERS-23.5.26.stamp")
+nnfw_include(StampTools)
+set(STAMP_PATH "${ONERT_EXTERNALS_DIR}/FLATBUFFERS-23.5.26.stamp")
 Stamp_Check(URL_CHECK "${STAMP_PATH}" "${FLATBUFFERS_URL}")
 if(NOT URL_CHECK)
   file(WRITE "${STAMP_PATH}" "${FLATBUFFERS_URL}")


### PR DESCRIPTION
This commit moves flatbuffer host build cmake.
It is used on onert on-device compiler cross build.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #15231