### PR TITLE
[infra/gbs] Use same onert core on test build

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -153,8 +153,7 @@ If you want to get coverage info, you should install runtime package which is bu
 %define test_suite_list infra/scripts tests/scripts
 
 %if %{test_build} == 1
-# ENVVAR_ONERT_CONFIG: Use environment variable for runtime core configuration and debug
-%define option_test -DENABLE_TEST=ON -DENVVAR_ONERT_CONFIG=ON
+%define option_test -DENABLE_TEST=ON
 %endif # test_build
 
 # Set option for configuration


### PR DESCRIPTION
This commit updates cmake option on test build to use same core build option with normal build.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>