### PR TITLE
[onert/python] Expose internal output and prepare_config API

### DIFF
--- a/runtime/onert/api/python/include/nnfw_api_wrapper.h
+++ b/runtime/onert/api/python/include/nnfw_api_wrapper.h
@@ -19,6 +19,7 @@
 
 #include "nnfw.h"
 #include "nnfw_experimental.h"
+#include "nnfw_internal.h"
 
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
@@ -171,6 +172,16 @@ public:
   void set_output_layout(uint32_t index, const char *layout);
   tensorinfo input_tensorinfo(uint32_t index);
   tensorinfo output_tensorinfo(uint32_t index);
+
+  //////////////////////////////////////////////
+  // Internal APIs
+  //////////////////////////////////////////////
+  py::array get_output(uint32_t index);
+
+  //////////////////////////////////////////////
+  // Experimental APIs for inference
+  //////////////////////////////////////////////
+  void set_prepare_config(NNFW_PREPARE_CONFIG config);
 
   //////////////////////////////////////////////
   // Experimental APIs for training

--- a/runtime/onert/api/python/include/nnfw_tensorinfo_bindings.h
+++ b/runtime/onert/api/python/include/nnfw_tensorinfo_bindings.h
@@ -29,6 +29,9 @@ namespace python
 // Declare binding tensorinfo
 void bind_tensorinfo(pybind11::module_ &m);
 
+// Declare binding enums
+void bind_nnfw_enums(pybind11::module_ &m);
+
 } // namespace python
 } // namespace api
 } // namespace onert

--- a/runtime/onert/api/python/src/bindings/nnfw_api_wrapper_pybind.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_api_wrapper_pybind.cc
@@ -48,6 +48,9 @@ PYBIND11_MODULE(libnnfw_api_pybind, m)
   // Bind common `tensorinfo` class
   bind_tensorinfo(m);
 
+  // Bind enums
+  bind_nnfw_enums(m);
+
   m.doc() = "NNFW Python Bindings for Training";
 
   // Bind training enums

--- a/runtime/onert/api/python/src/bindings/nnfw_session_bindings.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_session_bindings.cc
@@ -225,7 +225,7 @@ void bind_nnfw_session(py::module_ &m)
          Parameters:
              index (int): Index of the output tensor (0-indexed)
          Returns:
-             numpy.ndarray: a read-only copy of the internal buffer
+             numpy.ndarray: a copy of the internal buffer
          )pbdoc")
     .def("set_prepare_config", &NNFW_SESSION::set_prepare_config, py::arg("config"),
          "Set configuration to prepare");

--- a/runtime/onert/api/python/src/bindings/nnfw_session_bindings.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_session_bindings.cc
@@ -218,7 +218,17 @@ void bind_nnfw_session(py::module_ &m)
          "Parameters:\n"
          "\tindex (int): Index of output\n"
          "Returns:\n"
-         "\ttensorinfo: Tensor info (shape, type, etc)");
+         "\ttensorinfo: Tensor info (shape, type, etc)")
+    .def("get_output", &NNFW_SESSION::get_output, py::arg("index"),
+         R"pbdoc(
+         Retrieve the internally-allocated dynamic output as a copy.
+         Parameters:
+             index (int): Index of the output tensor (0-indexed)
+         Returns:
+             numpy.ndarray: a read-only copy of the internal buffer
+         )pbdoc")
+    .def("set_prepare_config", &NNFW_SESSION::set_prepare_config, py::arg("config"),
+         "Set configuration to prepare");
 }
 
 // Bind the `NNFW_SESSION` class with experimental APIs

--- a/runtime/onert/api/python/src/bindings/nnfw_tensorinfo_bindings.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_tensorinfo_bindings.cc
@@ -37,4 +37,12 @@ void bind_tensorinfo(py::module_ &m)
       "The dimension of tensor. Maximum rank is 6 (NNFW_MAX_RANK).");
 }
 
+void bind_nnfw_enums(py::module_ &m)
+{
+  // Bind NNFW_TRAIN_LOSS
+  py::enum_<NNFW_PREPARE_CONFIG>(m, "prepare_config", py::module_local())
+    .value("PREPARE_CONFIG_PROFILE", NNFW_PREPARE_CONFIG_PROFILE)
+    .value("ENABLE_INTERNAL_OUTPUT_ALLOC", NNFW_ENABLE_INTERNAL_OUTPUT_ALLOC);
+}
+
 } // namespace onert::api::python


### PR DESCRIPTION
This commit exposes internal get_output and prepare_config API in Python bindings.
- Include nnfw_internal.h in the Python API wrapper header
- Add `get_output(uint32_t index)` method to NNFW_SESSION wrapper, returning a read-only NumPy copy
- Register `get_output` and `set_prepare_config` in the pybind11 module
- Introduce `bind_nnfw_enums` to expose the NNFW_PREPARE_CONFIG enum values

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #15342 
Draft #15455 