### PR TITLE
[circle-mir] Enable dynamic_batch_to_single_batch test

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/TestModels.cmake
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/TestModels.cmake
@@ -62,6 +62,22 @@ macro(ValidateDynaShapeInf MLIR_FNAME)
   list(APPEND FILE_DEPS "${TEST_MLIR_MODEL_DST}")
 endmacro(ValidateDynaShapeInf)
 
+# ValidateDynaBatchInf is to test dynamic_batch_to_single_batch option
+set(VALIDATE_DYNABATCHTOSINGLE_MODELS)
+macro(ValidateDynaBatchToSingle MLIR_FNAME)
+  # copy to build folder
+  set(TEST_MLIR_MODEL_SRC "${CMAKE_SOURCE_DIR}/models/mlir/${MLIR_FNAME}")
+  set(TEST_MLIR_MODEL_DST "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MLIR_FNAME}")
+  add_custom_command(
+    OUTPUT ${TEST_MLIR_MODEL_DST}
+    COMMAND ${CMAKE_COMMAND} -E copy "${TEST_MLIR_MODEL_SRC}" "${TEST_MLIR_MODEL_DST}"
+    DEPENDS ${TEST_MLIR_MODEL_SRC}
+    COMMENT "tools/onnx2circle: prepare mlir/${MLIR_FNAME}"
+  )
+  list(APPEND VALIDATE_DYNABATCHTOSINGLE_MODELS "${MLIR_FNAME}")
+  list(APPEND FILE_DEPS "${TEST_MLIR_MODEL_DST}")
+endmacro(ValidateDynaBatchToSingle)
+
 # Read "test.lst"
 include("test.lst")
 
@@ -107,6 +123,17 @@ foreach(MODEL IN ITEMS ${VALIDATE_DYNASHAPEINF_MODELS})
   add_test(
     NAME onnx2circle_valdynshapeinf_${MODEL}
     COMMAND "$<TARGET_FILE:onnx2circle>" "--check_dynshapeinf"
+      "${MLIR_MODEL_PATH}"
+      "${CIRCLE_MODEL_PATH}"
+  )
+endforeach()
+
+foreach(MODEL IN ITEMS ${VALIDATE_DYNABATCHTOSINGLE_MODELS})
+  set(MLIR_MODEL_PATH "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MODEL}")
+  set(CIRCLE_MODEL_PATH "${CMAKE_CURRENT_BINARY_DIR}/models/mlir/${MODEL}.circle")
+  add_test(
+    NAME onnx2circle_valdynbat2sin_${MODEL}
+    COMMAND "$<TARGET_FILE:onnx2circle>" "--dynamic_batch_to_single_batch" "--check_shapeinf"
       "${MLIR_MODEL_PATH}"
       "${CIRCLE_MODEL_PATH}"
   )

--- a/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/test.lst
@@ -84,3 +84,6 @@ ValidateDynaShapeInf(Sin_F32_R4_ds.circle.mlir)
 ValidateDynaShapeInf(Slice_F32_R2_ds.circle.mlir)
 ValidateDynaShapeInf(Sqrt_F32_R4_ds.circle.mlir)
 ValidateDynaShapeInf(StridedSlice_F32_R2_ds.circle.mlir)
+
+# dynamic batch to single batch validation
+ValidateDynaBatchToSingle(Logistics_F32_R4_db.circle.mlir)

--- a/circle-mlir/models/mlir/Logistics_F32_R4_db.circle.mlir
+++ b/circle-mlir/models/mlir/Logistics_F32_R4_db.circle.mlir
@@ -1,0 +1,10 @@
+// function with dynamic batch to validate '--dynamic_batch_to_single_batch' option
+module {
+  func.func @main_graph(%arg0: tensor<?x2x3x3xf32>) -> tensor<?x2x3x3xf32> attributes {
+      input_names = ["input"],
+      output_names = ["output"]}
+  {
+    %0 = "Circle.logistic"(%arg0) : (tensor<?x2x3x3xf32>) -> tensor<?x2x3x3xf32>
+    return %0 : tensor<?x2x3x3xf32>
+  }
+}


### PR DESCRIPTION
This will enable dynamic_batch_to_single_batch option validation test with Logistics_F32_R4_db.circle.mlir model.
