### PR TITLE
[circle-mlir/dialect] Fix deprecation warning for absl

### DIFF
--- a/circle-mlir/circle-mlir/lib/dialect/src/CircleDialect.cpp
+++ b/circle-mlir/circle-mlir/lib/dialect/src/CircleDialect.cpp
@@ -426,7 +426,8 @@ Attribute ConstBytesAttr::parse(AsmParser &parser, Type type)
     return nullptr;
   }
 
-  std::string bytes_data = absl::HexStringToBytes(data.substr(2));
+  std::string bytes_data;
+  absl::HexStringToBytes(data.substr(2), &bytes_data);
   return ConstBytesAttr::get(parser.getBuilder().getContext(), bytes_data);
 }
 

--- a/circle-mlir/circle-mlir/lib/dialect/src/CircleDialect.cpp
+++ b/circle-mlir/circle-mlir/lib/dialect/src/CircleDialect.cpp
@@ -427,7 +427,10 @@ Attribute ConstBytesAttr::parse(AsmParser &parser, Type type)
   }
 
   std::string bytes_data;
-  absl::HexStringToBytes(data.substr(2), &bytes_data);
+  if (not absl::HexStringToBytes(data.substr(2), &bytes_data))
+  {
+    return nullptr;
+  }
   return ConstBytesAttr::get(parser.getBuilder().getContext(), bytes_data);
 }
 


### PR DESCRIPTION
This resolves the compiler warning related to the deprecated usage of `absl::HexStringToBytes()`.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>