### PR TITLE
[infra/gbs] Update tizen profile to tizen 9

### DIFF
--- a/.github/workflows/run-onert-gbs-build.yml
+++ b/.github/workflows/run-onert-gbs-build.yml
@@ -52,8 +52,8 @@ jobs:
     if: github.repository_owner == 'Samsung'
     strategy:
       matrix:
-        arch: ['armv7l'] # TODO: Add aarch64, x86_64, etc
-        profile: ['tizen_8'] # TODO: Add tizen_9, etc
+        arch: ['armv7l']
+        profile: ['tizen_9']
     runs-on: ubuntu-22.04
     steps:
       # Install binfmt support for gbs


### PR DESCRIPTION
This commit updates gbs build workflow to use tizen 9.0.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>