### PR TITLE
[github] Publish onert python package

### DIFF
--- a/.github/workflows/pub-onert-pypi.yml
+++ b/.github/workflows/pub-onert-pypi.yml
@@ -19,7 +19,7 @@ on:
         default: 'master'
 
 jobs:
-  build-and-publish:
+  build:
     if: github.repository_owner == 'Samsung'
     strategy:
       matrix:
@@ -81,8 +81,26 @@ jobs:
           name: onert-wheel-${{ matrix.python-version }}-${{ matrix.arch }}
           path: runtime/infra/python/dist/*.whl
 
-      # - name: Publish
-      #   if: github.event_name != 'pull_request'
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     packages-dir: runtime/infra/python/dist/
+  publish-to-pypi:
+    needs: [ build ]
+    if: github.repository_owner == 'Samsung'
+    runs-on: ubuntu-22.04
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/onert
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: "Download all the dists"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: onert-wheel-*
+          path: "./dist/"
+          merge-multiple: true  # download to 'dist/' directory, not individual directories
+
+      - name: "Publish distribution to PyPI"
+        if: github.event.inputs.official == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This commit updates python packaging workflow to publish onert python package to pypi.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>