### PR TITLE
[onert/python] Revisit output handling

### DIFF
--- a/runtime/onert/api/python/package/infer/session.py
+++ b/runtime/onert/api/python/package/infer/session.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from contextlib import contextmanager
 
-from ..native.libnnfw_api_pybind import infer, tensorinfo
+from ..native.libnnfw_api_pybind import infer, prepare_config, tensorinfo
 from ..native.libnnfw_api_pybind.exception import OnertError
 from ..common.basesession import BaseSession
 
@@ -32,7 +32,7 @@ class session(BaseSession):
     ) -> Union[List[np.ndarray], Tuple[List[np.ndarray], Dict[str, float]]]:
         """
         Run a complete inference cycle:
-         - If the session has not been prepared or outputs have not been set, call prepare() and set_outputs().
+         - If the session has not been prepared or outputs have not been set, call prepare().
          - Automatically configure input buffers based on the provided numpy arrays.
          - Execute the inference session.
          - Return the output tensors with proper multi-dimensional shapes.
@@ -59,7 +59,7 @@ class session(BaseSession):
                 f"Expected {expected_input_size} input(s), but received {len(inputs_array)}."
             )
 
-        # Check if the session is prepared. If not, call prepare() and set_outputs() once.
+        # Check if the session is prepared. If not, call prepare() once.
         if not self._prepared:
             try:
                 with self._time_block(metrics, 'prepare_time_ms', measure):
@@ -93,8 +93,9 @@ class session(BaseSession):
                     # Update tensorinfo to optimize using it
                     self._update_inputs_tensorinfo(fixed_infos)
 
+                    self.session.set_prepare_config(
+                        prepare_config.ENABLE_INTERNAL_OUTPUT_ALLOC)
                     self.session.prepare()
-                    self.set_outputs(self.session.output_size())
                     self._prepared = True
             except ValueError:
                 raise
@@ -103,7 +104,7 @@ class session(BaseSession):
 
         # Configure input buffers using the current session's input size and provided data.
         try:
-            with self._time_block(metrics, 'io_time_ms', measure):
+            with self._time_block(metrics, 'input_time_ms', measure):
                 self.set_inputs(expected_input_size, inputs_array)
         except ValueError:
             raise
@@ -119,10 +120,16 @@ class session(BaseSession):
         except Exception as e:
             raise OnertError(f"Inference execution failed: {e}") from e
 
-        # TODO: Support dynamic shapes for outputs.
+        try:
+            with self._time_block(metrics, 'output_time_ms', measure):
+                self._set_outputs(self.session.output_size())
+        except ValueError:
+            raise
+        except Exception as e:
+            raise OnertError(f"Failed to bind outputs: {e}") from e
 
         # Return the output buffers.
-        return (self.outputs.copy(), metrics) if measure else self.outputs.copy()
+        return (self.outputs, metrics) if measure else self.outputs
 
     def _update_inputs_tensorinfo(self, new_infos: List[tensorinfo]) -> None:
         """

--- a/runtime/onert/api/python/src/bindings/nnfw_session_bindings.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_session_bindings.cc
@@ -117,76 +117,6 @@ void bind_nnfw_session(py::module_ &m)
       "Parameters:\n"
       "\tindex (int): Index of input to be set (0-indexed)\n"
       "\tbuffer (numpy): Raw buffer for input")
-    .def(
-      "set_output",
-      [](NNFW_SESSION &session, uint32_t index, py::array_t<float> &buffer) {
-        session.set_output<float>(index, buffer);
-      },
-      py::arg("index"), py::arg("buffer"),
-      "Set output buffer\n"
-      "Parameters:\n"
-      "\tindex (int): Index of output to be set (0-indexed)\n"
-      "\tbuffer (numpy): Raw buffer for output")
-    .def(
-      "set_output",
-      [](NNFW_SESSION &session, uint32_t index, py::array_t<int> &buffer) {
-        session.set_output<int>(index, buffer);
-      },
-      py::arg("index"), py::arg("buffer"),
-      "Set output buffer\n"
-      "Parameters:\n"
-      "\tindex (int): Index of output to be set (0-indexed)\n"
-      "\tbuffer (numpy): Raw buffer for output")
-    .def(
-      "set_output",
-      [](NNFW_SESSION &session, uint32_t index, py::array_t<uint8_t> &buffer) {
-        session.set_output<uint8_t>(index, buffer);
-      },
-      py::arg("index"), py::arg("buffer"),
-      "Set output buffer\n"
-      "Parameters:\n"
-      "\tindex (int): Index of output to be set (0-indexed)\n"
-      "\tbuffer (numpy): Raw buffer for output")
-    .def(
-      "set_output",
-      [](NNFW_SESSION &session, uint32_t index, py::array_t<bool> &buffer) {
-        session.set_output<bool>(index, buffer);
-      },
-      py::arg("index"), py::arg("buffer"),
-      "Set output buffer\n"
-      "Parameters:\n"
-      "\tindex (int): Index of output to be set (0-indexed)\n"
-      "\tbuffer (numpy): Raw buffer for output")
-    .def(
-      "set_output",
-      [](NNFW_SESSION &session, uint32_t index, py::array_t<int64_t> &buffer) {
-        session.set_output<int64_t>(index, buffer);
-      },
-      py::arg("index"), py::arg("buffer"),
-      "Set output buffer\n"
-      "Parameters:\n"
-      "\tindex (int): Index of output to be set (0-indexed)\n"
-      "\tbuffer (numpy): Raw buffer for output")
-    .def(
-      "set_output",
-      [](NNFW_SESSION &session, uint32_t index, py::array_t<int8_t> &buffer) {
-        session.set_output<int8_t>(index, buffer);
-      },
-      py::arg("index"), py::arg("buffer"),
-      "Set output buffer\n"
-      "Parameters:\n"
-      "\tindex (int): Index of output to be set (0-indexed)\n"
-      "\tbuffer (numpy): Raw buffer for output")
-    .def(
-      "set_output",
-      [](NNFW_SESSION &session, uint32_t index, py::array_t<int16_t> &buffer) {
-        session.set_output<int16_t>(index, buffer);
-      },
-      py::arg("index"), py::arg("buffer"),
-      "Set output buffer\n"
-      "Parameters:\n"
-      "\tindex (int): Index of output to be set (0-indexed)\n"
-      "\tbuffer (numpy): Raw buffer for output")
     .def("input_size", &NNFW_SESSION::input_size,
          "Get the number of inputs defined in loaded model\n"
          "Returns:\n"
@@ -201,12 +131,6 @@ void bind_nnfw_session(py::module_ &m)
          "Parameters:\n"
          "\tindex (int): Index of input to be set (0-indexed)\n"
          "\tlayout (str): Layout to set to target input")
-    .def("set_output_layout", &NNFW_SESSION::set_output_layout, py::arg("index"),
-         py::arg("layout") = "NONE",
-         "Set the layout of an output\n"
-         "Parameters:\n"
-         "\tindex (int): Index of output to be set (0-indexed)\n"
-         "\tlayout (str): Layout to set to target output")
     .def("input_tensorinfo", &NNFW_SESSION::input_tensorinfo, py::arg("index"),
          "Get i-th input tensor info\n"
          "Parameters:\n"

--- a/runtime/onert/api/python/src/wrapper/nnfw_api_wrapper.cc
+++ b/runtime/onert/api/python/src/wrapper/nnfw_api_wrapper.cc
@@ -187,11 +187,6 @@ void NNFW_SESSION::set_input_layout(uint32_t index, const char *layout)
   NNFW_LAYOUT nnfw_layout = getLayout(layout);
   ensure_status(nnfw_set_input_layout(session, index, nnfw_layout));
 }
-void NNFW_SESSION::set_output_layout(uint32_t index, const char *layout)
-{
-  NNFW_LAYOUT nnfw_layout = getLayout(layout);
-  ensure_status(nnfw_set_output_layout(session, index, nnfw_layout));
-}
 tensorinfo NNFW_SESSION::input_tensorinfo(uint32_t index)
 {
   nnfw_tensorinfo tensor_info = nnfw_tensorinfo();

--- a/runtime/onert/sample/minimal-python/inference_benchmark.py
+++ b/runtime/onert/sample/minimal-python/inference_benchmark.py
@@ -63,7 +63,7 @@ def benchmark_inference(nnpackage_path: str, backends: str, input_shapes: List[L
         shape = tuple(info.dims[:info.rank])
         dummy_inputs.append(np.random.rand(*shape).astype(info.dtype))
 
-    prepare = total_io = total_run = 0.0
+    prepare = total_input = total_output = total_run = 0.0
 
     # Warmup runs
     prepare_kb = 0
@@ -78,8 +78,9 @@ def benchmark_inference(nnpackage_path: str, backends: str, input_shapes: List[L
     for _ in range(repeat):
         outputs, metrics = sess.infer(dummy_inputs, measure=True)
         del outputs
-        total_io += metrics["io_time_ms"]
+        total_input += metrics["input_time_ms"]
         total_run += metrics["run_time_ms"]
+        total_output += metrics["output_time_ms"]
 
     execute_kb = get_memory_usage_mb() * 1024 - mem_before_kb
 
@@ -87,7 +88,7 @@ def benchmark_inference(nnpackage_path: str, backends: str, input_shapes: List[L
     print(f"- Warmup runs   : 3")
     print(f"- Measured runs : {repeat}")
     print(f"- Prepare       : {prepare:.3f} ms")
-    print(f"- Avg I/O       : {total_io / repeat:.3f} ms")
+    print(f"- Avg I/O       : {(total_input + total_output) / repeat:.3f} ms")
     print(f"- Avg Run       : {total_run / repeat:.3f} ms")
     print("===================================")
     print("RSS")


### PR DESCRIPTION
This commit refactors output handling.
- Remove set_output and set_output_layout from Python bindings and wrapper
- Refactor output buffer allocation to use get_output directly
- Add output shape sync logic when input shape changes
- Separate input/output timing metrics in benchmark script

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #15342 
Draft #15455 