### PR TITLE
[onert] Remove BUILD_TRIX_LOADER option

### DIFF
--- a/runtime/infra/cmake/CfgOptionFlags.cmake
+++ b/runtime/infra/cmake/CfgOptionFlags.cmake
@@ -16,7 +16,6 @@ option(ENABLE_COVERAGE "Build for coverage test" OFF)
 #
 # Default build configuration for runtime
 #
-option(BUILD_TRIX_LOADER "Build trix loader" ON)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" ON)
 
 #

--- a/runtime/onert/loader/trix/CMakeLists.txt
+++ b/runtime/onert/loader/trix/CMakeLists.txt
@@ -1,7 +1,3 @@
-if (NOT BUILD_TRIX_LOADER)
-  return()
-endif ()
-
 nnfw_find_package(TRIXEngine QUIET)
 if(NOT TRIXEngine_FOUND)
   message(STATUS "ONERT frontend: Failed to find TRIXEngine")


### PR DESCRIPTION
This commit removes BUILD_TRIX_LOADER cmake option. 
Like other loaders, trix loader is always tried to built, and decided by the build environment.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>