### PR TITLE
[luci/lang] Remove install header pattern

### DIFF
--- a/compiler/luci/lang/CMakeLists.txt
+++ b/compiler/luci/lang/CMakeLists.txt
@@ -16,8 +16,7 @@ target_link_libraries(luci_lang PRIVATE logo)
 target_link_libraries(luci_lang PRIVATE nncc_common)
 
 install(TARGETS luci_lang DESTINATION lib)
-install(DIRECTORY include/ DESTINATION include
-        FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY include/ DESTINATION include)
 
 if(NOT ENABLE_TEST)
   return()


### PR DESCRIPTION
This commit remove install header file name pattern. 
This pattern excludes `CircleNodes.lst` file, but it is used in other header files.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>