### PR TITLE
[github] Enable noble for run-onecc-build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         type: [ Debug, Release ]
-        ubuntu_code: [ focal, jammy ]
+        ubuntu_code: [ focal, jammy, noble ]
     runs-on: one-x64-linux
     container:
       image: samsungonedev.azurecr.io/nnfw/one-devtools:${{ matrix.ubuntu_code }}


### PR DESCRIPTION
This will revise run-onecc-build workflow to check noble too.
