### PR TITLE
[infra/command] File handling to use arrays instead of strings

### DIFF
--- a/infra/command/format
+++ b/infra/command/format
@@ -57,7 +57,7 @@ function check_newline() {
   # Exclude binary (refer .gitattributes file)
   # TODO Remove svg file excluding
   #   .svg: xml type ML for vector graphic
-  FILES_TO_CHECK_EOF=$(echo "$FILES_TO_CHECK" | tr ' ' '\n' | grep -Ev '((\.caffemodel)|(\.png)|(\.pdf)|(\.h5)|(\.pdf)|(\.tar.gz)|(\.tflite)|(\.pdf)|(\.bmp)|(\.svg))$')
+  FILES_TO_CHECK_EOF=$(echo "${FILES_TO_CHECK[@]}" | tr ' ' '\n' | grep -Ev '((\.caffemodel)|(\.png)|(\.pdf)|(\.h5)|(\.pdf)|(\.tar.gz)|(\.tflite)|(\.pdf)|(\.bmp)|(\.svg))$')
 
   echo "${FILES_TO_CHECK_EOF[@]}" | xargs -P $(nproc) -I {} bash -c "if diff /dev/null '{}' | tail -1 | grep -q '\\ No newline'; then echo >> '{}'; fi"
 }
@@ -99,7 +99,7 @@ function check_cpp_files() {
   fi
 
   # Check c++ files: replace ' ' with newline, check with grep
-  FILES_TO_CHECK_CPP=$(echo "$FILES_TO_CHECK" | tr ' ' '\n' | grep -E '((\.c[cl]?)|(\.cpp)|(\.h(pp)?))$')
+  FILES_TO_CHECK_CPP=($(echo "${FILES_TO_CHECK[@]}" | grep -E '((\.c[cl]?)|(\.cpp)|(\.h(pp)?))$'))
   # Transform to array
   FILES_TO_CHECK_CPP=($FILES_TO_CHECK_CPP)
 
@@ -125,15 +125,15 @@ function check_python_files() {
   fi
 
   # Check python files
-  FILES_TO_CHECK_PYTHON=($(echo "$FILES_TO_CHECK" | tr ' ' '\n' | grep -E '\.py$'))
+  FILES_TO_CHECK_PYTHON=($(echo "${FILES_TO_CHECK[@]}" | tr ' ' '\n' | grep -E '\.py$'))
   # Exceptional case: one-cmds don't have '.py' extension: ignore non-python source (cmake, etc) and ignore shell script: one-prepare-venv
-  FILES_TO_CHECK_PYTHON+=($(echo "$FILES_TO_CHECK" | tr ' ' '\n' | grep -E '^compiler/one-cmds/[^(\./)]*$' | grep -Ev '^compiler/one-cmds/one-prepare-venv$'))
+  FILES_TO_CHECK_PYTHON+=($(echo "${FILES_TO_CHECK[@]}" | tr ' ' '\n' | grep -E '^compiler/one-cmds/[^(\./)]*$' | grep -Ev '^compiler/one-cmds/one-prepare-venv$'))
   # Exceptional case: onecc-docker don't have '.py' extension.
-  FILES_TO_CHECK_PYTHON+=($(echo "$FILES_TO_CHECK" | tr ' ' '\n' | grep -E '^compiler/onecc-docker/onecc-docker$'))
+  FILES_TO_CHECK_PYTHON+=($(echo "${FILES_TO_CHECK[@]}" | tr ' ' '\n' | grep -E '^compiler/onecc-docker/onecc-docker$'))
   # Exceptional case: visq don't have '.py' extension.
-  FILES_TO_CHECK_PYTHON+=($(echo "$FILES_TO_CHECK" | tr ' ' '\n' | grep -E '^compiler/visq/visq$'))
+  FILES_TO_CHECK_PYTHON+=($(echo "${FILES_TO_CHECK[@]}" | tr ' ' '\n' | grep -E '^compiler/visq/visq$'))
   # Exceptional case: fm-equalize doesn't have '.py' extension.
-  FILES_TO_CHECK_PYTHON+=($(echo "$FILES_TO_CHECK" | tr ' ' '\n' | grep -E '^compiler/fm-equalize/fm-equalize$'))
+  FILES_TO_CHECK_PYTHON+=($(echo "${FILES_TO_CHECK[@]}" | tr ' ' '\n' | grep -E '^compiler/fm-equalize/fm-equalize$'))
 
   if [[ ${#FILES_TO_CHECK_PYTHON} -ne 0 ]]; then
     yapf -p -i ${FILES_TO_CHECK_PYTHON[@]}
@@ -160,7 +160,7 @@ __Check_PYTHON=${CHECK_PYTHON:-"1"}
 #   100755: regular executable
 #   100644: regular readable
 # Reference: https://github.com/git/git/blob/cd42415/Documentation/technical/index-format.txt#L72-L81
-FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${DIRECTORIES_TO_BE_TESTED[@]} | grep -Ev '^1[26]0000' | cut -f2)
+FILES_TO_CHECK=($(git ls-files -c -s --exclude-standard ${DIRECTORIES_TO_BE_TESTED[@]} | grep -Ev '^1[26]0000' | cut -f2))
 if [[ "${CHECK_DIFF_ONLY}" = "1" ]]; then
   MASTER_EXIST=$(git rev-parse --verify master)
   CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
@@ -171,11 +171,11 @@ if [[ "${CHECK_DIFF_ONLY}" = "1" ]]; then
     echo "Current branch is master"
   else
     if [[ "${CHECK_STAGED_ONLY}" = "1" ]]; then
-      FILES_TO_CHECK=$(git diff --staged --name-only --diff-filter=d)
+      FILES_TO_CHECK=($(git diff --staged --name-only --diff-filter=d))
     else
-      FILES_TO_CHECK=$(git diff --name-only --diff-filter=d HEAD~${DIFF_COMMITS})
+      FILES_TO_CHECK=($(git diff --name-only --diff-filter=d HEAD~${DIFF_COMMITS}))
     fi
-    FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | grep -Ev '^1[26]0000' | cut -f2)
+    FILES_TO_CHECK=($(git ls-files -c -s --exclude-standard "${FILES_TO_CHECK[@]}" | grep -Ev '^1[26]0000' | cut -f2))
   fi
 fi
 
@@ -185,8 +185,8 @@ check_cpp_files
 check_python_files
 
 if [[ "${CHECK_DIFF_ONLY}" = "1" ]] && [[ "${CHECK_STAGED_ONLY}" = "1" ]]; then
-  if [[ -n "${FILES_TO_CHECK}" ]]; then
-    DIFF=$(git diff ${FILES_TO_CHECK} | tee ${PATCH_FILE})
+  if [[ ${#FILES_TO_CHECK[@]} -ne 0 ]]; then
+    DIFF=$(git diff "${FILES_TO_CHECK[@]}" | tee ${PATCH_FILE})
   fi
 else
   DIFF=$(git diff | tee ${PATCH_FILE})


### PR DESCRIPTION
This commit converts FILES_TO_CHECK and related variables to arrays. 
It includes fixing potential issues with spaces in filenames by properly using array syntax.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>