### PR TITLE
[onert] Deprecate QUANT_INT16_ASYMM type

### DIFF
--- a/runtime/onert/backend/acl_common/Convert.cc
+++ b/runtime/onert/backend/acl_common/Convert.cc
@@ -91,8 +91,8 @@ namespace onert::backend::acl_common
       return ::arm_compute::DataType::F16;
     case ir::DataType::INT64:
       return ::arm_compute::DataType::S64;
-    case ir::DataType::QUANT_INT16_ASYMM:
-      return ::arm_compute::DataType::QASYMM16;
+    case ir::DataType::QUANT_INT16_SYMM:
+      return ::arm_compute::DataType::QSYMM16;
     case ir::DataType::QUANT_INT8_SYMM_PER_CHANNEL:
       return ::arm_compute::DataType::QSYMM8_PER_CHANNEL;
     default:

--- a/runtime/onert/core/include/ir/DataType.h
+++ b/runtime/onert/core/include/ir/DataType.h
@@ -34,7 +34,7 @@ enum class DataType
   FLOAT16 = 7,
   INT64 = 8,
   QUANT_INT8_ASYMM = 9,
-  QUANT_INT16_ASYMM = 10,
+  // QUANT_INT16_ASYMM = 10, // Not used now
   QUANT_INT8_SYMM_PER_CHANNEL = 11,
   QUANT_INT16_SYMM = 12,
   QUANT_GGML_Q4_0 = 13, // 4bit quantization, 32 block, 16bit delta

--- a/runtime/onert/core/src/ir/DataType.cc
+++ b/runtime/onert/core/src/ir/DataType.cc
@@ -46,8 +46,6 @@ size_t sizeOfDataType(DataType data_type)
       return sizeof(float16);
     case DataType::INT64:
       return sizeof(int64_t);
-    case DataType::QUANT_INT16_ASYMM:
-      return sizeof(int16_t);
     case DataType::QUANT_INT16_SYMM:
       return sizeof(int16_t);
     default:

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -269,12 +269,12 @@ void OperationValidator::visit(const operation::ElementwiseActivation &node)
     case operation::ElementwiseActivation::Type::LEAKY_RELU:
       OP_REQUIRES(
         isValidType(input_index, {DataType::FLOAT32, DataType::QUANT_UINT8_ASYMM,
-                                  DataType::QUANT_INT8_ASYMM, DataType::QUANT_INT16_ASYMM}));
+                                  DataType::QUANT_INT8_ASYMM, DataType::QUANT_INT16_SYMM}));
       break;
     case operation::ElementwiseActivation::Type::LOGISTIC:
       OP_REQUIRES(
         isValidType(input_index, {DataType::FLOAT32, DataType::QUANT_UINT8_ASYMM,
-                                  DataType::QUANT_INT8_ASYMM, DataType::QUANT_INT16_ASYMM}));
+                                  DataType::QUANT_INT8_ASYMM, DataType::QUANT_INT16_SYMM}));
       break;
     case operation::ElementwiseActivation::Type::RELU:
       OP_REQUIRES(isValidType(
@@ -283,7 +283,7 @@ void OperationValidator::visit(const operation::ElementwiseActivation &node)
     case operation::ElementwiseActivation::Type::TANH:
       OP_REQUIRES(
         isValidType(input_index, {DataType::FLOAT32, DataType::QUANT_UINT8_ASYMM,
-                                  DataType::QUANT_INT8_ASYMM, DataType::QUANT_INT16_ASYMM}));
+                                  DataType::QUANT_INT8_ASYMM, DataType::QUANT_INT16_SYMM}));
       break;
   }
 }

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Add.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Add.test.cc
@@ -286,14 +286,14 @@ TEST_F(GenModelTest, neg_OneOp_Add_VarToVarSize0_InvalidShape)
 TEST_F(GenModelTest, neg_OneOp_Add_VarToVarInt16)
 {
   CircleGen cgen;
-  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT16}, 1., 2);
-  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT16}, 2., 3);
-  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT16}, 0.5, -6);
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT16}, 1., 0);
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT16}, 2., 0);
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT16}, 0.5, 0);
   cgen.addOperatorAdd({{lhs, rhs}, {out}}, circle::ActivationFunctionType_NONE);
   cgen.setInputsAndOutputs({lhs, rhs}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(uniformTCD<int8_t>({{1, 3, 2, 4}, {5, -4, -7, 4}}, {{0, -32, -46, 2}}));
+  _context->addTestCase(uniformTCD<int8_t>({{1, 3, 2, 4}, {5, -4, -7, 4}}, {{22, -10, -24, 24}}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->expectFailCompile();
 


### PR DESCRIPTION
This commit deprecates QUANT_INT16_ASYMM type.
QUANT_INT16_ASYMM is introduced for NNAPI support, but it is not used any more. 
To confirm type is symmetric, check zero-point values in loader. 
Now signed 16bit tensor quantization is QUANT_INT16_SYMM.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>