### PR TITLE
[onert] Add skipping permute elimination pass condition

### DIFF
--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
@@ -34,6 +34,14 @@ void PermutationEliminationPass::visit(const ir::operation::Permute &node)
   auto in_operand = node.getInputs().at(0);
   auto out_operand = node.getOutputs().at(0);
 
+  // If permutation type is not SAME, we don't need to do anything here.
+  if (node.getPermuteType() != ir::PermuteType::SAME)
+    return;
+
+  // Check if the input and output are the same type
+  if (_graph.operands().at(in_operand).typeInfo() != _graph.operands().at(out_operand).typeInfo())
+    return;
+
   // Check if two tensors are both portable if not, we can't eliminate the node
   {
     auto &operand_li_map = _lowered_graph.lower_info().operand;


### PR DESCRIPTION
This commit adds a condition to skip permute elimination pass when the permute layout and data type is not same.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13645
Draft: #13679