### PR TITLE
[fm-eq-val-py-test] Temporary disable

### DIFF
--- a/compiler/fm-equalize-value-py-test/CMakeLists.txt
+++ b/compiler/fm-equalize-value-py-test/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Temporary disable, reenable after python upgrade is finished
+return()
+
 if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)


### PR DESCRIPTION
This will temporary disable fm-equalize-value-py-test module.
