### PR TITLE
[circle-mlir/infra] Update changelog for onnx2circle

### DIFF
--- a/circle-mlir/infra/debian/onnx2circle/changelog
+++ b/circle-mlir/infra/debian/onnx2circle/changelog
@@ -1,3 +1,9 @@
+onnx2circle (0.4.0~202506100012~jammy) jammy; urgency=medium
+
+  * Fix ResizeBilinear with int64
+
+ -- On-device AI developers <nnfw@samsung.com>  Tue, 10 Jun 2025 00:22:23 +0000
+
 onnx2circle (0.3.0~202506050623~jammy) jammy; urgency=medium
 
   * Added ConvertDivToMul in pass


### PR DESCRIPTION
This updates the changelog for onnx2circle_0.4.0~202506100012.
This PR includes updated changelog after successful debian build.
It is auto-generated PR from github workflow.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>