### PR TITLE
[circle-mlir/tools-test] Revise rewrite-test module path

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-rewrite-test/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-rewrite-test/CMakeLists.txt
@@ -66,7 +66,7 @@ add_custom_target(
   DEPENDS onnx2circle_models_target ${FILE_DEPS_VALCHK}
 )
 
-set(MODELS_ROOT "${CMAKE_SOURCE_DIR}/models/net")
+set(MODELS_ROOT "${CMAKE_SOURCE_DIR}/models")
 set(RUN_PATH "${CMAKE_CURRENT_BINARY_DIR}")
 
 foreach(MODEL IN ITEMS ${UNIT_TEST_MODELS})

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-rewrite-test/check_circle_ops.py
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-rewrite-test/check_circle_ops.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 # Check operators with final Circle MLIR
 def check_model(models_root, model_name, ops_path):
-    sys.path.append(models_root)
+    sys.path.append(models_root + "/net")
+    sys.path.append(models_root + "/unit")
     module = importlib.import_module(model_name)
 
     m_keys = module.__dict__.keys()


### PR DESCRIPTION
This will revise onnx2circle-rewrite-test to include also models in 'unit' folder.
