### PR TITLE
[infra/onert] Fix debian packaging bug

### DIFF
--- a/runtime/infra/debian/rules
+++ b/runtime/infra/debian/rules
@@ -32,7 +32,7 @@ override_dh_auto_configure:
 # Actual install path is set by --prefix option in cmake install command
 	./nnfw configure -DCMAKE_BUILD_TYPE=Release -DEXTERNALS_BUILD_THREADS=$(NPROC) \
 	  -DDOWNLOAD_GTEST=OFF -DENABLE_TEST=OFF \
-		-DBUILD_PYTHON_BINDING=OFF -DBUILD_MINIMAL_SAMPLE=OFF
+		-DBUILD_PYTHON_BINDING=OFF -DBUILD_MINIMAL_SAMPLE=OFF \
 		-DCMAKE_INSTALL_PREFIX=/usr
 
 override_dh_auto_build:


### PR DESCRIPTION
This commit adds missing `\` to the `rules` file for onert debian packaging.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>