### PR TITLE
[tf2tfliteV2] Always use v2 interface

### DIFF
--- a/compiler/tf2tfliteV2/tf2tfliteV2.py
+++ b/compiler/tf2tfliteV2/tf2tfliteV2.py
@@ -263,9 +263,8 @@ def _convert(flags):
     _apply_verbosity(flags.verbose)
 
     if (flags.v1):
-        _v1_convert(flags)
-    else:
-        _v2_convert(flags)
+        print("tf2tfliteV2: v1 not supported anymore. convert with v2.")
+    _v2_convert(flags)
 
 
 """


### PR DESCRIPTION
This will revise to always use v2 interface as v1 will not be available
when we upgrade to TF2.19.0.
