### PR TITLE
[onert] Add one-op test for Call

### DIFF
--- a/runtime/tests/nnfw_api/lib/CircleGen.cc
+++ b/runtime/tests/nnfw_api/lib/CircleGen.cc
@@ -635,6 +635,13 @@ uint32_t CircleGen::addOperatorRoPE(const OperatorParams &params, circle::RoPEMo
                                 circle::BuiltinOptions_RoPEOptions, options);
 }
 
+uint32_t CircleGen::addOperatorCall(const OperatorParams &params, uint32_t callee_subg)
+{
+  auto options = circle::CreateCallOptions(_fbb, callee_subg).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_CALL,
+                                circle::BuiltinOptions_CallOptions, options);
+}
+
 // NOTE Please add addOperator functions ABOVE this lie
 //
 // %  How to add a new addOperatorXXX fuction

--- a/runtime/tests/nnfw_api/lib/CircleGen.h
+++ b/runtime/tests/nnfw_api/lib/CircleGen.h
@@ -151,6 +151,7 @@ public:
                                   bool asymmetric_quantize_inputs = false);
   uint32_t addOperatorBatchToSpaceND(const OperatorParams &params);
   uint32_t addOperatorBroadcastTo(const OperatorParams &params);
+  uint32_t addOperatorCall(const OperatorParams &params, uint32_t callee_subg);
   uint32_t addOperatorCast(const OperatorParams &params, circle::TensorType input_type,
                            circle::TensorType output_type);
   uint32_t addOperatorConcatenation(const OperatorParams &params, int axis,

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Call.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Call.test.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+#include <memory>
+
+TEST_F(GenModelTest, OneOp_Call)
+{
+  // The model looks just like the below pseudocode
+  //
+  // function model(x)
+  // {
+  //   return x+1;
+  // }
+
+  CircleGen cgen;
+  uint32_t incr_buf = cgen.addBuffer(std::vector<float>{1});
+
+  // primary subgraph
+  {
+    int x_in = cgen.addTensor({{1}, circle::TensorType_FLOAT32});
+    int x_out = cgen.addTensor({{1}, circle::TensorType_FLOAT32});
+    cgen.addOperatorCall({{x_in}, {x_out}}, 1);
+    cgen.setInputsAndOutputs({x_in}, {x_out});
+  }
+
+  // callee subgraph
+  {
+    cgen.nextSubgraph();
+    int x_in = cgen.addTensor({{1}, circle::TensorType_FLOAT32});
+    int incr = cgen.addTensor({{1}, circle::TensorType_FLOAT32, incr_buf});
+    int x_out = cgen.addTensor({{1}, circle::TensorType_FLOAT32});
+    cgen.addOperatorAdd({{x_in, incr}, {x_out}}, circle::ActivationFunctionType_NONE);
+    cgen.setInputsAndOutputs({x_in}, {x_out});
+  }
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{0}}, {{1}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}


### PR DESCRIPTION
This commit adds one-op test for Call operator.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/15704
Related issue: https://github.com/Samsung/ONE/issues/15655