### PR TITLE
[onert] Add permute type to Permute IR

### DIFF
--- a/runtime/onert/backend/cpu/SharedMemoryOperands.test.cc
+++ b/runtime/onert/backend/cpu/SharedMemoryOperands.test.cc
@@ -34,7 +34,7 @@ namespace
 {
 void addNotOptimizedNode(Graph *graph, const OperandIndex &input, const OperandIndex &output)
 {
-  graph->addOperation(std::make_unique<operation::Permute>(input, output));
+  graph->addOperation(std::make_unique<operation::Permute>(input, output, PermuteType::SAME));
 }
 } // namespace
 

--- a/runtime/onert/core/include/ir/operation/Permute.h
+++ b/runtime/onert/core/include/ir/operation/Permute.h
@@ -29,21 +29,22 @@ namespace onert::ir::operation
 
 /**
  * @brief Class to represent Permute operation
- * @note  Permute operation reorders the dimensions of a tensor.
+ * @note  Permute operation reorders the dimensions of a tensor and convert data types if needed
  *
  *        This operation is virtual operation, which is not used on real model, but used internally.
- *        It was introduced to support various model layout (NHWC, NCHW, etc) and backend layout.
+ *        This operation is used for below cases.
+ *
  *        But currently, model layout and backend layout are always same as NHWC.
  *        So this operation is used for below cases.
  *        1) Handle model output buffer's special case
  *          1-1) Model output is comes from model constant
  *          1-2) Model output is comes from model input
  *          1-3) Model output shares tensor with other model output(s)
- *        2) Handle shared tensor between different backend
- *
- *        Q) Why name is still 'Permute'?
- *        A) It is handled as copy operation on compile phase,
- *           but it can be permute operation if output buffer layout is changed by API call
+ *        2) Handle when tensor defining backend is different with tensor using backend
+ *        3) Handle when actual input and/or output layouts are different with model layout
+ *           by user setting
+ *        4) Handle when actual input and/or output data type is different with model data type
+ *           by user setting or model connection
  */
 class Permute : public Operation
 {
@@ -52,7 +53,13 @@ public:
   OpCode opcode() const final { return OpCode::Permute; }
 
 public:
-  Permute(const OperandIndex &input, const OperandIndex &output);
+  Permute(const OperandIndex &input, const OperandIndex &output, PermuteType type);
+
+public:
+  PermuteType getPermuteType() const { return _type; }
+
+private:
+  PermuteType _type = PermuteType::SAME;
 };
 
 } // namespace onert::ir::operation

--- a/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
@@ -37,7 +37,7 @@ void ConstantOutputPass::callback(const ir::OperandIndex &ind, ir::Operand &obj)
   obj.info().setAsNonConst();
 
   using ir::operation::Permute;
-  auto permute_obj = std::make_unique<Permute>(permute_input_ind, ind);
+  auto permute_obj = std::make_unique<Permute>(permute_input_ind, ind, ir::PermuteType::SAME);
   auto permute_ind = _graph.operations().push(std::move(permute_obj));
 
   permute_input_obj.insertUse(permute_ind);

--- a/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
@@ -65,7 +65,7 @@ ir::OperandIndex OddOutputPass::insertPermute(ir::OperandIndex ind)
   auto &output_obj = _graph.operands().at(output_ind);
 
   using ir::operation::Permute;
-  auto permute_obj = std::make_unique<Permute>(ind, output_ind);
+  auto permute_obj = std::make_unique<Permute>(ind, output_ind, ir::PermuteType::SAME);
   auto permute_ind = _graph.operations().push(std::move(permute_obj));
 
   output_obj.setDef(permute_ind);

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -146,7 +146,8 @@ ir::OperationIndex PermutationInsertionPass::insertPermute(const ir::OperandInde
 
   // Insert permute operation to the graph
   using Permute = ir::operation::Permute;
-  auto insert_node = std::make_unique<Permute>(operand_index, out_operand_index);
+  auto insert_node =
+    std::make_unique<Permute>(operand_index, out_operand_index, ir::PermuteType::SAME);
 
   auto node_index = _graph.operations().push(std::move(insert_node));
 

--- a/runtime/onert/core/src/ir/operation/Permute.cc
+++ b/runtime/onert/core/src/ir/operation/Permute.cc
@@ -22,8 +22,8 @@ namespace onert::ir::operation
 
 void Permute::accept(OperationVisitor &v) const { v.visit(*this); }
 
-Permute::Permute(const OperandIndex &input, const OperandIndex &output)
-  : Operation{OperandConstraint::createExact(1u)}
+Permute::Permute(const OperandIndex &input, const OperandIndex &output, ir::PermuteType type)
+  : Operation{OperandConstraint::createExact(1u)}, _type{type}
 {
   setInputs({input});
   setOutputs({output});

--- a/runtime/onert/core/src/ir/train/operation/Permute.cc
+++ b/runtime/onert/core/src/ir/train/operation/Permute.cc
@@ -32,7 +32,8 @@ void Permute::accept(OperationVisitor &v) const { v.visit(*this); }
 void Permute::accept(TrainableOperationVisitor &v) const { v.visit(*this); }
 
 Permute::Permute(const OperationType &operation)
-  : OperationType{operation.getInputs().at(0), operation.getOutputs().at(0)}
+  : OperationType{operation.getInputs().at(0), operation.getOutputs().at(0),
+                  operation.getPermuteType()}
 {
   // DO NOTHING
 }

--- a/runtime/onert/core/src/ir/train/operation/UntrainableOperation.test.cc
+++ b/runtime/onert/core/src/ir/train/operation/UntrainableOperation.test.cc
@@ -319,7 +319,7 @@ operation::Pad generatePad()
 
 operation::Permute generatePermute()
 {
-  return operation::Permute{OperandIndex{1}, OperandIndex{0}};
+  return operation::Permute{OperandIndex{1}, OperandIndex{0}, PermuteType::SAME};
 }
 
 operation::Pool2D generatePool2D()


### PR DESCRIPTION
This commit adds permute type to Permute IR.
Compile optimization and backend will use this type to decide optimization and kernel selection.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13679
Related issue: #13645