### PR TITLE
[github] Fix run-onert-micro-unit-tests.yml

### DIFF
--- a/.github/workflows/run-onert-micro-unit-tests.yml
+++ b/.github/workflows/run-onert-micro-unit-tests.yml
@@ -55,5 +55,5 @@ jobs:
           mkdir build
           cd build
           cmake ../infra/onert-micro/ -DENABLE_ONERT_MICRO_TEST=1 -DENABLE_TEST=1
-          make -j$(nproc) onert_micro_execute_kernels_test
+          make "-j$(nproc)" onert_micro_execute_kernels_test
           ./onert-micro/eval-driver/onert-micro/src/execute/onert_micro_execute_kernels_test


### PR DESCRIPTION
This commit fixes run-onert-micro-unit-tests.yml
- SC2046: Quote this to prevent word splitting

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15699