### PR TITLE
[onert] Set compile option for each model in MultiModelCompiler

### DIFF
--- a/runtime/onert/core/src/compiler/MultiModelCompiler.h
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.h
@@ -56,6 +56,9 @@ public:
   std::shared_ptr<CompilerArtifact> compile(void);
 
 private:
+  CompilerOptions optionForSingleModel(const ir::ModelIndex &model_index);
+
+private:
   std::shared_ptr<ir::NNPkg> _nnpkg;
   CompilerOptions *_options;
 };


### PR DESCRIPTION
This commit implements to use compile options for each model in MultiModelCompiler.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/13679