### PR TITLE
[onert] Support scalar shape input setting

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -768,7 +768,7 @@ NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensor
       return NNFW_STATUS_UNEXPECTED_NULL;
     }
 
-    if (ti->rank <= 0 || ti->rank > NNFW_MAX_RANK)
+    if (ti->rank < 0 || ti->rank > NNFW_MAX_RANK)
     {
       std::cerr << "unsupported rank: " << ti->rank << std::endl;
       return NNFW_STATUS_ERROR;


### PR DESCRIPTION
This commit supports scalar shape in nnfw_set_inputinfo API.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #15836
