### PR TITLE
[github] Fix pub-onnx2circle-launchpad.yml

### DIFF
--- a/.github/workflows/pub-onnx2circle-launchpad.yml
+++ b/.github/workflows/pub-onnx2circle-launchpad.yml
@@ -60,8 +60,10 @@ jobs:
             version="${base_version}~${release_date}"
             br_version="${base_version}-${release_date}"
           fi
-          echo "version=${version}" >> $GITHUB_OUTPUT
-          echo "br_version=${br_version}" >> $GITHUB_OUTPUT
+          {
+            echo "version=${version}"
+            echo "br_version=${br_version}"
+          } >> "$GITHUB_OUTPUT"
 
   debian-release:
     needs: configure
@@ -86,9 +88,11 @@ jobs:
           VERSION="${{ needs.configure.outputs.version }}~${{ matrix.ubuntu_code }}"
           changes_file="onnx2circle_${VERSION}_source.changes"
           tarball_file="onnx2circle_${VERSION}.orig.tar.xz"
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-          echo "changes_file=${changes_file}" >> $GITHUB_OUTPUT
-          echo "tarball_file=${tarball_file}" >> $GITHUB_OUTPUT
+          {
+            echo "VERSION=${VERSION}"
+            echo "changes_file=${changes_file}"
+            echo "tarball_file=${tarball_file}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install circle-interpreter
         run: |
@@ -158,7 +162,7 @@ jobs:
           FPR=$(gpg --list-keys --with-colons | awk -F: '$1 == "fpr" { print $10; exit }')
           echo "$FPR:6:" | gpg --import-ownertrust
           debuild -S -us -uc
-          debsign -k${FPR} ../onnx2circle_*.changes
+          debsign "-k${FPR}" ../onnx2circle_*.changes
 
       - name: Upload to Launchpad
         run: |
@@ -219,7 +223,7 @@ jobs:
         id: prepare
         run: |
           VERSION="${{ needs.configure.outputs.version }}"
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -243,14 +247,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH=auto/update-o2c-changelog-${BR_VERSION}
-          git checkout -b ${BRANCH}
+          git checkout -b "${BRANCH}"
           git add circle-mlir/infra/debian/onnx2circle/changelog
           git commit -m "[circle-mlir/infra] Update changelog for onnx2circle" \
             -m "This updates the changelog for onnx2circle_${{ steps.prepare.outputs.VERSION }}." \
             -m "It is auto-generated PR from github workflow." \
             -m "" \
             -m "ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>"
-          git push origin ${BRANCH}
+          git push origin "${BRANCH}"
 
       - name: Create PR
         env:


### PR DESCRIPTION
This commit fixes pub-onnx2circle-launchpad.yml
- SC2086: Double quote to prevent globbing and word splitting
- SC2129: Consider using `{ cmd1; cmd2; } >> file` instead of individual redirects

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15699