### PR TITLE
[onert] Support Call operator in builtin backend

### DIFF
--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.h
@@ -51,6 +51,7 @@ public:
   std::unique_ptr<exec::FunctionSequence> generate(ir::OperationIndex ind) override;
 
 private:
+  void visit(const ir::operation::Call &) override;
   void visit(const ir::operation::If &) override;
   void visit(const ir::operation::Permute &) override;
   void visit(const ir::operation::While &) override;

--- a/runtime/onert/core/src/backend/builtin/kernel/CallLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/CallLayer.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CallLayer.h"
+
+namespace onert::backend::builtin::kernel
+{
+
+CallLayer::CallLayer(const std::vector<backend::IPortableTensor *> input_tensors,
+                     const std::vector<backend::IPortableTensor *> output_tensors,
+                     const ir::SubgraphIndex &callee_subg_index, exec::IExecutors *executors,
+                     const ir::ModelIndex &model_index,
+                     const std::shared_ptr<ExternalContext> &external_context)
+  : _input_tensors{input_tensors}, _output_tensors{output_tensors},
+    _callee_subg_index{callee_subg_index}, _executors{executors}, _model_index{model_index},
+    _external_context{external_context}
+{
+  // DO NOTHING
+}
+
+void CallLayer::run()
+{
+  exec::IExecutor *subg_exec = _executors->at(_model_index, _callee_subg_index);
+  subg_exec->execute(_input_tensors, _output_tensors,
+                     _executors->entryExecutor()->currentOptions());
+}
+
+} // namespace onert::backend::builtin::kernel

--- a/runtime/onert/core/src/backend/builtin/kernel/CallLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/CallLayer.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_BUILTIN_KERNEL_CALL_LAYER_H__
+#define __ONERT_BACKEND_BUILTIN_KERNEL_CALL_LAYER_H__
+
+#include <backend/IPortableTensor.h>
+#include <exec/IExecutors.h>
+#include <exec/IFunction.h>
+#include "../ExternalContext.h"
+
+namespace onert::backend::builtin::kernel
+{
+
+class CallLayer : public ::onert::exec::IFunction
+{
+public:
+  CallLayer(const std::vector<backend::IPortableTensor *> input_tensors,
+            const std::vector<backend::IPortableTensor *> output_tensors,
+            const ir::SubgraphIndex &callee_subg_index, exec::IExecutors *executors,
+            const ir::ModelIndex &model_index,
+            const std::shared_ptr<ExternalContext> &external_context);
+
+public:
+  void run() override;
+
+private:
+  const std::vector<backend::IPortableTensor *> _input_tensors;
+  const std::vector<backend::IPortableTensor *> _output_tensors;
+  const ir::SubgraphIndex _callee_subg_index;
+  exec::IExecutors *_executors;
+  ir::ModelIndex _model_index;
+  const std::shared_ptr<ExternalContext> _external_context;
+};
+
+} // namespace onert::backend::builtin::kernel
+
+#endif // __ONERT_BACKEND_BUILTIN_KERNEL_CALL_LAYER_H__


### PR DESCRIPTION
This commit introduces Call operator builtin backend kernel.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/15704
Related issue: https://github.com/Samsung/ONE/issues/15655