### PR TITLE
[github] Change cross build docker image name

### DIFF
--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -53,7 +53,7 @@ jobs:
             platform: arm
     runs-on: one-x64-linux
     container:
-      image: samsungonedev.azurecr.io/nnfw/one-devtools:${{ matrix.ubuntu_code }}-cross
+      image: samsungonedev.azurecr.io/nnfw/one-devtools:${{ matrix.ubuntu_code }}
       options: --user root
     env:
       TARGET_ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
This commit changes the cross build docker image name. 
Docker image for cross build is removed, and use same docker image as normal build.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>