### PR TITLE
[one-cmds] Disable one-quantize_020 test

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_020.test
+++ b/compiler/one-cmds/tests/one-quantize_020.test
@@ -18,6 +18,11 @@
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
+# This test does not end in Ubuntu 20.04 (https://github.com/Samsung/ONE/issues/15625)
+# TODO Re-enable this test
+echo "${filename_ext} SKIPPED"
+exit 0
+
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"


### PR DESCRIPTION
This disables the one-quantize_020 test.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/15625