### PR TITLE
[onert] Reposition LowerInfo in PermutationEliminationPass

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -157,6 +157,9 @@ createBackendContexts(compiler::ILoweredGraph &lgraph, bool linear_executor,
     data.graph = std::move(graph);
   };
 
+  // Append builtin context
+  init_context_data(compiler::BackendManager::get().getBuiltin());
+
   auto &whole_graph = lgraph.graph();
   // Separate operands into partial graphs
   whole_graph.operands().iterate([&](const ir::OperandIndex &operand_ind, ir::Operand &operand) {

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -90,10 +90,10 @@ void LoweredGraph::lowerGraph(const CompilerOptions &options)
     .append(std::make_unique<pass::PermutationInsertionPass>(*this))
     .run();
 
-  dumpLowerInfo();
-
   // Optimization passes (optional)
   pass::PassRunner{}.append(std::make_unique<pass::PermutationEliminationPass>(*this)).run();
+
+  dumpLowerInfo();
 
   VERBOSE(LoweredGraph) << "Dump after all the passes" << std::endl;
   for (auto &&operand : _graph.getInputs())


### PR DESCRIPTION
This commit repositions LowerInfo in PermutationEliminationPass.
- Move `dumpLowerInfo()` to after all optimization passes in LoweredGraph for accurate state dumping
- In `PermutationEliminationPass`, update `lower_info`'s def_backends and use_backends:
  - Transfer def_backends from input to output operands when eliminating permutes
  - Transfer use_backends from output back to input operands

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #15342 
Draft #15455 