### PR TITLE
[infra/command] Fix git branch detection

### DIFF
--- a/infra/command/format
+++ b/infra/command/format
@@ -175,7 +175,7 @@ __Check_PYTHON=${CHECK_PYTHON:-"1"}
   mapfile -t FILES_TO_CHECK < <(git ls-files -c -s --exclude-standard "${DIRECTORIES_TO_BE_TESTED[@]}" | grep -Ev '^1[26]0000' | cut -f2)
 if [[ "${CHECK_DIFF_ONLY}" = "1" ]]; then
   MASTER_EXIST=$(git rev-parse --verify master)
-  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
+  CURRENT_BRANCH=$(git branch | grep '^\*' | cut -d ' ' -f2-)
   DIFF_COMMITS=$(git log --graph --oneline master..HEAD | wc -l)
   if [[ -z "${MASTER_EXIST}" ]]; then
     echo "Cannot found local master branch"


### PR DESCRIPTION
This commit updates the git branch detection command by using a more precise regex pattern ('^\*').

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>