### PR TITLE
[infra/onert] Update Debian install scripts

### DIFF
--- a/runtime/infra/debian/onert-dev.install
+++ b/runtime/infra/debian/onert-dev.install
@@ -1,4 +1,2 @@
-# {FILES_TO_INSTALL} {DEST_DIR}
-# include
-usr/include/nnfw usr/include/
-usr/lib/pkgconfig/onert.pc usr/lib/pkgconfig/
+/usr/include/nnfw
+/usr/lib/*/pkgconfig/onert.pc

--- a/runtime/infra/debian/onert-plugin-dev.install
+++ b/runtime/infra/debian/onert-plugin-dev.install
@@ -1,3 +1,2 @@
-# {FILES_TO_INSTALL} {DEST_DIR}
-usr/include/onert usr/include/
-usr/lib/pkgconfig/onert-plugin.pc usr/lib/pkgconfig/
+/usr/include/onert
+/usr/lib/*/pkgconfig/onert-plugin.pc

--- a/runtime/infra/debian/onert-train.install
+++ b/runtime/infra/debian/onert-train.install
@@ -1,2 +1,1 @@
-# {FILES_TO_INSTALL} {DEST_DIR}
-usr/lib/nnfw/backend/libbackend_train.so
+/usr/lib/*/nnfw/backend/libbackend_train.so

--- a/runtime/infra/debian/onert-trix.install
+++ b/runtime/infra/debian/onert-trix.install
@@ -1,4 +1,2 @@
-# {FILES_TO_INSTALL} {DEST_DIR}
-# lib
-usr/lib/nnfw/loader/libtvn_loader.so usr/lib/nnfw/loader/
-usr/lib/nnfw/backend/libbackend_trix.so usr/lib/nnfw/backend/
+/usr/lib/*/nnfw/loader/libtvn_loader.so
+/usr/lib/*/nnfw/backend/libbackend_trix.so

--- a/runtime/infra/debian/onert.install
+++ b/runtime/infra/debian/onert.install
@@ -1,6 +1,4 @@
-# {FILES_TO_INSTALL} {DEST_DIR}
-# lib
-usr/lib/*.so usr/lib/
-usr/lib/nnfw/*.so usr/lib/nnfw
-usr/lib/nnfw/backend/libbackend_cpu.so usr/lib/nnfw/backend/
-usr/lib/nnfw/backend/libbackend_ruy.so usr/lib/nnfw/backend/
+/usr/lib/*/libonert.so
+/usr/lib/*/nnfw/libonert_core.so
+/usr/lib/*/nnfw/backend/libbackend_cpu.so
+/usr/lib/*/nnfw/backend/libbackend_ruy.so

--- a/runtime/infra/debian/rules
+++ b/runtime/infra/debian/rules
@@ -42,4 +42,4 @@ override_dh_auto_install:
 	./nnfw install --prefix $(NNFW_INSTALL_PREFIX) --strip
 
 override_dh_install:
-	dh_install
+	dh_install --sourcedir=debian/tmp --fail-missing


### PR DESCRIPTION
This commit updates the debian installation scripts to use `--sourcedir` option to find install target files. 
It will help to describe file including platform dependent path. 
It include `--fail-missing` option to fail when file is missing.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>