### PR TITLE
[github] Exclude debug build in run-onecc-build

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -46,6 +46,11 @@ jobs:
       matrix:
         type: [ Debug, Release ]
         ubuntu_code: [ focal, jammy, noble ]
+        exclude:
+          - ubuntu_code: focal
+            type: Debug
+          - ubuntu_code: noble
+            type: Debug
     runs-on: one-x64-linux
     container:
       image: samsungonedev.azurecr.io/nnfw/one-devtools:${{ matrix.ubuntu_code }}


### PR DESCRIPTION
This will exclude debug build in run-onecc-build Workflow.
This is to reduce runner resource.
Internal CI runs all combinations so exclusion here is OK.
