### PR TITLE
[onert] Support DynamicUpdateSlice in loader

### DIFF
--- a/runtime/onert/core/src/loader/BaseLoader.h
+++ b/runtime/onert/core/src/loader/BaseLoader.h
@@ -1650,6 +1650,9 @@ void BaseLoader<LoaderDomain>::loadOperation(const Operator *op, ir::Graph &subg
     case BuiltinOperator::BuiltinOperator_HASHTABLE_LOOKUP:
       loadOperationTo<ir::operation::HashtableLookup>(op, subg);
       return;
+    case BuiltinOperator::BuiltinOperator_DYNAMIC_UPDATE_SLICE:
+      loadOperationTo<ir::operation::DynamicUpdateSlice>(op, subg);
+      return;
     default:
       throw std::runtime_error(
         std::string("Unsupported operation: ").append(EnumNameBuiltinOperator(builtin_op)));


### PR DESCRIPTION
This commit updates loader to support DynamicUpdateSlice.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/15808
Draft: https://github.com/Samsung/ONE/pull/15818