### PR TITLE
[circle-mlir/tools-test] Test for Conv2d_F32_R4_g4

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-rewrite-test/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-rewrite-test/test.lst
@@ -3,6 +3,9 @@
 # AddModel(test_model)
 #
 
+AddModel(Conv2d_F32_R4_g4_1)
+AddModel(Conv2d_F32_R4_g4_2)
+
 AddModel(Net_AddReLU_F32_R4)
 AddModel(Net_AddReLUConcat_F32_R4)
 AddModel(Net_AddReLUSub_F32_R4)


### PR DESCRIPTION
This will enable test for Conv2D with group that converts to
Split-[Conv2D]-Concat-Add works as expected.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>