### PR TITLE
[onert] Support QUANT_INT16_SYMM dequante and quantize OPs

### DIFF
--- a/runtime/onert/backend/cpu/ops/ElementwiseUnaryLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseUnaryLayer.cc
@@ -125,6 +125,12 @@ void dequantizeUint8(const IPortableTensor *input, IPortableTensor *output)
                          getBuffer<float>(output), input->data_scale(), input->data_zero_point());
 }
 
+void dequantizeInt16(const IPortableTensor *input, IPortableTensor *output)
+{
+  nnfw::cker::Dequantize(getShape(input), getBuffer<int16_t>(input), getShape(output),
+                         getBuffer<float>(output), input->data_scale(), input->data_zero_point());
+}
+
 void expFloat32(const IPortableTensor *input, IPortableTensor *output)
 {
   nnfw::cker::Exp(getShape(input), getBuffer<float>(input), getShape(output),
@@ -244,6 +250,10 @@ void ElementwiseUnaryLayer::configure(const IPortableTensor *input, IPortableTen
                (input->data_type() == OperandType::QUANT_INT8_SYMM))
       {
         _kernel = dequantizeInt8;
+      }
+      else if (input->data_type() == OperandType::QUANT_INT16_SYMM)
+      {
+        _kernel = dequantizeInt16;
       }
       else
       {

--- a/runtime/onert/backend/cpu/ops/QuantizeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/QuantizeLayer.cc
@@ -62,9 +62,14 @@ void QuantizeLayer::configure(const IPortableTensor *input, IPortableTensor *out
 
 void QuantizeLayer::run()
 {
-  if ((_input->data_type() == OperandType::FLOAT32))
+  if (_input->data_type() == OperandType::FLOAT32)
   {
-    affineQuantize<float, uint8_t>(_input, _output);
+    if (_output->data_type() == OperandType::QUANT_UINT8_ASYMM)
+      affineQuantize<float, uint8_t>(_input, _output);
+    else if (_output->data_type() == OperandType::QUANT_INT16_SYMM)
+      affineQuantize<float, int16_t>(_input, _output);
+    else
+      throw std::runtime_error{"Quantize: Unsupported data type"};
   }
   else if ((_input->data_type() == OperandType::QUANT_UINT8_ASYMM) &&
            (_output->data_type() == OperandType::QUANT_INT8_ASYMM))

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -315,15 +315,15 @@ void OperationValidator::visit(const operation::ElementwiseUnary &node)
   {
     // NNAPI allow QUANT_INT8_SYMM type input
     OP_REQUIRES(isValidType(input_index, {DataType::QUANT_UINT8_ASYMM, DataType::QUANT_INT8_SYMM,
-                                          DataType::QUANT_INT8_ASYMM}));
+                                          DataType::QUANT_INT8_ASYMM, DataType::QUANT_INT16_SYMM}));
     OP_REQUIRES(isValidType(output_index, DataType::FLOAT32));
   }
   else if (node.param().op_type == operation::ElementwiseUnary::Type::QUANTIZE)
   {
     OP_REQUIRES(isValidType(
       input_index, {DataType::FLOAT32, DataType::QUANT_UINT8_ASYMM, DataType::QUANT_INT8_ASYMM}));
-    OP_REQUIRES(
-      isValidType(output_index, {DataType::QUANT_UINT8_ASYMM, DataType::QUANT_INT8_ASYMM}));
+    OP_REQUIRES(isValidType(output_index, {DataType::QUANT_UINT8_ASYMM, DataType::QUANT_INT8_ASYMM,
+                                           DataType::QUANT_INT16_SYMM}));
   }
   else if (node.param().op_type == operation::ElementwiseUnary::Type::FLOOR)
   {

--- a/runtime/tests/nnfw_api/lib/GenModelTest.h
+++ b/runtime/tests/nnfw_api/lib/GenModelTest.h
@@ -36,6 +36,8 @@ inline size_t sizeOfNnfwType(NNFW_TYPE type)
     case NNFW_TYPE_TENSOR_QUANT8_ASYMM:
     case NNFW_TYPE_TENSOR_QUANT8_ASYMM_SIGNED:
       return 1;
+    case NNFW_TYPE_TENSOR_QUANT16_SYMM_SIGNED:
+      return 2;
     case NNFW_TYPE_TENSOR_FLOAT32:
     case NNFW_TYPE_TENSOR_INT32:
       return 4;
@@ -413,6 +415,9 @@ protected:
               break;
             case NNFW_TYPE_TENSOR_QUANT8_ASYMM_SIGNED:
               compareBuffersExact<int8_t>(ref_output, output, i);
+              break;
+            case NNFW_TYPE_TENSOR_QUANT16_SYMM_SIGNED:
+              compareBuffersExact<int16_t>(ref_output, output, i);
               break;
             case NNFW_TYPE_TENSOR_INT32:
               compareBuffersExact<int32_t>(ref_output, output, i);

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Quantize.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Quantize.test.cc
@@ -29,6 +29,20 @@ CircleGen genSimpleQuantizeModel(circle::TensorType from_t, float input_scale, i
   return cgen;
 }
 
+TEST_F(GenModelTest, OneOp_Quantize_toInt16)
+{
+  CircleGen cgen =
+    genSimpleQuantizeModel(circle::TensorType_FLOAT32, 0, 0, circle::TensorType_INT16, 2., 0);
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(TestCaseData{}
+                          .addInput<float>({-128, 42, 200, -6, 254, -200, 16, -240, 98, -90, 152,
+                                            -32, 180, -150, 84, 20})
+                          .addOutput<int16_t>({-64, 21, 100, -3, 127, -100, 8, -120, 49, -45, 76,
+                                               -16, 90, -75, 42, 10}));
+  _context->setBackends({"cpu"});
+  SUCCEED();
+}
+
 TEST_F(GenModelTest, OneOp_Quantize_Uint8toInt8)
 {
   CircleGen cgen =


### PR DESCRIPTION
This commit updates cpu backend and operation validator to support QUANT_INT16_SYMM type quantize and dequantize operator.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>