### PR TITLE
[onert] Introduce outputBuffer into executors

### DIFF
--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -115,6 +115,13 @@ struct IExecutor
   virtual ir::Layout outputLayout(uint32_t index) const = 0;
 
   /**
+   * @brief     Get output buffer at index
+   * @param[in] index Index of output
+   * @return    Output buffer
+   */
+  virtual const uint8_t *outputBuffer(uint32_t index) const = 0;
+
+  /**
    * @brief   Return current execution configuration
    * @return  Current execution configuration
    */

--- a/runtime/onert/core/include/exec/IExecutors.h
+++ b/runtime/onert/core/include/exec/IExecutors.h
@@ -84,6 +84,13 @@ public:
   virtual const ir::OperandInfo &outputInfo(const ir::IOIndex &index) const = 0;
 
   /**
+   * @brief     Return NN package output buffer
+   * @param[in] index Output index
+   * @return    Buffer of output
+   */
+  virtual const void *outputBuffer(const ir::IOIndex &index) const = 0;
+
+  /**
    * @brief     Execute NN package executor set
    * @param[in] ctx  Execution context
    */

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -76,6 +76,11 @@ public:
     return _output_tensors[index]->layout();
   }
 
+  const uint8_t *outputBuffer(uint32_t index) const final
+  {
+    return _output_tensors[index]->buffer();
+  }
+
   // Used only in Dataflow and Parallel Executors
   void setIndexedRanks(std::shared_ptr<ir::OperationIndexMap<int64_t>> ranks) final
   {

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -83,6 +83,13 @@ const ir::OperandInfo &MultiModelExecutors::outputInfo(const ir::IOIndex &index)
   return executor->outputInfo(io_index.value());
 }
 
+const void *MultiModelExecutors::outputBuffer(const ir::IOIndex &index) const
+{
+  auto const [model_index, subg_index, io_index] = _model_edges->pkg_outputs[index.value()];
+  auto const executor = at(model_index, subg_index);
+  return static_cast<const void *>(executor->outputBuffer(index.value()));
+}
+
 // Allow below edges only
 //  m1 < m2, s1 == 0 and s2 == 0 if m1:s1:o1 -> m2:s2:o2'
 void MultiModelExecutors::checkSupportedMultimodel() const

--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -78,6 +78,8 @@ public:
 
   const ir::OperandInfo &outputInfo(const ir::IOIndex &index) const override;
 
+  const void *outputBuffer(const ir::IOIndex &index) const final;
+
   void execute(const ExecutionContext &ctx) override;
 
 private:

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -49,6 +49,11 @@ const ir::OperandInfo &SingleModelExecutors::outputInfo(const ir::IOIndex &index
   return entryExecutor()->outputInfo(index.value());
 }
 
+const void *SingleModelExecutors::outputBuffer(const ir::IOIndex &index) const
+{
+  return static_cast<const void *>(entryExecutor()->outputBuffer(index.value()));
+}
+
 void SingleModelExecutors::execute(const ExecutionContext &ctx)
 {
   // UserTensor for Input/Output

--- a/runtime/onert/core/src/exec/SingleModelExecutors.h
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.h
@@ -56,6 +56,8 @@ public:
 
   const ir::OperandInfo &outputInfo(const ir::IOIndex &index) const override;
 
+  const void *outputBuffer(const ir::IOIndex &index) const final;
+
   void execute(const ExecutionContext &ctx) override;
 
 private:

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -80,6 +80,11 @@ public:
     return _output_tensors[index]->layout();
   }
 
+  const uint8_t *outputBuffer(uint32_t index) const final
+  {
+    return _output_tensors[index]->buffer();
+  }
+
   void forward(const std::vector<backend::IPortableTensor *> &inputs,
                const std::vector<backend::IPortableTensor *> &outputs,
                const ExecutionOptions &options, bool training);

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -51,6 +51,11 @@ const ir::OperandInfo &TrainableExecutors::outputInfo(const ir::IOIndex &index) 
   return entryExecutor()->outputInfo(index.value());
 }
 
+const void *TrainableExecutors::outputBuffer(const ir::IOIndex &index) const
+{
+  return static_cast<const void *>(entryExecutor()->outputBuffer(index.value()));
+}
+
 void TrainableExecutors::execute(const ExecutionContext &ctx)
 {
   if (_executors.size() > 1)

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.h
@@ -63,6 +63,8 @@ public:
 
   const ir::OperandInfo &outputInfo(const ir::IOIndex &index) const override;
 
+  const void *outputBuffer(const ir::IOIndex &index) const final;
+
   void execute(const ExecutionContext &ctx) override;
 
   /**


### PR DESCRIPTION
This commit introduces outputBuffer into executors.
- Add `outputBuffer` pure virtual to IExecutor and IExecutors interfaces
- Implement `outputBuffer` in ExecutorBase, SingleModelExecutors, MultiModelExecutors, and TrainableExecutors

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #15342 
Draft #15455 