### PR TITLE
[onert] Check null on output tensor dynamic casting

### DIFF
--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -46,6 +46,9 @@ Execution::Execution(const std::shared_ptr<IExecutors> &executors) : _executors{
   {
     const auto output_tensor =
       dynamic_cast<const backend::builtin::IOTensor *>(executors->outputTensor(ir::IOIndex{i}));
+    if (!output_tensor)
+      throw std::runtime_error("Output tensor must be IOTensor");
+
     _is_internal_output_tensor.at(i) = output_tensor->hasBackendTensor();
   }
 

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -373,6 +373,8 @@ void MultiModelExecutors::execute(const ExecutionContext &ctx)
   {
     const auto output_io_tensor =
       dynamic_cast<const backend::builtin::IOTensor *>(outputTensor(ir::IOIndex{i}));
+    if (!output_io_tensor)
+      throw std::runtime_error{"Output tensor must be IOTensor"};
     if (output_io_tensor->hasBackendTensor())
       throw std::runtime_error(
         "MultiModelExecutors does not support allocating output tensors internally");

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -124,9 +124,11 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   for (uint32_t i = 0; i < outputs.size(); i++)
   {
     auto &desc = ctx.desc.outputs[i];
-    bool skip_set_output =
-      dynamic_cast<const backend::builtin::IOTensor *>(outputTensor(ir::IOIndex{i}))
-        ->hasBackendTensor();
+    const auto output_io_tensor =
+      dynamic_cast<const backend::builtin::IOTensor *>(outputTensor(ir::IOIndex{i}));
+    if (!output_io_tensor)
+      throw std::runtime_error{"Output tensor must be IOTensor"};
+    bool skip_set_output = output_io_tensor->hasBackendTensor();
 
     // Output is optional if buffer is nullptr, and optional output's size is 0
     if (desc->buffer == nullptr && (desc->size != 0 || desc->info.total_size() != 0) &&


### PR DESCRIPTION
This commit adds dynamic casting null check for output tensors.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>