### PR TITLE
[github] Remove ubuntu 20.04 aarch64 docker publish test

### DIFF
--- a/.github/workflows/build-pub-dev-docker.yml
+++ b/.github/workflows/build-pub-dev-docker.yml
@@ -165,7 +165,7 @@ jobs:
     needs: build-docker-image
     strategy:
       matrix:
-        ubuntu_code: [ 'focal', 'jammy', 'noble' ]
+        ubuntu_code: [ 'jammy', 'noble' ] # focal: not supported onert build
       fail-fast: false
     runs-on: one-arm-linux
     container:


### PR DESCRIPTION
This commit removes ubuntu 20.04 aarch64 docker publish test in build-pub-dev-docker.yml.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>