### PR TITLE
[one-cmds] Add one-import-pytorch test

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -50,11 +50,6 @@ set(ONE_COMMAND_FILES
     onecc
 )
 
-# pytorch importer is an experimental feature, it is not used in default configuration
-if(ENABLE_ONE_IMPORT_PYTORCH)
-  list(APPEND ONE_COMMAND_FILES one-import-pytorch)
-endif(ENABLE_ONE_IMPORT_PYTORCH)
-
 foreach(ONE_COMMAND IN ITEMS ${ONE_COMMAND_FILES})
 
   set(ONE_COMMAND_FILE ${ONE_COMMAND})

--- a/compiler/one-cmds/tests/one-import-pytorch_001.test
+++ b/compiler/one-cmds/tests/one-import-pytorch_001.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./test_pytorch_model.pt2"
+outputfile="./test_pytorch_model.circle"
+
+rm -rf ${outputfile}
+rm -f ${filename}.log
+
+# run test
+one-import-pytorch \
+--input_path ${inputfile} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-import-pytorch_001.test
+++ b/compiler/one-cmds/tests/one-import-pytorch_001.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -92,6 +92,13 @@ if [[ ! -s "test_onnx_model.onnx" ]]; then
     # https://github.com/Samsung/ONE/issues/5548#issuecomment-754373360
 fi
 
+if [[ ! -s "test_pytorch_model.pt2" ]]; then
+    rm -rf test_pytorch_model.zip
+    wget -nv https://github.com/user-attachments/files/20944985/test_pytorch_model.zip
+    unzip test_pytorch_model.zip
+    # https://github.com/Samsung/ONE/issues/15406#issuecomment-3012389865
+fi
+
 if [[ ! -s "onnx_conv2d_conv2d.onnx" ]]; then
     rm -rf onnx_conv2d_conv2d.zip
     wget -nv https://github.com/Samsung/ONE/files/5774648/onnx_conv2d_conv2d.zip


### PR DESCRIPTION
This commit adds a simple test for one-import-pytorch.

Related: #15406
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>