### PR TITLE
[onert] Add get_output tests

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -314,7 +314,7 @@ void bindInternalOutputTensors(const compiler::ILoweredGraph &lgraph,
     else
     {
       auto io_tensor = tensor_regs.getIOTensor(idx);
-      io_tensor->setTensor(backend_tensor);
+      io_tensor->setBackendTensor(backend_tensor);
     }
   }
 }

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -147,6 +147,10 @@ void Execution::execute()
       const auto &output = _ctx.desc.outputs.at(i);
       if (!is_managed_internally && output->info.total_size() > output->size)
         throw std::runtime_error{"Too small output buffer length"};
+      if (is_managed_internally && output->buffer != nullptr)
+        VERBOSE(Execution) << "Warning: Output buffer was set from API even though the output "
+                              "tensor was allocated internally"
+                           << std::endl;
     }
   }
 

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -70,9 +70,10 @@ void ExecutorBase::execute(const std::vector<backend::IPortableTensor *> &inputs
   for (uint32_t n = 0; n < outputs.size(); ++n)
   {
     const auto output = outputs[n];
-    assert(output->buffer() != nullptr || output->get_info().total_size() == 0);
     auto output_tensor = _output_tensors[n];
     assert(output_tensor != nullptr);
+    assert(output->buffer() != nullptr || output->get_info().total_size() == 0 ||
+           output_tensor->hasBackendTensor());
     if (!output_tensor->hasBackendTensor())
       output_tensor->setTensor(output);
   }
@@ -87,7 +88,10 @@ void ExecutorBase::execute(const std::vector<backend::IPortableTensor *> &inputs
     auto output_tensor = _output_tensors[n];
     assert(output_tensor != nullptr);
     if (output_tensor->hasBackendTensor())
+    {
+      assert(output_tensor->buffer() != nullptr);
       output_tensor->syncInfoFromBackendTensor();
+    }
   }
 }
 


### PR DESCRIPTION
This commit adds get_output tests.
- Use setBackendTensor for internal outputs
- Warn if API buffer is set when using internal allocation
- Update asserts for backend tensor usage
- Add tests for dynamic output buffer cases

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #15342 
Draft #15455 