### PR TITLE
[circle-mlir/infra] Update changelog for onnx2circle

### DIFF
--- a/circle-mlir/infra/debian/onnx2circle/changelog
+++ b/circle-mlir/infra/debian/onnx2circle/changelog
@@ -1,3 +1,9 @@
+onnx2circle (0.4.0~202506240759~jammy) jammy; urgency=medium
+
+  * Fixed ConvAveragePool
+
+ -- On-device AI developers <nnfw@samsung.com>  Tue, 24 Jun 2025 08:09:07 +0000
+
 onnx2circle (0.4.0~202506240100~jammy) jammy; urgency=medium
 
   * publish noble too


### PR DESCRIPTION
This updates the changelog for onnx2circle_0.4.0~202506240759.
This PR includes updated changelog after successful debian build.
It is auto-generated PR from github workflow.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>