### PR TITLE
[infra] Introduce github action workflow file checker

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - one-x64-linux
+    - one-arm-linux

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -48,6 +48,13 @@ jobs:
           path: format.patch
           retention-days: 3
 
+      # Refer https://github.com/rhysd/actionlint/blob/main/docs/usage.md#use-actionlint-on-github-actions
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:latest
+        continue-on-error: true # Ignore failure because it is not prepared yet. It will be enabled later.
+        with:
+          args: -color
+
   check-copyright:
     name: Check copyright
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This commit updates format checker to check workflow files. 
It ignores failure because workflows are not fixed yet.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>