### PR TITLE
[infra] Fix generate-rootfs.yml

### DIFF
--- a/.github/workflows/generate-rootfs.yml
+++ b/.github/workflows/generate-rootfs.yml
@@ -51,7 +51,7 @@ jobs:
           pushd tools/cross
           sudo ./install_rootfs.sh ${{ matrix.arch }} ${{ matrix.os }} --skipunmount
           sudo umount --recursive rootfs || true
-          sudo chown -R $(id -u):$(id -g) rootfs/${{ matrix.arch }}
+          sudo chown -R "$(id -u):$(id -g)" rootfs/${{ matrix.arch }}
           tar -zcvf rootfs_${{ matrix.arch }}_${{ matrix.os }}.tar.gz -C rootfs \
             ${{ matrix.arch }}/usr ${{ matrix.arch }}/etc
           popd


### PR DESCRIPTION
This commit fixes generate-rootfs.yml
- SC2046: Quote this to prevent word splitting

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/15699