### PR TITLE
[onert/backend] Add round opeation for cpu backend

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -49,6 +49,7 @@
 #include "ops/ResizeBilinearLayer.h"
 #include "ops/ReverseLayer.h"
 #include "ops/RoPELayer.h"
+#include "ops/RoundLayer.h"
 #include "ops/SelectLayer.h"
 #include "ops/ShapeLayer.h"
 #include "ops/SliceLayer.h"
@@ -1069,7 +1070,7 @@ void KernelGenerator::visit(const ir::operation::Range &node)
 void KernelGenerator::visit(const ir::operation::Rank &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};
-  const auto ifm_index{node.getInputs().at(ir::operation::Shape::Input::INPUT)};
+  const auto ifm_index{node.getInputs().at(ir::operation::Rank::Input::INPUT)};
 
   auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
   auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
@@ -1095,6 +1096,21 @@ void KernelGenerator::visit(const ir::operation::RmsNorm &node)
   auto fn = std::make_unique<ops::RmsNormLayer>();
 
   fn->configure(ifm_tensor, gamma_tensor, epsilon, ofm_tensor);
+
+  _return_fn = std::move(fn);
+}
+
+void KernelGenerator::visit(const ir::operation::Round &node)
+{
+  const auto ofm_index{node.getOutputs().at(0)};
+  const auto ifm_index{node.getInputs().at(ir::operation::Round::Input::INPUT)};
+
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
+
+  auto fn = std::make_unique<ops::RoundLayer>();
+
+  fn->configure(ifm_tensor, ofm_tensor);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -77,6 +77,7 @@ public:
   void visit(const ir::operation::Reverse &) override;
   void visit(const ir::operation::RmsNorm &) override;
   void visit(const ir::operation::RoPE &) override;
+  void visit(const ir::operation::Round &) override;
   void visit(const ir::operation::Select &) override;
   void visit(const ir::operation::Shape &) override;
   void visit(const ir::operation::Slice &) override;

--- a/runtime/onert/backend/cpu/ops/RoundLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RoundLayer.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RoundLayer.h"
+
+#include "OperationUtils.h"
+
+#include <cker/operation/Round.h>
+#include <cker/Types.h>
+
+namespace onert::backend::cpu::ops
+{
+
+RoundLayer::RoundLayer() : _input(nullptr), _output(nullptr)
+{
+  // DO NOTHING
+}
+
+void RoundLayer::configure(const IPortableTensor *input, IPortableTensor *output)
+{
+  _input = input;
+  _output = output;
+}
+
+void RoundLayer::run()
+{
+  switch (_input->data_type())
+  {
+    case OperandType::FLOAT32:
+      nnfw::cker::Round(getShape(_input), getBuffer<float>(_input), getShape(_output),
+                        getBuffer<float>(_output));
+      break;
+
+    default:
+      throw std::runtime_error{"Round: Unsupported data type"};
+  }
+}
+
+} // namespace onert::backend::cpu::ops

--- a/runtime/onert/backend/cpu/ops/RoundLayer.h
+++ b/runtime/onert/backend/cpu/ops/RoundLayer.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in riting, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CPU_OPS_ROUNDLAYER_H__
+#define __ONERT_BACKEND_CPU_OPS_ROUNDLAYER_H__
+
+#include <backend/IPortableTensor.h>
+
+#include <exec/IFunction.h>
+
+namespace onert::backend::cpu::ops
+{
+
+class RoundLayer : public ::onert::exec::IFunction
+{
+public:
+  RoundLayer();
+
+public:
+  void configure(const IPortableTensor *input, IPortableTensor *output);
+
+  void run() override;
+
+private:
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
+};
+
+} // namespace onert::backend::cpu::ops
+
+#endif // __ONERT_BACKEND_CPU_OPS_ROUNDLAYER_H__


### PR DESCRIPTION
This commit add round operation to cpu backend.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

for https://github.com/Samsung/ONE/issues/15758