### PR TITLE
[infra/onert] Add git ignore file to debian directory

### DIFF
--- a/runtime/infra/debian/.gitignore
+++ b/runtime/infra/debian/.gitignore
@@ -1,0 +1,14 @@
+files
+*.log
+*.substvars
+.debhelper/
+tmp/
+
+# Pacakge dir
+nnfw/
+nnfw-dev/
+onert/
+onert-dev/
+onert-plugin-dev/
+onert-train/
+onert-trix/

--- a/runtime/infra/debian/.gitignore
+++ b/runtime/infra/debian/.gitignore
@@ -4,7 +4,7 @@ files
 .debhelper/
 tmp/
 
-# Pacakge dir
+# Package dir
 nnfw/
 nnfw-dev/
 onert/


### PR DESCRIPTION
This commit adds .gitignore file into onert debian directory. 
It will be useful to use symlink to debian directory in root directory.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>