### PR TITLE
[onert] Support logging and threads setting from driver

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -961,6 +961,17 @@ NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
   {
     _coptions->he_profiling_mode = toBool(value);
   }
+  else if (skey == config::ONERT_LOG_ENABLE || skey == config::NUM_THREADS)
+  {
+    onert::util::CfgKeyValues keyValues;
+    keyValues[skey] = std::string(value);
+    onert::util::setConfigKeyValues(keyValues);
+
+    if (skey == config::ONERT_LOG_ENABLE)
+    {
+      UPDATE_VERBOSE_CONFIG();
+    }
+  }
   else
   {
     return NNFW_STATUS_ERROR;

--- a/runtime/onert/core/include/util/logging.h
+++ b/runtime/onert/core/include/util/logging.h
@@ -42,6 +42,7 @@ public:
 
 public:
   bool enabled(void) const { return _enabled; }
+  void update(void) { _enabled = util::getConfigBool(util::config::ONERT_LOG_ENABLE); }
 
 private:
   bool _enabled;
@@ -76,6 +77,8 @@ inline std::string decorated_name(const char *input)
     {                                        \
       METHOD;                                \
   } while (0)
+
+#define UPDATE_VERBOSE_CONFIG() ::onert::util::logging::ctx.update()
 
 #define MEASURE_TIME_START(name) \
   do                             \

--- a/runtime/tests/tools/onert_run/src/onert_run.cc
+++ b/runtime/tests/tools/onert_run/src/onert_run.cc
@@ -222,9 +222,16 @@ int main(const int argc, char **argv)
       NNPR_ENSURE_STATUS(nnfw_codegen(session, codegen.c_str(), NNFW_CODEGEN_PREF_DEFAULT));
     }
 
+    // Configurations from environment variable
     char *available_backends = std::getenv("BACKENDS");
     if (available_backends)
       NNPR_ENSURE_STATUS(nnfw_set_available_backends(session, available_backends));
+    char *log_enable = std::getenv("ONERT_LOG_ENABLE");
+    if (log_enable)
+      NNPR_ENSURE_STATUS(nnfw_set_config(session, "ONERT_LOG_ENABLE", log_enable));
+    char *num_threads = std::getenv("NUM_THREADS");
+    if (num_threads)
+      NNPR_ENSURE_STATUS(nnfw_set_config(session, "NUM_THREADS", num_threads));
 
     // verify input and output
     for (uint32_t i = 0; i < num_inputs; ++i)

--- a/runtime/tests/tools/onert_train/src/onert_train.cc
+++ b/runtime/tests/tools/onert_train/src/onert_train.cc
@@ -74,6 +74,14 @@ int main(const int argc, char **argv)
     // Set training backend
     NNPR_ENSURE_STATUS(nnfw_set_available_backends(session, default_backend_cand));
 
+    // Configurations from environment variable
+    char *log_enable = std::getenv("ONERT_LOG_ENABLE");
+    if (log_enable)
+      NNPR_ENSURE_STATUS(nnfw_set_config(session, "ONERT_LOG_ENABLE", log_enable));
+    char *num_threads = std::getenv("NUM_THREADS");
+    if (num_threads)
+      NNPR_ENSURE_STATUS(nnfw_set_config(session, "NUM_THREADS", num_threads));
+
     uint32_t num_inputs;
     NNPR_ENSURE_STATUS(nnfw_input_size(session, &num_inputs));
 

--- a/runtime/tests/tools/tflite_comparator/src/tflite_comparator.cc
+++ b/runtime/tests/tools/tflite_comparator/src/tflite_comparator.cc
@@ -239,6 +239,20 @@ int main(const int argc, char **argv)
   NNFW_ASSERT_FAIL(nnfw_load_model_from_file(onert_session, tflite_file.c_str()),
                    "[ ERROR ] Failure during model load");
 
+  // Configurations from environment variable
+  char *available_backends = std::getenv("BACKENDS");
+  if (available_backends)
+    NNFW_ASSERT_FAIL(nnfw_set_available_backends(onert_session, available_backends),
+                     "[ ERROR ] Failure to set backend");
+  char *log_enable = std::getenv("ONERT_LOG_ENABLE");
+  if (log_enable)
+    NNFW_ASSERT_FAIL(nnfw_set_config(onert_session, "ONERT_LOG_ENABLE", log_enable),
+                     "[ ERROR ] Failure to set logging");
+  char *num_threads = std::getenv("NUM_THREADS");
+  if (num_threads)
+    NNFW_ASSERT_FAIL(nnfw_set_config(onert_session, "NUM_THREADS", num_threads),
+                     "[ ERROR ] Failure to set number of threads");
+
   uint32_t num_inputs;
   uint32_t num_outputs;
   NNFW_ASSERT_FAIL(nnfw_input_size(onert_session, &num_inputs),


### PR DESCRIPTION
This commit updates nnfw_set_config internal API to support ONERT_LOG_ENABLE and NUM_THREADS. 
It helps to test release onert through test drivers on tizen.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>