### PR TITLE
[onert] Support FullyConnected shape inference with keep_num_dim

### DIFF
--- a/runtime/onert/core/include/ir/operation/FullyConnected.h
+++ b/runtime/onert/core/include/ir/operation/FullyConnected.h
@@ -39,6 +39,7 @@ public:
   {
     Activation activation;
     FullyConnectedWeightsFormat weights_format;
+    bool keep_num_dims;
   };
 
 public:

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -66,7 +66,8 @@ ir::Shape inferExpandDimsShape(const ir::Shape &in_shape, int32_t axis);
 
 template <typename T> ir::Shape inferFillShape(const ir::Shape &fill_shape, const T *shape_buf);
 
-ir::Shape inferFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &ker_shape);
+ir::Shape inferFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &ker_shape,
+                                   bool keep_num_dims);
 
 ir::Shape inferGatherShape(const ir::Shape &input_shape, const ir::Shape &indices_shape, int axis,
                            int rank);

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -585,8 +585,8 @@ void StaticShapeInferer::visit(const ir::operation::FullyConnected &op)
   const auto output_idx = op.getOutputs().at(0);
   ir::Operand &output = operands.at(output_idx);
   // re-sizing output shape
-  ir::Shape new_shape =
-    shape_inference::inferFullyConnectedShape(input.info().shape(), ker.info().shape());
+  ir::Shape new_shape = shape_inference::inferFullyConnectedShape(
+    input.info().shape(), ker.info().shape(), op.param().keep_num_dims);
   output.info().shape(new_shape);
 }
 

--- a/runtime/onert/core/src/exec/DynamicShapeInferer.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInferer.cc
@@ -470,7 +470,8 @@ void DynamicShapeInferer::visit(const ir::operation::FullyConnected &op)
   auto input_shape = input->getShape();
   auto ker_shape = ker->getShape();
 
-  ir::Shape new_shape = shape_inference::inferFullyConnectedShape(input_shape, ker_shape);
+  ir::Shape new_shape =
+    shape_inference::inferFullyConnectedShape(input_shape, ker_shape, op.param().keep_num_dims);
 
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);

--- a/runtime/onert/core/src/loader/BaseLoader.h
+++ b/runtime/onert/core/src/loader/BaseLoader.h
@@ -795,6 +795,7 @@ void BaseLoader<LoaderDomain>::loadFC(const Operator *op, ir::Graph &subg)
 
   param.activation = convertActivation(options->fused_activation_function());
   param.weights_format = static_cast<ir::FullyConnectedWeightsFormat>(options->weights_format());
+  param.keep_num_dims = options->keep_num_dims();
 
   const auto fc = loadOperationTo<ir::operation::FullyConnected>(op, subg, param);
 

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -390,7 +390,8 @@ template <typename T> ir::Shape inferFillShape(const ir::Shape &fill_shape, cons
 template ir::Shape inferFillShape(const ir::Shape &fill_shape, const int32_t *shape_buf);
 template ir::Shape inferFillShape(const ir::Shape &fill_shape, const int64_t *shape_buf);
 
-ir::Shape inferFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &ker_shape)
+ir::Shape inferFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &ker_shape,
+                                   bool keep_num_dims)
 {
   assert(in_shape.rank() >= 2);
   assert(ker_shape.rank() == 2);
@@ -400,6 +401,14 @@ ir::Shape inferFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &k
   const auto input_size = ker_shape.dim(1);
   const auto batch_size = input_size_with_batch / input_size;
   assert(input_size_with_batch % input_size == 0);
+
+  if (keep_num_dims)
+  {
+    assert(in_shape.dim(in_shape.rank() - 1) == input_size);
+    auto output_shape = ir::Shape(in_shape);
+    output_shape.dim(output_shape.rank() - 1) = num_units;
+    return output_shape;
+  }
 
   return {ir::Shape({static_cast<int32_t>(batch_size), num_units})};
 }

--- a/runtime/onert/core/src/util/ShapeInference.test.cc
+++ b/runtime/onert/core/src/util/ShapeInference.test.cc
@@ -349,11 +349,26 @@ TEST(ShapeInference, FullyConnected)
 {
   Shape in_shape{3, 4, 5, 6};
   Shape ker_shape{3, 10};
-  auto infered_out_shape = onert::shape_inference::inferFullyConnectedShape(in_shape, ker_shape);
+  auto infered_out_shape =
+    onert::shape_inference::inferFullyConnectedShape(in_shape, ker_shape, false);
 
   ASSERT_EQ(infered_out_shape.rank(), 2);
   ASSERT_EQ(infered_out_shape.dim(0), 36);
   ASSERT_EQ(infered_out_shape.dim(1), 3);
+}
+
+TEST(ShapeInference, FullyConnected_keep_num_dims)
+{
+  Shape in_shape{3, 4, 5, 6};
+  Shape ker_shape{3, 6};
+  auto infered_out_shape =
+    onert::shape_inference::inferFullyConnectedShape(in_shape, ker_shape, true);
+
+  ASSERT_EQ(infered_out_shape.rank(), 4);
+  ASSERT_EQ(infered_out_shape.dim(0), 3);
+  ASSERT_EQ(infered_out_shape.dim(1), 4);
+  ASSERT_EQ(infered_out_shape.dim(2), 5);
+  ASSERT_EQ(infered_out_shape.dim(3), 3);
 }
 
 TEST(ShapeInference, Transpose)

--- a/runtime/tests/nnapi/bridge/wrapper/OperationFactory.cc
+++ b/runtime/tests/nnapi/bridge/wrapper/OperationFactory.cc
@@ -513,6 +513,7 @@ OperationFactory::OperationFactory()
     param.activation =
       NNAPIConvert::getFusedActivation(operands.at(activation_index).asScalar<FuseCode>());
     param.weights_format = FullyConnectedWeightsFormat::Default;
+    param.keep_num_dims = false;
 
     return new operation::FullyConnected{inputs, outputs, param};
   };


### PR DESCRIPTION
This commit updates shape inference for FullyConnected operation with keep_num_dim option.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15704