### PR TITLE
[onert] Introduce set input & output type API

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -171,11 +171,12 @@ NNFW_STATUS nnfw_pop_pipeline_output(nnfw_session *session, void *outputs);
  * If it is not called, runtime will infer the type from the model.
  * This function should be called after {@link nnfw_load_model_from_file} and
  * before {@link nnfw_prepare}.
- * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
+ * Now only NNFW_TYPE_TENSOR_FLOAT32 is supported. If other types are passed,
+ * runtime will return error.
  *
  * @param[in] session session from input is to be extracted
  * @param[in] index   index of input to be set (0-indexed)
- * @param[in] type    type to set to target input. This can be NNFW_TYPE_FLOAT32 only.
+ * @param[in] type    type to set to target input. This can be NNFW_TYPE_TENSOR_FLOAT32 only.
  *
  * @return    @c NNFW_STATUS_NO_ERROR if successful
  */
@@ -189,11 +190,12 @@ NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE
  * If it is not called, runtime will output the type from the model.
  * This function should be called after {@link nnfw_load_model_from_file} and
  * before {@link nnfw_prepare}.
- * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
+ * Now only NNFW_TYPE_TENSOR_FLOAT32 is supported. If other types are passed,
+ * runtime will return error.
  *
  * @param[in] session session from output is to be extracted
  * @param[in] index   index of output to be set (0-indexed)
- * @param[in] type    type to set to target output. This can be NNFW_TYPE_FLOAT32 only.
+ * @param[in] type    type to set to target output. This can be NNFW_TYPE_TENSOR_FLOAT32 only.
  *
  * @return    @c NNFW_STATUS_NO_ERROR if successful
  */

--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -164,6 +164,42 @@ NNFW_STATUS nnfw_push_pipeline_input(nnfw_session *session, void *inputs, void *
 NNFW_STATUS nnfw_pop_pipeline_output(nnfw_session *session, void *outputs);
 
 /**
+ * @brief Set the type of an input
+ *
+ * User can call this function to set the type of an input.
+ * Then user can pass input data of that type.
+ * If it is not called, runtime will infer the type from the model.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
+ * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
+ *
+ * @param[in] session session from input is to be extracted
+ * @param[in] index   index of input to be set (0-indexed)
+ * @param[in] type    type to set to target input. This can be NNFW_TYPE_FLOAT32 only.
+ *
+ * @return    @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
+
+/**
+ * @brief Set the type of an output
+ *
+ * User can call this function to set the type of an output.
+ * Then user can pass output data of that type.
+ * If it is not called, runtime will output the type from the model.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
+ * Now only NNFW_TYPE_FLOAT32 is supported. If other types are passed, runtime will return error.
+ *
+ * @param[in] session session from output is to be extracted
+ * @param[in] index   index of output to be set (0-indexed)
+ * @param[in] type    type to set to target output. This can be NNFW_TYPE_FLOAT32 only.
+ *
+ * @return    @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
+
+/**
  *  Training C APIs
  *
  * Training APIs are designed to be used in the following order for training

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -131,6 +131,18 @@ NNFW_STATUS nnfw_set_output_layout(nnfw_session *session, uint32_t index, NNFW_L
   return session->set_output_layout(index, layout);
 }
 
+NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE type)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_input_type(index, type);
+}
+
+NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYPE type)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_output_type(index, type);
+}
+
 NNFW_STATUS nnfw_input_tensorinfo(nnfw_session *session, uint32_t index,
                                   nnfw_tensorinfo *tensor_info)
 {

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -691,7 +691,7 @@ NNFW_STATUS nnfw_session::set_input_type(uint32_t index, NNFW_TYPE type)
   if (!isStateModelLoaded())
   {
     std::cerr << "Error during nnfw_session::set_input_type : "
-              << "run should be run before prepare" << std::endl;
+              << "set_input_type should be called before prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -723,7 +723,7 @@ NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
   if (!isStateModelLoaded())
   {
     std::cerr << "Error during nnfw_session::set_output_type : "
-              << "run should be run before prepare" << std::endl;
+              << "set_output_type should be called before prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -686,6 +686,70 @@ NNFW_STATUS nnfw_session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
   return NNFW_STATUS_NO_ERROR;
 }
 
+NNFW_STATUS nnfw_session::set_input_type(uint32_t index, NNFW_TYPE type)
+{
+  if (!isStateModelLoaded())
+  {
+    std::cerr << "Error during nnfw_session::set_input_type : "
+              << "run should be run before prepare" << std::endl;
+    return NNFW_STATUS_INVALID_STATE;
+  }
+
+  try
+  {
+    if (type != NNFW_TYPE_TENSOR_FLOAT32)
+    {
+      std::cerr << "Error during nnfw_session::set_input_type, not supported type" << std::endl;
+      return NNFW_STATUS_ERROR;
+    }
+
+    _coptions->input_type.insert_or_assign(onert::ir::IOIndex{index},
+                                           onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::set_input_type : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  // Not supporting yet
+  // TODO Enable this
+  std::cerr << "Error during nnfw_session::set_input_type : NYI" << std::endl;
+  return NNFW_STATUS_ERROR;
+}
+
+NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
+{
+  if (!isStateModelLoaded())
+  {
+    std::cerr << "Error during nnfw_session::set_output_type : "
+              << "run should be run before prepare" << std::endl;
+    return NNFW_STATUS_INVALID_STATE;
+  }
+
+  try
+  {
+    if (type != NNFW_TYPE_TENSOR_FLOAT32)
+    {
+      std::cerr << "Error during nnfw_session::set_output_type, not supported type" << std::endl;
+      return NNFW_STATUS_ERROR;
+    }
+
+    _coptions->output_type.insert_or_assign(onert::ir::IOIndex{index},
+                                            onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::set_output_type : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  // Not supporting yet
+  // TODO Enable this
+  std::cerr << "Error during nnfw_session::set_output_type : NYI" << std::endl;
+  return NNFW_STATUS_ERROR;
+}
+
 NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti)
 {
   // sanity check

--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -120,6 +120,8 @@ public:
 
   NNFW_STATUS set_input_layout(uint32_t index, NNFW_LAYOUT layout);
   NNFW_STATUS set_output_layout(uint32_t index, NNFW_LAYOUT layout);
+  NNFW_STATUS set_input_type(uint32_t index, NNFW_TYPE type);
+  NNFW_STATUS set_output_type(uint32_t index, NNFW_TYPE type);
 
   NNFW_STATUS set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti);
 


### PR DESCRIPTION
This commit introduces set input & output type experimental API to support passing float data to quantized model.
New APIs should be called before preparing.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/13679
Related issue: https://github.com/Samsung/ONE/issues/13645