### PR TITLE
[circle-mlir/dialect] Implement splitFPTensor method

### DIFF
--- a/circle-mlir/circle-mlir/lib/dialect/src/ops/SplitOp.h
+++ b/circle-mlir/circle-mlir/lib/dialect/src/ops/SplitOp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
- * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ * Copyright 2021 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 
 // from tensorflow/compiler/mlir/lite/ir/tfl_ops.cc
+// from tensorflow/lite/kernels/internal/reference/reference_ops.h
 
 #ifndef __CIRCLE_MLIR_DIALECT_OPS_SPLIT_OP_H__
 #define __CIRCLE_MLIR_DIALECT_OPS_SPLIT_OP_H__
@@ -76,8 +77,83 @@ bool splitFPTensor(Value input, int64_t split_dim, int64_t num_splits,
                    RankedTensorType expected_output_type, SmallVectorImpl<OpFoldResult> &results)
 {
   assert(num_splits > 0);
-  // TODO implement
-  return false;
+
+  std::vector<T> input_values;
+  if (!getAsConstant(input, input_values))
+    return false;
+
+  auto input_type = mlir::dyn_cast<RankedTensorType>(input.getType());
+  auto num_elements = input_type.getNumElements() / num_splits;
+  assert(num_elements == expected_output_type.getNumElements());
+
+  // prepare allocated outputs
+  std::vector<std::vector<T>> output_all;
+  for (int64_t i = 0; i < num_splits; ++i)
+  {
+    std::vector<T> output_data;
+    output_data.resize(num_elements);
+    output_all.push_back(output_data);
+  }
+
+  // NOTE below is reference implementation from
+  //      tensorflow/lite/kernels/internal/reference/reference_ops.h
+  /*
+  int64_t outer_size = 1;
+  for (int i = 0; i < axis; ++i) {
+    outer_size *= input_shape.Dims(i);
+  }
+  // For all output arrays,
+  // FlatSize() = outer_size * Dims(axis) * base_inner_size;
+  int64_t base_inner_size = 1;
+  for (int i = axis + 1; i < split_dimensions; ++i) {
+    base_inner_size *= input_shape.Dims(i);
+  }
+
+  const Scalar* input_ptr = input_data;
+  for (int k = 0; k < outer_size; k++) {
+    for (int i = 0; i < outputs_count; ++i) {
+      const int copy_size = output_shapes[i]->Dims(axis) * base_inner_size;
+      memcpy(output_data[i] + k * copy_size, input_ptr,
+             copy_size * sizeof(Scalar));
+      input_ptr += copy_size;
+    }
+  }
+  */
+
+  int64_t rank = input_type.getRank();
+  int64_t outer_size = 1;
+  for (int64_t i = 0; i < split_dim; ++i)
+  {
+    outer_size *= input_type.getDimSize(i);
+  }
+
+  int64_t base_inner_size = 1;
+  for (int64_t i = split_dim + 1; i < rank; ++i)
+  {
+    base_inner_size *= input_type.getDimSize(i);
+  }
+
+  int64_t copy_size = expected_output_type.getDimSize(split_dim) * base_inner_size;
+  int64_t src = 0;
+  for (int64_t k = 0; k < outer_size; k++)
+  {
+    for (int64_t i = 0; i < num_splits; ++i)
+    {
+      std::vector<T> &split_values = output_all[i];
+      for (int64_t j = 0; j < copy_size; ++j)
+      {
+        split_values[k * copy_size + j] = input_values[src++];
+      }
+    }
+  }
+
+  for (int64_t i = 0; i < num_splits; ++i)
+  {
+    std::vector<T> &split_values = output_all[i];
+    auto elements = DenseFPElementsAttr::get(expected_output_type, split_values);
+    results.push_back(elements);
+  }
+  return true;
 }
 
 LogicalResult SplitOp::fold(FoldAdaptor adaptor, SmallVectorImpl<OpFoldResult> &results)


### PR DESCRIPTION
This will implement splitFPTensor method with reference code from TensorFlow lite kernel.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>