### PR TITLE
[onert] Set default value to Operation struct

### DIFF
--- a/runtime/onert/core/src/util/MDTableEventWriter.cc
+++ b/runtime/onert/core/src/util/MDTableEventWriter.cc
@@ -90,7 +90,7 @@ struct MDContent
 struct Operation : public MDContent
 {
   std::string backend;
-  uint64_t graph_latency;
+  uint64_t graph_latency = 0;
 
   struct OperationCmp
   {


### PR DESCRIPTION
This commit adds default value to Operation struct in MDTableEventWriter.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>