### PR TITLE
[onert/python] Bump up python onert to 0.2.0

### DIFF
--- a/runtime/infra/python/setup.py
+++ b/runtime/infra/python/setup.py
@@ -147,7 +147,7 @@ except Exception as e:
 # copy .so files to architecture directories
 
 setup(name=package_name,
-      version='0.1.0',
+      version='0.2.0',
       description='onert API binding',
       long_description='It provides onert Python api',
       url='https://github.com/Samsung/ONE',


### PR DESCRIPTION
This commit bumps up python onert to 0.2.0 as dev version.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>