### PR TITLE
[infra/debian] Fix package dependency

### DIFF
--- a/infra/debian/compiler/control
+++ b/infra/debian/compiler/control
@@ -2,14 +2,14 @@ Source: one
 Section: devel
 Priority: extra
 Maintainer: Neural Network Acceleration Solution Developers <nnfw@samsung.com>
-Build-Depends: cmake, debhelper (>=9), dh-python, python3-all, python3.8, python3.8-venv
+Build-Depends: cmake, debhelper (>=9), dh-python, python3-all, python3.10, python3.10-venv
 Standards-Version: 3.9.8
 Homepage: https://github.com/Samsung/ONE
 
 Package: one-compiler
 Architecture: amd64
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, python3-venv, python3-pip, python3.8, python3.8-venv
+Depends: ${misc:Depends}, ${shlibs:Depends}, python3-venv, python3-pip, python3.10, python3.10-venv
 Description: On-device Neural Engine compiler package
 
 Package: one-compiler-dev


### PR DESCRIPTION
This commit updates onecc debian package dependency with python version.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>