### PR TITLE
[github] Reduce commit check runs

### DIFF
--- a/.github/workflows/run-circle-mlir-build.yml
+++ b/.github/workflows/run-circle-mlir-build.yml
@@ -38,6 +38,11 @@ jobs:
       matrix:
         type: [ Debug, Release ]
         ubuntu_code: [ focal, jammy, noble ]
+        exclude:
+          - ubuntu_code: focal
+            type: Debug
+          - ubuntu_code: noble
+            type: Debug
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This will reduce commit check runs with excluding Debug build of focal and noble.
