### PR TITLE
[github] Revise workflow for running tools-onnx-subgraph

### DIFF
--- a/.github/workflows/run-tools-onnx-subgr-build.yml
+++ b/.github/workflows/run-tools-onnx-subgr-build.yml
@@ -34,17 +34,14 @@ jobs:
       matrix:
         type: [ Debug, Release ]
         ubuntu_code: [ jammy ]
-        include:
-          - ubuntu_code: jammy
-            ubuntu_vstr: u2204
 
     runs-on: ubuntu-latest
 
     container:
-      image: nnfw/onnx-subgraph-build-${{ matrix.ubuntu_vstr }}:latest
+      image: nnfw/onnx-subgraph-build:${{ matrix.ubuntu_code }}
       options: --user root
 
-    name: tools/onnx-subgraph ${{ matrix.ubuntu_vstr }} ${{ matrix.type }} test
+    name: tools/onnx-subgraph ${{ matrix.ubuntu_code }} ${{ matrix.type }} test
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This updates the workflow to use the revised DockerHub repository name,
which includes the Ubuntu distro as the image tag.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>