### PR TITLE
[onert] Support I/O type setting API

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw.h
+++ b/runtime/onert/api/nnfw/include/nnfw.h
@@ -332,13 +332,10 @@ NNFW_STATUS nnfw_await(nnfw_session *session);
  * reused for many inferences. \p length must be greater or equal than the operand requires. To
  * specify an optional input, you can either not call this for that input or call this with \p
  * buffer of NULL and \p length of 0.
- * If you set {@link NNFW_TYPE_TENSOR_FLOAT32} type and model has quantized input type on given
- * index, runtime will set quantized data type model input by converting from float buffer data
- * internally.
  *
  * @param[in] session Session to the input is to be set
  * @param[in] index   Index of input to be set (0-indexed)
- * @param[in] type    Type of the input
+ * @param[in] type    Type of the input (deprecated)
  * @param[in] buffer  Raw buffer for input
  * @param[in] length  Size of bytes of input buffer
  *
@@ -354,13 +351,10 @@ NNFW_STATUS nnfw_set_input(nnfw_session *session, uint32_t index, NNFW_TYPE type
  * reused for many inferences. \p length must be greater or equal than the operand requires. An
  * output operand can have unspecified shape and deduced dynamically during the execution. You must
  * provide \p buffer large enough.
- * If you set {@link NNFW_TYPE_TENSOR_FLOAT32} type and model has quantized output type on given
- * index, runtime will set dequantized float buffer data from quantize data type model output
- * internally.
  *
  * @param[in]   session Session from inference output is to be extracted
  * @param[in]   index   Index of output to be set (0-indexed)
- * @param[in]   type    Type of the output
+ * @param[in]   type    Type of the output (deprecated)
  * @param[out]  buffer  Raw buffer for output
  * @param[in]   length  Size of bytes of output buffer
  *
@@ -398,9 +392,11 @@ NNFW_STATUS nnfw_output_size(nnfw_session *session, uint32_t *number);
 /**
  * @brief Set the layout of an input
  *
- * The input that does not call this has NNFW_LAYOUT_NHWC layout
+ * The input that does not call this has NNFW_LAYOUT_NHWC layout.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
  *
- * @param[in] session session from inference input is to be extracted
+ * @param[in] session session from input is to be extracted
  * @param[in] index   index of input to be set (0-indexed)
  * @param[in] layout  layout to set to target input
  *
@@ -411,9 +407,11 @@ NNFW_STATUS nnfw_set_input_layout(nnfw_session *session, uint32_t index, NNFW_LA
 /**
  * @brief Set the layout of an output
  *
- * The output that does not call this has NNFW_LAYOUT_NHWC layout
+ * The output that does not call this has NNFW_LAYOUT_NHWC layout.
+ * This function should be called after {@link nnfw_load_model_from_file} and
+ * before {@link nnfw_prepare}.
  *
- * @param[in] session session from inference output is to be extracted
+ * @param[in] session session from output is to be extracted
  * @param[in] index   index of output to be set (0-indexed)
  * @param[in] layout  layout to set to target output
  *

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -520,8 +520,7 @@ NNFW_STATUS nnfw_session::await()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_input(uint32_t index, NNFW_TYPE type, const void *buffer,
-                                    size_t length)
+NNFW_STATUS nnfw_session::set_input(uint32_t index, NNFW_TYPE, const void *buffer, size_t length)
 {
   if (!isStatePreparedOrFinishedRun())
   {
@@ -539,10 +538,6 @@ NNFW_STATUS nnfw_session::set_input(uint32_t index, NNFW_TYPE type, const void *
 
   try
   {
-    // Allow float input internal quantization only
-    if (type == NNFW_TYPE_TENSOR_FLOAT32)
-      _execution->setInputType(onert::ir::IOIndex(index),
-                               onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
     _execution->setInput(onert::ir::IOIndex(index), buffer, length);
   }
   catch (const std::exception &e)
@@ -553,7 +548,7 @@ NNFW_STATUS nnfw_session::set_input(uint32_t index, NNFW_TYPE type, const void *
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_output(uint32_t index, NNFW_TYPE type, void *buffer, size_t length)
+NNFW_STATUS nnfw_session::set_output(uint32_t index, NNFW_TYPE, void *buffer, size_t length)
 {
   if (!isStatePreparedOrFinishedRun())
   {
@@ -571,10 +566,6 @@ NNFW_STATUS nnfw_session::set_output(uint32_t index, NNFW_TYPE type, void *buffe
 
   try
   {
-    // Allow float output internal dequantization only
-    if (type == NNFW_TYPE_TENSOR_FLOAT32)
-      _execution->setOutputType(onert::ir::IOIndex(index),
-                                onert::ir::TypeInfo(onert::ir::DataType::FLOAT32));
     _execution->setOutput(onert::ir::IOIndex(index), buffer, length);
   }
   catch (const std::exception &e)
@@ -712,10 +703,7 @@ NNFW_STATUS nnfw_session::set_input_type(uint32_t index, NNFW_TYPE type)
     return NNFW_STATUS_ERROR;
   }
 
-  // Not supporting yet
-  // TODO Enable this
-  std::cerr << "Error during nnfw_session::set_input_type : NYI" << std::endl;
-  return NNFW_STATUS_ERROR;
+  return NNFW_STATUS_NO_ERROR;
 }
 
 NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
@@ -744,10 +732,7 @@ NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
     return NNFW_STATUS_ERROR;
   }
 
-  // Not supporting yet
-  // TODO Enable this
-  std::cerr << "Error during nnfw_session::set_output_type : NYI" << std::endl;
-  return NNFW_STATUS_ERROR;
+  return NNFW_STATUS_NO_ERROR;
 }
 
 NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti)


### PR DESCRIPTION
This commit updates nnfw_set_input_type and nnfw_set_output_type API implementation to support I/O setting before prepare. 
These APIs are used on onert_run with '--force_float' option. 
It deprecates type setting on nnfw_set_input and nnfw_set_output API. 
By this update, type casting operation is added in internal graph, not in executor.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/13645
Draft: https://github.com/Samsung/ONE/pull/13679