### PR TITLE
[onert] Add CompilerOptions field for I/O information

### DIFF
--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -19,6 +19,8 @@
 
 #include "ir/OpCode.h"
 #include "ir/Index.h"
+#include "ir/Layout.h"
+#include "ir/TypeInfo.h"
 
 #include <memory>
 #include <string>
@@ -63,6 +65,10 @@ struct CompilerOptions
 
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
+  std::unordered_map<ir::IOIndex, ir::Layout> input_layout;
+  std::unordered_map<ir::IOIndex, ir::Layout> output_layout;
+  std::unordered_map<ir::IOIndex, ir::TypeInfo> input_type;
+  std::unordered_map<ir::IOIndex, ir::TypeInfo> output_type;
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   int graph_dump_level; //< Graph dump level, values between 0 and 2 are valid


### PR DESCRIPTION
This commit adds input & output data type and layout information map in CompilerOptions to prepare permutation operation on compile phase.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13645
Draft: #13679