### PR TITLE
[onert/test] Add SUCCEED macro to test

### DIFF
--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Gather.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Gather.test.cc
@@ -97,6 +97,8 @@ TEST_F(GenModelTest, neg_OneOp_Gather_Q4_0_InvalidOutType)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"cpu"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_Gather_Q4_0_shape)
@@ -115,4 +117,6 @@ TEST_F(GenModelTest, neg_OneOp_Gather_Q4_0_shape)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"cpu"});
   _context->expectFailCompile();
+
+  SUCCEED();
 }


### PR DESCRIPTION
This commit adds SUCCEED macro to test for TC checker workaround.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>