### PR TITLE
[infra] Remove needless compiler header copy

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -161,13 +161,8 @@ ifeq (,$(findstring android,$(TARGET_OS)))
 # install angkor TensorIndex and oops InternalExn header (TODO: Remove this)
 	@mkdir -p ${OVERLAY_FOLDER}/include/nncc/core/ADT/tensor
 	@mkdir -p ${OVERLAY_FOLDER}/include/oops
-	@mkdir -p ${OVERLAY_FOLDER}/include/luci/IR
-	@mkdir -p ${OVERLAY_FOLDER}/include/mio/circle
 	@cp compiler/angkor/include/nncc/core/ADT/tensor/Index.h ${OVERLAY_FOLDER}/include/nncc/core/ADT/tensor
 	@cp compiler/oops/include/oops/InternalExn.h ${OVERLAY_FOLDER}/include/oops
-	@cp compiler/luci/lang/include/luci/IR/CircleNodes.lst ${OVERLAY_FOLDER}/include/luci/IR
-	@cp ${NNCC_WORKSPACE}/compiler/mio-circle08/gen/mio/circle/schema_generated.h ${OVERLAY_FOLDER}/include/mio/circle
-	@cp -r ${NNCC_WORKSPACE}/overlay/include/flatbuffers ${OVERLAY_FOLDER}/include
 	@echo "Done prepare-nncc"
 endif
 

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -196,13 +196,8 @@ cmake --install %{nncc_workspace} %{strip_options}
 # install angkor TensorIndex and oops InternalExn header (TODO: Remove this)
 mkdir -p %{overlay_path}/include/nncc/core/ADT/tensor
 mkdir -p %{overlay_path}/include/oops
-mkdir -p %{overlay_path}/include/luci/IR
-mkdir -p %{overlay_path}/include/mio/circle
 cp compiler/angkor/include/nncc/core/ADT/tensor/Index.h %{overlay_path}/include/nncc/core/ADT/tensor
 cp compiler/oops/include/oops/InternalExn.h %{overlay_path}/include/oops
-cp compiler/luci/lang/include/luci/IR/CircleNodes.lst %{overlay_path}/include/luci/IR
-cp %{nncc_workspace}/compiler/mio-circle08/gen/mio/circle/schema_generated.h %{overlay_path}/include/mio/circle
-cp -r %{nncc_workspace}/overlay/include/flatbuffers %{overlay_path}/include
 %endif # odc_build
 
 # runtime build


### PR DESCRIPTION
This commit removes needless compiler header copy.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>