### PR TITLE
[onert] Rename permute type for same layout

### DIFF
--- a/runtime/onert/core/include/ir/Layout.h
+++ b/runtime/onert/core/include/ir/Layout.h
@@ -31,11 +31,12 @@ enum class Layout
   NCHW
 };
 
+// PermuteType::SAME is used for data forwarding and type conversion
 enum class PermuteType
 {
   NHWC_TO_NCHW,
   NCHW_TO_NHWC,
-  COPY
+  SAME
 };
 
 inline std::string to_string(Layout layout)

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -100,7 +100,7 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
 
   // Layout in graph is always NHWC, so layout is not changed
   for (uint32_t i = 0; i < input_tensors.size(); i++)
-    permute_types.emplace_back(ir::PermuteType::COPY);
+    permute_types.emplace_back(ir::PermuteType::SAME);
 
   auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, permute_types,
                                                    _external_context);

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
@@ -71,7 +71,7 @@ void PermuteLayer::optimize()
           // NOTE The buffer of both tensor can be nullptr in this step
           const auto data_size = ir::sizeOfDataType(src_tensor.data_type());
 
-          if (permute_type == ir::PermuteType::COPY)
+          if (permute_type == ir::PermuteType::SAME)
           {
             if ((!src_tensor.has_padding() && !dst_tensor.has_padding()))
             {
@@ -133,7 +133,7 @@ void PermuteLayer::appendPermuteTasks(const ITensor *src_tensor, ITensor *dst_te
 {
   size_t distributed_dim = 0;
   auto src_shape = src_tensor->getShape();
-  if (permute_type == ir::PermuteType::COPY)
+  if (permute_type == ir::PermuteType::SAME)
   {
     for (int i = 1; i < src_shape.rank() - 1; ++i)
     {
@@ -259,7 +259,7 @@ void PermuteLayer::run()
         // If dst is subtensor, we have to use clEnqueueMapBuffer instead of clEnqueueWirteBuffer
         else if (dst->needMemoryMap() && !dst->is_subtensor())
         {
-          if (!src->has_padding() && !dst->has_padding() && permute_type == ir::PermuteType::COPY)
+          if (!src->has_padding() && !dst->has_padding() && permute_type == ir::PermuteType::SAME)
           {
             // This is more effective than multi-threading
             src->access([&](backend::ITensor &) { dst->enqueueWriteBuffer(src->buffer(), false); });
@@ -275,7 +275,7 @@ void PermuteLayer::run()
           }
         }
         else if (src->needMemoryMap() && !src->is_subtensor() && !src->has_padding() &&
-                 !dst->has_padding() && permute_type == ir::PermuteType::COPY)
+                 !dst->has_padding() && permute_type == ir::PermuteType::SAME)
         {
           // This is more effective than multi-threading
           assert(!dst->needMemoryMap());

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
@@ -67,7 +67,7 @@ private:
                       uint32_t dst_start_offset, size_t size)
       : _src_buffer{src_buffer}, _dst_buffer{dst_buffer}, _src_start_offset{src_start_offset},
         _dst_start_offset{dst_start_offset}, _src_strides{0}, _dst_strides{0}, _loop_shape{1},
-        _size{size}, _permute_type{ir::PermuteType::COPY}
+        _size{size}, _permute_type{ir::PermuteType::SAME}
     {
       // DO NOTHING
     }
@@ -83,7 +83,7 @@ private:
         size_t dst_offset = _dst_start_offset;
         assert(static_cast<size_t>(_loop_shape.rank()) == coords.size());
         ir::Coordinates dst_coords = coords;
-        if (_permute_type != ir::PermuteType::COPY && _loop_shape.rank() == 4)
+        if (_permute_type != ir::PermuteType::SAME && _loop_shape.rank() == 4)
         {
           dst_coords = ir::convertCoordinates(coords, _permute_type);
         }

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -81,7 +81,7 @@ void WhileLayer::run()
   std::vector<ir::PermuteType> permute_types;
   // Layout in graph is always NHWC, so layout is not changed
   for (uint32_t i = 0; i < op_outputs.size(); i++)
-    permute_types.emplace_back(ir::PermuteType::COPY);
+    permute_types.emplace_back(ir::PermuteType::SAME);
   // Copying body inputs to outputs when the loop body is never executed
   if (!getResultCond(cond_output_tensor.get()))
   {

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -64,7 +64,7 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
 
   // Layout in graph is always NHWC, so layout is not changed
   for (uint32_t i = 0; i < input_tensors.size(); i++)
-    permute_types.emplace_back(ir::PermuteType::COPY);
+    permute_types.emplace_back(ir::PermuteType::SAME);
 
   // NOTE The output buffers of IOTensors are not essential for training. If there
   //      is no output buffer provided by the user, permute is not performed.

--- a/runtime/onert/core/src/exec/IPermuteFunction.cc
+++ b/runtime/onert/core/src/exec/IPermuteFunction.cc
@@ -58,7 +58,7 @@ void elementwiseQuantize(const backend::ITensor *src_tensor, backend::ITensor *d
   int max_val = std::numeric_limits<OutputT>::max();
 
   auto loop_shape = src_tensor->getShape();
-  const bool is_permutation = type != ir::PermuteType::COPY && loop_shape.rank() == 4;
+  const bool is_permutation = type != ir::PermuteType::SAME && loop_shape.rank() == 4;
   ShapeLoop(loop_shape, [&](const onert::ir::Coordinates &coords) {
     const InputT *input_data =
       reinterpret_cast<const InputT *>(src_tensor->buffer() + src_tensor->calcOffset(coords));
@@ -77,7 +77,7 @@ template <typename InputT, typename OutputT>
 void quantize(const backend::ITensor *src_tensor, backend::ITensor *dst_tensor,
               const ir::PermuteType &type)
 {
-  if (!src_tensor->has_padding() && !dst_tensor->has_padding() && type == ir::PermuteType::COPY &&
+  if (!src_tensor->has_padding() && !dst_tensor->has_padding() && type == ir::PermuteType::SAME &&
       !src_tensor->is_dynamic())
   {
     assert(!dst_tensor->is_dynamic());
@@ -103,7 +103,7 @@ void elementwiseDequantize(const backend::ITensor *src_tensor, backend::ITensor 
   const auto zero_point = src_tensor->data_zero_point();
 
   auto loop_shape = src_tensor->getShape();
-  const bool is_permutation = type != ir::PermuteType::COPY && loop_shape.rank() == 4;
+  const bool is_permutation = type != ir::PermuteType::SAME && loop_shape.rank() == 4;
   ShapeLoop(loop_shape, [&](const onert::ir::Coordinates &coords) {
     const InputT *input_data =
       reinterpret_cast<const InputT *>(src_tensor->buffer() + src_tensor->calcOffset(coords));
@@ -121,7 +121,7 @@ template <typename InputT, typename OutputT>
 void dequantize(const backend::ITensor *src_tensor, backend::ITensor *dst_tensor,
                 const ir::PermuteType &type)
 {
-  if (!src_tensor->has_padding() && !dst_tensor->has_padding() && type == ir::PermuteType::COPY &&
+  if (!src_tensor->has_padding() && !dst_tensor->has_padding() && type == ir::PermuteType::SAME &&
       !src_tensor->is_dynamic())
   {
     assert(!dst_tensor->is_dynamic());

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -91,7 +91,7 @@ private:
       // Now there is no case where both src and dst have cl buffer.
       assert(!src->needMemoryMap());
 
-      if (!src->has_padding() && !dst->has_padding() && permute_type == ir::PermuteType::COPY)
+      if (!src->has_padding() && !dst->has_padding() && permute_type == ir::PermuteType::SAME)
       {
         src->access([&](backend::ITensor &) { dst->enqueueWriteBuffer(src->buffer(), false); });
       }
@@ -108,7 +108,7 @@ private:
       }
     }
     else if (src->needMemoryMap() && !src->is_subtensor() && !src->has_padding() &&
-             !dst->has_padding() && permute_type == ir::PermuteType::COPY)
+             !dst->has_padding() && permute_type == ir::PermuteType::SAME)
     {
       assert(!dst->needMemoryMap());
       dst->access([&](backend::ITensor &) { src->enqueueReadBuffer(dst->buffer(), true); });
@@ -133,7 +133,7 @@ private:
     assert(dst_buffer != nullptr);
     assert(dst_size == dst->total_size());
 
-    if (rank == 4 && permute_type != ir::PermuteType::COPY)
+    if (rank == 4 && permute_type != ir::PermuteType::SAME)
     {
       switch (permute_type)
       {

--- a/runtime/onert/core/src/exec/IPermuteFunction.test.cc
+++ b/runtime/onert/core/src/exec/IPermuteFunction.test.cc
@@ -111,7 +111,7 @@ public:
       _src_tensors[i] = inputs[i].get();
       _dst_tensors[i] = outputs[i].get();
       if (inputs[i]->layout() == outputs[i]->layout())
-        _permute_types[i] = ir::PermuteType::COPY;
+        _permute_types[i] = ir::PermuteType::SAME;
       else if (inputs[i]->layout() == ir::Layout::NHWC)
         _permute_types[i] = ir::PermuteType::NHWC_TO_NCHW;
       else

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -213,7 +213,7 @@ void MultiModelExecutors::createEdgeQuantLayers()
             outputs.emplace_back(type_aware_quant_tensor.get());
 
             // No layout change on edge
-            permute_types.emplace_back(ir::PermuteType::COPY);
+            permute_types.emplace_back(ir::PermuteType::SAME);
 
             _edge_quant_tensors[to_iodesc] = std::move(type_aware_quant_tensor);
           }
@@ -307,7 +307,7 @@ void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
         if (input_desc->layout == ir::Layout::NCHW)
           permute_types.emplace_back(ir::PermuteType::NCHW_TO_NHWC);
         else
-          permute_types.emplace_back(ir::PermuteType::COPY);
+          permute_types.emplace_back(ir::PermuteType::SAME);
       }
     }
 
@@ -355,7 +355,7 @@ void MultiModelExecutors::createPkgIOQuantLayers(const IODescription &desc)
         if (output_desc->layout == ir::Layout::NCHW)
           permute_types.emplace_back(ir::PermuteType::NHWC_TO_NCHW);
         else
-          permute_types.emplace_back(ir::PermuteType::COPY);
+          permute_types.emplace_back(ir::PermuteType::SAME);
       }
     }
 

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -114,7 +114,7 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       if (desc->layout == ir::Layout::NCHW)
         input_permute_types.push_back(ir::PermuteType::NCHW_TO_NHWC);
       else
-        input_permute_types.push_back(ir::PermuteType::COPY);
+        input_permute_types.push_back(ir::PermuteType::SAME);
     }
     else
       inputs[i] = tensorpool.back().get();
@@ -160,7 +160,7 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       if (desc->layout == ir::Layout::NCHW)
         output_permute_types.push_back(ir::PermuteType::NHWC_TO_NCHW);
       else
-        output_permute_types.push_back(ir::PermuteType::COPY);
+        output_permute_types.push_back(ir::PermuteType::SAME);
     }
     else
       outputs[i] = tensorpool.back().get();

--- a/runtime/onert/core/src/ir/Coordinates.cc
+++ b/runtime/onert/core/src/ir/Coordinates.cc
@@ -25,7 +25,7 @@ Coordinates convertCoordinates(const Coordinates &coords, const PermuteType &typ
 {
   assert(coords.size() == 4);
   Coordinates to{coords};
-  if (type == PermuteType::COPY)
+  if (type == PermuteType::SAME)
     return to;
 
   if (type == PermuteType::NHWC_TO_NCHW)

--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -64,7 +64,7 @@ Shape convertShape(const Shape &shape, const PermuteType &type)
   assert(shape.rank() <= Shape::kMaxRank);
   Shape ret{shape};
 
-  if (type == ir::PermuteType::COPY || shape.rank() < 4)
+  if (type == ir::PermuteType::SAME || shape.rank() < 4)
     return ret;
 
   // Permutation changing layout beyond 4-D is not supported yet


### PR DESCRIPTION
This commit renames PermuteType::COPY to PermuteType::SAME because it can include type conversion.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13679