### PR TITLE
[github] Throw error on workflow check step

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -51,7 +51,6 @@ jobs:
       # Refer https://github.com/rhysd/actionlint/blob/main/docs/usage.md#use-actionlint-on-github-actions
       - name: Check workflow files
         uses: docker://rhysd/actionlint:latest
-        continue-on-error: true # Ignore failure because it is not prepared yet. It will be enabled later.
         with:
           args: -color
 


### PR DESCRIPTION
This commit allows to throw an error if workflow check step fails.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15699