### PR TITLE
[fm-eq-val-py-test] Re-enable module

### DIFF
--- a/compiler/fm-equalize-value-py-test/CMakeLists.txt
+++ b/compiler/fm-equalize-value-py-test/CMakeLists.txt
@@ -1,6 +1,3 @@
-# Temporary disable, reenable after python upgrade is finished
-return()
-
 if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)


### PR DESCRIPTION
This will re-enable fm-equalize-value-py-test module.
