### PR TITLE
[circle-mlir/infra] Update changelog for onnx2circle

### DIFF
--- a/circle-mlir/infra/debian/onnx2circle/changelog
+++ b/circle-mlir/infra/debian/onnx2circle/changelog
@@ -1,3 +1,9 @@
+onnx2circle (0.4.0~202506120221~jammy) jammy; urgency=medium
+
+  * added new dynamic_batch_to_single_batch option.
+
+ -- On-device AI developers <nnfw@samsung.com>  Thu, 12 Jun 2025 02:31:34 +0000
+
 onnx2circle (0.4.0~202506100012~jammy) jammy; urgency=medium
 
   * Fix ResizeBilinear with int64


### PR DESCRIPTION
This updates the changelog for onnx2circle_0.4.0~202506120221.
This PR includes updated changelog after successful debian build.
It is auto-generated PR from github workflow.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>