### PR TITLE
[github] Revise run-circle-mlir-build

### DIFF
--- a/.github/workflows/run-circle-mlir-build.yml
+++ b/.github/workflows/run-circle-mlir-build.yml
@@ -10,6 +10,7 @@ on:
       - 'circle-mlir/**'
       - '!circle-mlir/infra/debian/**'
       - '!circle-mlir/infra/docker/**'
+      - '!circle-mlir/externals/**'
   pull_request:
     branches:
       - master
@@ -19,6 +20,7 @@ on:
       - 'circle-mlir/**'
       - '!circle-mlir/infra/debian/**'
       - '!circle-mlir/infra/docker/**'
+      - '!circle-mlir/externals/**'
 
 defaults:
   run:


### PR DESCRIPTION
This will revise run-circle-mlir-build to exclude externals folder change from build.