### PR TITLE
[circle-mlir/dialect] Introduce SplitOp::fold

### DIFF
--- a/circle-mlir/circle-mlir/lib/dialect/mlir/CircleOps.td
+++ b/circle-mlir/circle-mlir/lib/dialect/mlir/CircleOps.td
@@ -2080,6 +2080,8 @@ def CIR_SplitOp : CIR_Op<"split", [
   let hasVerifier = 1;
 
   let hasOptions = 1;
+
+  let hasFolder = 1;
 }
 
 def CIR_SplitVOp : CIR_Op<"split_v", [

--- a/circle-mlir/circle-mlir/lib/dialect/src/ops/SplitOp.h
+++ b/circle-mlir/circle-mlir/lib/dialect/src/ops/SplitOp.h
@@ -71,6 +71,13 @@ mlir::LogicalResult SplitOp::verify()
                                   [expected_output_type](int64_t) { return expected_output_type; });
 }
 
+LogicalResult SplitOp::fold(FoldAdaptor adaptor, SmallVectorImpl<OpFoldResult> &results)
+{
+  // TODO implement
+
+  return failure();
+}
+
 } // namespace Circle
 } // namespace mlir
 


### PR DESCRIPTION
This will introduce SplitOp::fold() to enable folding of SplitOp.
