### PR TITLE
[circle-mlir/dialect] Fix deprecated warnings for td file

### DIFF
--- a/circle-mlir/circle-mlir/lib/dialect/mlir/CircleOps.td
+++ b/circle-mlir/circle-mlir/lib/dialect/mlir/CircleOps.td
@@ -1920,7 +1920,7 @@ def CIR_ShapeOp: CIR_Op<"shape", [
   let results = (outs CIR_TensorOf<[I32, I64]>:$output);
 
   DerivedTypeAttr out_type = DerivedTypeAttr<[{
-    return getResult().getType().cast<TensorType>().getElementType();
+    return mlir::cast<TensorType>(getResult().getType()).getElementType();
   }]>;
 
   let hasOptions = 1;


### PR DESCRIPTION
This will fix deprecated warnings from generated codes from td file,
that was missed in previous change.
