### PR TITLE
[infra/onert] Handle package config file in cmake

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -8,8 +8,6 @@ License: Apache-2.0 and MIT and BSD-2-Clause and MPL-2.0
 Source0: %{name}-%{version}.tar.gz
 Source1: %{name}.manifest
 Source1001: nnapi_test_generated.tar.gz
-Source2001: onert.pc.in
-Source2002: onert-plugin.pc.in
 Source3001: ABSEIL.tar.gz
 Source3002: CPUINFO.tar.gz
 Source3003: FARMHASH.tar.gz
@@ -142,9 +140,11 @@ If you want to use test package, you should install runtime package which is bui
 %define option_config -DASAN_BUILD=ON
 %endif # asan
 
+# CMAKE_INSTALL_PREFIX is used for config files
+# Actual install path is set by --prefix option in cmake install command
 %define build_options -DCMAKE_BUILD_TYPE=%{build_type} -DTARGET_ARCH=%{target_arch} -DTARGET_OS=tizen \\\
         -DEXTERNALS_BUILD_THREAD=%{nproc} -DBUILD_MINIMAL_SAMPLE=OFF -DNNFW_OVERLAY_DIR=$(pwd)/%{overlay_path} \\\
-        %{option_test} %{option_config} %{extra_option}
+        -DCMAKE_INSTALL_PREFIX=%{_prefix} %{option_test} %{option_config} %{extra_option}
 
 %define strip_options %{nil}
 %if %{build_type} == "Release"
@@ -215,18 +215,7 @@ cp -r %{nncc_workspace}/overlay/include/flatbuffers %{overlay_path}/include
 
 %{build_env} ./nnfw install --prefix %{buildroot}%{_prefix} %{strip_options}
 
-# For developer
-cp %{SOURCE2001} .
-cp %{SOURCE2002} .
-sed -i 's:@libdir@:%{_libdir}:g
-        s:@includedir@:%{_includedir}:g
-        s:@version@:%{version}:g' ./onert.pc.in
-sed -i 's:@libdir@:%{_libdir}:g
-        s:@includedir@:%{_includedir}:g
-        s:@version@:%{version}:g' ./onert-plugin.pc.in
-mkdir -p %{buildroot}%{_libdir}/pkgconfig
-install -m 0644 ./onert.pc.in %{buildroot}%{_libdir}/pkgconfig/onert.pc
-install -m 0644 ./onert-plugin.pc.in %{buildroot}%{_libdir}/pkgconfig/onert-plugin.pc
+# For developer - linking pkg-config files for backward compatibility
 pushd %{buildroot}%{_libdir}/pkgconfig
 ln -sf onert.pc nnfw.pc
 ln -sf onert-plugin.pc nnfw-plugin.pc

--- a/packaging/onert-plugin.pc.in
+++ b/packaging/onert-plugin.pc.in
@@ -1,5 +1,0 @@
-Name: onert-plugin
-Description: onert plugin API
-Version: @version@
-Libs: -L@libdir@ -lonert_core
-Cflags: -I@includedir@/nnfw -I@includedir@/onert

--- a/packaging/onert.pc.in
+++ b/packaging/onert.pc.in
@@ -1,5 +1,0 @@
-Name: onert
-Description: onert API
-Version: @version@
-Libs: -L@libdir@ -lonert
-Cflags: -I@includedir@/nnfw

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3)
 
-project(nnfw)
+project(onert VERSION 1.31.0)
 
 enable_testing()
 

--- a/runtime/infra/debian/rules
+++ b/runtime/infra/debian/rules
@@ -28,9 +28,12 @@ override_dh_auto_configure:
 	test -d externals || mkdir -p externals
 	find packaging/ -type f -name "*.tar.gz" | xargs -i tar xf {} -C externals
 	mkdir -p $(NNFW_WORKSPACE)
+# CMAKE_INSTALL_PREFIX is used for config files
+# Actual install path is set by --prefix option in cmake install command
 	./nnfw configure -DCMAKE_BUILD_TYPE=Release -DEXTERNALS_BUILD_THREADS=$(NPROC) \
 	  -DDOWNLOAD_GTEST=OFF -DENABLE_TEST=OFF \
 		-DBUILD_PYTHON_BINDING=OFF -DBUILD_MINIMAL_SAMPLE=OFF
+		-DCMAKE_INSTALL_PREFIX=/usr
 
 override_dh_auto_build:
 	./nnfw build -j$(NPROC)
@@ -39,13 +42,4 @@ override_dh_auto_install:
 	./nnfw install --prefix $(NNFW_INSTALL_PREFIX) --strip
 
 override_dh_install:
-	install -d $(NNFW_INSTALL_PREFIX)/lib/pkgconfig
-	install -m 0644 packaging/onert.pc.in -T $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/onert.pc
-	install -m 0644 packaging/onert-plugin.pc.in -T $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/onert-plugin.pc
-	sed -i 's:@libdir@:\/usr\/lib:g' $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/onert.pc
-	sed -i 's:@includedir@:\/usr\/include:g' $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/onert.pc
-	sed -i 's:@version@:${DEBVER}:g' $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/onert.pc
-	sed -i 's:@libdir@:\/usr\/lib:g' $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/onert-plugin.pc
-	sed -i 's:@includedir@:\/usr\/include:g' $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/onert-plugin.pc
-	sed -i 's:@version@:${DEBVER}:g' $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/onert-plugin.pc
 	dh_install

--- a/runtime/onert/api/nnfw/CMakeLists.txt
+++ b/runtime/onert/api/nnfw/CMakeLists.txt
@@ -29,3 +29,7 @@ set_target_properties(${ONERT_DEV} PROPERTIES
 install(TARGETS ${ONERT_DEV}
         LIBRARY DESTINATION ${ONERT_INSTALL_APIDIR}
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nnfw)
+
+# Install pkg-config file for NNFW API
+configure_file(onert.pc.in onert.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/onert.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/runtime/onert/api/nnfw/onert.pc.in
+++ b/runtime/onert/api/nnfw/onert.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@ONERT_INSTALL_APIDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+version=@CMAKE_PROJECT_VERSION@
+
+Name: onert
+Description: onert API
+Version: ${version}
+Libs: -L${libdir} -lonert
+Cflags: -I${includedir}/nnfw

--- a/runtime/onert/core/CMakeLists.txt
+++ b/runtime/onert/core/CMakeLists.txt
@@ -45,6 +45,10 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
 
 set_target_properties(onert_core PROPERTIES INSTALL_RPATH ${ONERT_RPATH_CORE})
 
+# Install pkg-config file for onert plugin developer
+configure_file(onert-plugin.pc.in onert-plugin.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/onert-plugin.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)

--- a/runtime/onert/core/onert-plugin.pc.in
+++ b/runtime/onert/core/onert-plugin.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@ONERT_INSTALL_COREDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+version=@CMAKE_PROJECT_VERSION@
+
+Name: onert-plugin
+Description: onert plugin API
+Version: @CMAKE_PROJECT_VERSION@
+Libs: -L@libdir@ -lonert_core
+Cflags: -I@includedir@/onert


### PR DESCRIPTION
This commit moves package config file handling from each build script into cmake.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>