### PR TITLE
[infra/command] Change pushd & popd usage to cd

### DIFF
--- a/infra/command/format
+++ b/infra/command/format
@@ -49,14 +49,6 @@ do
   esac
 done
 
-function pushd () {
-  command pushd "$@" > /dev/null
-}
-
-function popd () {
-  command popd "$@" > /dev/null
-}
-
 function command_exists() {
   command -v $1 > /dev/null 2>&1
 }
@@ -152,7 +144,7 @@ function check_python_files() {
   fi
 }
 
-pushd ${NNAS_PROJECT_PATH}
+cd ${NNAS_PROJECT_PATH} || exit
 
 if [[ -n "$(git diff)" ]] && { [[ "${CHECK_DIFF_ONLY}" != "1" ]] || [[ "${CHECK_STAGED_ONLY}" != "1" ]]; }; then
   echo "[WARNING] Commit all the changes before running format check"
@@ -200,7 +192,7 @@ else
   DIFF=$(git diff | tee ${PATCH_FILE})
 fi
 
-popd
+cd ~- || exit
 
 if [[ -z "${CRCHECK}" ]] && [[ ! -n "${DIFF}" ]] && [[ ${INVALID_EXIT} -eq 0 ]]; then
   echo "[PASSED] Format checker succeed."


### PR DESCRIPTION
This commit changes the usage of pushd and popd in the format command
- Remove indirect usage for pushd and popd
- Replace pushd to cd
- Replace popd to 'cd -'
- Exit if 'cd' fails

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>