### PR TITLE
[one-cmds] Fix test qconf alternate

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_009.qconf.json
+++ b/compiler/one-cmds/tests/one-quantize_009.qconf.json
@@ -5,7 +5,9 @@
         {
             "name" : "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Mixed_6a/Branch_1/Conv2d_0a_1x1/Conv2D;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D",
             "alternate": {
-                "tf2190": "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D"
+                "tf2190": [
+                    "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D"
+                ]
             },
             "dtype" : "int16",
             "granularity" : "channel"

--- a/compiler/one-cmds/tests/one-quantize_012.qconf.json
+++ b/compiler/one-cmds/tests/one-quantize_012.qconf.json
@@ -10,7 +10,9 @@
             "InceptionV3/InceptionV3/Mixed_7c/concat",
             "InceptionV3/Predictions/Reshape_1"],
             "alternate": {
-                "tf2190": "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D"
+                "tf2190": [
+                    "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D"
+                ]
             },
             "dtype" : "int16",
             "granularity" : "channel"

--- a/compiler/one-cmds/tests/one-quantize_013.qconf.json
+++ b/compiler/one-cmds/tests/one-quantize_013.qconf.json
@@ -10,7 +10,9 @@
             "InceptionV3/InceptionV3/Mixed_7c/concat",
             "InceptionV3/Predictions/Reshape_1"],
             "alternate": {
-                "tf2190": "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D"
+                "tf2190": [
+                    "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D"
+                ]
             },
             "dtype" : "int16",
             "granularity" : "channel"


### PR DESCRIPTION
This will fix test qconf alternate to be array.
