### PR TITLE
[onert] Fix test fail by RPATH

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -18,10 +18,10 @@ set(ONERT_INSTALL_CODEGENDIR ${ONERT_INSTALL_COREDIR}/codegen)
 # Decide rpath for runtime library here because install path is decided above
 # API rpath: find core
 # core rpath: find plugins - loader, backend, odc, codegen
-# plugin rpath: find core
+# plugin rpath: find core, dependent libraries (ex. armcompute)
 set(ONERT_RPATH_API "$ORIGIN:$ORIGIN/nnfw")
 set(ONERT_RPATH_CORE "$ORIGIN:$ORIGIN/loader:$ORIGIN/backend:$ORIGIN/odc:$ORIGIN/codegen")
-set(ONERT_RPATH_PLUGIN "$ORIGIN:$ORIGIN/..")
+set(ONERT_RPATH_PLUGIN "$ORIGIN:$ORIGIN/..:$ORIGIN/../..")
 
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)


### PR DESCRIPTION
This commit fixes RPATH for backend to find arm compute library on acl_cl and acl_neon backend

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>