### PR TITLE
[onert] Fix incremental on while loop

### DIFF
--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
@@ -61,9 +61,16 @@ void PermuteLayer::optimize()
       auto dst = *dst_it;
       src_offsets_it->resize(0);
       dst_offsets_it->resize(0);
+      const auto permute_type = *type_it;
+
+      src_it++;
+      dst_it++;
+      src_offsets_it++;
+      dst_offsets_it++;
+      type_it++;
+
       if (underlying_type(src->data_type()) != underlying_type(dst->data_type()))
         continue;
-      const auto permute_type = *type_it;
 
       // TODO Support different types
       auto fn = [&](backend::ITensor &src_tensor) {
@@ -118,11 +125,6 @@ void PermuteLayer::optimize()
         });
       };
       src->access(fn);
-      src_it++;
-      dst_it++;
-      src_offsets_it++;
-      dst_offsets_it++;
-      type_it++;
     }
   }
 }


### PR DESCRIPTION
This commit fixes invalid incremental update of while loop of PermuteLayer::optimize(). 
It fixes to update incremental before continue statement to avoid skipping the update.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13679