### PR TITLE
[luci/pass] Copy qparam in SubstituteTransposeToReshapePass

### DIFF
--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.cpp
@@ -92,6 +92,8 @@ bool substitute_transpose_to_reshape(luci::CircleTranspose *node)
   new_const_node->name(name + "/Reshape/shape");
   luci::add_origin(new_const_node, luci::get_origin(node));
 
+  luci::copy_quantparam(node, new_reshape_node);
+
   replace(node).with(new_reshape_node);
   return true;
 }

--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
@@ -71,6 +71,67 @@ public:
   luci::CircleOutput *output = nullptr;
 };
 
+std::unique_ptr<luci::CircleQuantParam> gen_qparam(const float scale, const int64_t zerop)
+{
+  auto qparam = std::make_unique<luci::CircleQuantParam>();
+  qparam->scale = {scale};
+  qparam->zerop = {zerop};
+
+  return std::move(qparam);
+}
+
+class QuantizedTransposeToReshapeTest : public ::testing::Test
+{
+public:
+  QuantizedTransposeToReshapeTest() {}
+
+  void buildGraph(const std::initializer_list<uint32_t> shape, const std::vector<int32_t> perm)
+  {
+    // Input Create.
+    input = g.nodes()->create<luci::CircleInput>();
+    auto graph_input = g.inputs()->create();
+    input->index(graph_input->index());
+    input->shape_status(luci::ShapeStatus::VALID);
+    input->rank(shape.size());
+    input->shape(shape);
+    input->name("input");
+    input->quantparam(std::move(gen_qparam(1.0, 0)));
+
+    // Permutation Create.
+    auto perm_const = g.nodes()->create<luci::CircleConst>();
+    perm_const->dtype(loco::DataType::S32);
+    perm_const->size<loco::DataType::S32>(perm.size());
+    perm_const->shape_status(luci::ShapeStatus::VALID);
+    perm_const->rank(1);
+    perm_const->dim(0).set(perm.size());
+    for (uint32_t i = 0; i < static_cast<uint32_t>(perm.size()); i++)
+    {
+      perm_const->at<loco::DataType::S32>(i) = perm.at(i);
+    }
+    perm_const->name("perm_const");
+
+    // Transpose Create.
+    auto transpose_node = g.nodes()->create<luci::CircleTranspose>();
+    transpose_node->a(input);
+    transpose_node->perm(perm_const);
+    transpose_node->name("transpose_node");
+    transpose_node->quantparam(std::move(gen_qparam(1.0, 0)));
+
+    // Output Connect.
+    output = g.nodes()->create<luci::CircleOutput>();
+    output->from(transpose_node);
+    auto graph_output = g.outputs()->create();
+    output->index(graph_output->index());
+    output->name("output");
+    output->quantparam(std::move(gen_qparam(1.0, 0)));
+  }
+
+public:
+  loco::Graph g;
+  luci::CircleInput *input = nullptr;
+  luci::CircleOutput *output = nullptr;
+};
+
 } // namespace
 
 TEST(SubstituteTransposeToReshapePassTest, name)
@@ -117,4 +178,27 @@ TEST_F(SubstituteTransposeToReshapeTest, failed_to_substitute_NEG)
   auto transpose_node = dynamic_cast<luci::CircleTranspose *>(output->from());
   ASSERT_EQ(nullptr, reshape_node);
   ASSERT_NE(nullptr, transpose_node);
+}
+
+TEST_F(QuantizedTransposeToReshapeTest, quantized)
+{
+  // Create graph that tranpose input {12, 20, 1, 1} with permutation {2, 0, 3, 1}
+  buildGraph({12, 20, 1, 1}, std::vector<int32_t>({2, 0, 3, 1}));
+  // With this input shape and permutation values, output shape will be [1, 12, 1, 20].
+  // The order of non-one values is unchanged (12, 20).
+  // So this Transpose op can be converted to Reshape op.
+  luci::SubstituteTransposeToReshapePass pass;
+  while (pass.run(&g))
+    ;
+
+  auto reshape_node = dynamic_cast<luci::CircleReshape *>(output->from());
+  auto transpose_node = dynamic_cast<luci::CircleTranspose *>(output->from());
+  ASSERT_NE(nullptr, reshape_node);
+  ASSERT_EQ(nullptr, transpose_node);
+  auto new_shape = loco::must_cast<luci::CircleConst *>(reshape_node->shape());
+  ASSERT_EQ(1, new_shape->at<loco::DataType::S32>(0));
+  ASSERT_EQ(12, new_shape->at<loco::DataType::S32>(1));
+  ASSERT_EQ(1, new_shape->at<loco::DataType::S32>(2));
+  ASSERT_EQ(20, new_shape->at<loco::DataType::S32>(3));
+  ASSERT_NE(nullptr, reshape_node->quantparam());
 }


### PR DESCRIPTION
This copies qparam in SubstituteTransposeToReshapePass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>