### PR TITLE
[github] Fix docker image build platform on publish workflow

### DIFF
--- a/.github/workflows/build-pub-dev-docker.yml
+++ b/.github/workflows/build-pub-dev-docker.yml
@@ -236,7 +236,7 @@ jobs:
         with:
           file: ./infra/docker/${{ matrix.version }}/Dockerfile
           push: true
-          platforms: linux/amd64${{ matrix.platform }}
+          platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.version }}
           cache-to: type=gha,mode=max,scope=${{ matrix.version }}
           tags: |


### PR DESCRIPTION
This commit fixes a bug setting build platform on image publish workflow.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>