### PR TITLE
[onert] Use PermutationIOPass on auto compilation

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -635,15 +635,15 @@ NNFW_STATUS nnfw_odc_delete_minmax_file(nnfw_session *session);
  *
  * Additionally the following parameters should be set up :
  * 1. Quantization type {@link nnfw_set_quantization_type }
- * 2. Quantizated model path {@link  nnfw_set_quantized_model_path }
+ * 2. Quantized model path {@link  nnfw_set_quantized_model_path }
  * 3. Minmax records threshold for quantization {@link nnfw_set_odc_param_minmax_records_count }
- * 3. File with minMax statistics can be removed by {@link nnfw_odc_delete_minmax_file}
- * 4. Compiled model path {@link  nnfw_set_codegen_model_path}
+ * 4. File with minMax statistics can be removed by {@link nnfw_odc_delete_minmax_file}
+ * 5. Compiled model path {@link  nnfw_set_codegen_model_path}
  *
  * Model is loaded by {@link nnfw_load_model_from_file},
  * session is prepared for inference by {@link nnfw_prepare},
  * set input and output float buffers by {@link nnfw_set_input} and {@link nnfw_set_output}.
- * This function should be called after those functions.
+ * This function must be called after model loading, preparation, and buffer setup are complete.
  *
  * After auto compilation, quantized model still uses float input/output buffer
  * and cast them to quantized type in runtime automatically.

--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -620,16 +620,18 @@ NNFW_STATUS nnfw_odc_delete_minmax_file(nnfw_session *session);
 /**
  * @brief  Run inference with auto compilation
  *
- * <p>This function runs inference with automatic compilation and replaces
- *  the original model with a quantized or compiled model inside.
- * During the inference the minmax statistics is collected and after that quantization is performed.
- * If quantization was successful, try to code generating for target backend, otherwise run original
- float model.
+ * This function runs inference float model with automatic compilation and
+ * replaces the original model with a quantized or compiled model inside.
+ *
+ * During the inference, the minmax statistics is collected and after that
+ * quantization is performed.
+ * If quantization was successful, try to code generating for target backend,
+ * otherwise run original float model.
+ *
  * If compilation was successful, run compiled model, otherwise run quantized model.
- * On-device compiler (ODC) provides quantization and compilation functionality.
- * Function should be called after model is loaded by {@link nnfw_load_model_from_file},
- * session is prepared for inference by {@link nnfw_prepare}, set input and output buffers
- * by {@link nnfw_set_input} and {@link nnfw_set_output}.
+ *
+ * Auto compilation uses on-device compiler (ODC), and ODC provides
+ * quantization and compilation functionality.
  *
  * Additionally the following parameters should be set up :
  * 1. Quantization type {@link nnfw_set_quantization_type }
@@ -637,7 +639,14 @@ NNFW_STATUS nnfw_odc_delete_minmax_file(nnfw_session *session);
  * 3. Minmax records threshold for quantization {@link nnfw_set_odc_param_minmax_records_count }
  * 3. File with minMax statistics can be removed by {@link nnfw_odc_delete_minmax_file}
  * 4. Compiled model path {@link  nnfw_set_codegen_model_path}
- * </p>
+ *
+ * Model is loaded by {@link nnfw_load_model_from_file},
+ * session is prepared for inference by {@link nnfw_prepare},
+ * set input and output float buffers by {@link nnfw_set_input} and {@link nnfw_set_output}.
+ * This function should be called after those functions.
+ *
+ * After auto compilation, quantized model still uses float input/output buffer
+ * and cast them to quantized type in runtime automatically.
  *
  * @param[in] session nnfw_session
  * @param[in] target  Target backend to generate code as in {@link nnfw_codegen}

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -2300,25 +2300,25 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
       std::vector<const void *> _input_buffers;
       std::vector<void *> _output_buffers;
 
-      // Save Inputs buffers
-      for (size_t input_index = 0; input_index < input_size; input_index++)
+      using namespace onert::ir;
+      // Save Inputs buffers, set compile option to use float type
+      for (auto input_index = IOIndex{0}; input_index < IOIndex{input_size}; input_index++)
       {
-        auto io_input_index = onert::ir::IOIndex(input_index);
-        auto input_Shape = _execution->getInputShape(io_input_index);
-        auto input_buffer = _execution->getInputBuffer(io_input_index);
+        auto input_Shape = _execution->getInputShape(input_index);
+        auto input_buffer = _execution->getInputBuffer(input_index);
 
         _input_buffers.push_back(input_buffer);
+        _coptions->input_type.insert_or_assign(input_index, TypeInfo(DataType::FLOAT32));
       }
 
       // Save Outputs buffers
-      for (size_t output_index = 0; output_index < output_size; output_index++)
+      for (auto output_index = IOIndex{0}; output_index < IOIndex{output_size}; output_index++)
       {
-        auto io_output_index = onert::ir::IOIndex(output_index);
-
-        auto output_Shape = _execution->getOutputShape(io_output_index);
-        auto output_buffer = _execution->getOutputBuffer(io_output_index);
+        auto output_Shape = _execution->getOutputShape(output_index);
+        auto output_buffer = _execution->getOutputBuffer(output_index);
 
         _output_buffers.push_back(output_buffer);
+        _coptions->output_type.insert_or_assign(output_index, TypeInfo(DataType::FLOAT32));
       }
 
       // Save execution options
@@ -2377,7 +2377,6 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         if (status != NNFW_STATUS_NO_ERROR)
           return status;
 
-        ti.dtype = NNFW_TYPE_TENSOR_FLOAT32;
         auto input_size_in_bytes = getBufSize(&ti);
 
         status = set_input(input_index, ti.dtype, _input_buffers[input_index], input_size_in_bytes);
@@ -2394,8 +2393,6 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         status = output_tensorinfo(output_index, &ti);
         if (status != NNFW_STATUS_NO_ERROR)
           return status;
-
-        ti.dtype = NNFW_TYPE_TENSOR_FLOAT32;
 
         uint64_t output_size_in_bytes = getBufSize(&ti);
 


### PR DESCRIPTION
This commit updates auto compilation API implementation to use PermutationIOPass compile option internally. 
This commit includes updating API comment for user understanding. 
This update is tested on unittest: OdcAutoCompilation.test.cc

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/13645
Draft: https://github.com/Samsung/ONE/pull/13679