### PR TITLE
[github] Update pypi official release input description

### DIFF
--- a/.github/workflows/pub-onert-pypi.yml
+++ b/.github/workflows/pub-onert-pypi.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       official:
-        description: 'Official release?'
+        description: 'Official release'
         required: true
         type: boolean
         default: false


### PR DESCRIPTION
This commit updates input description for the pypi official release.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>