### PR TITLE
[onert] Remove I/O type setting in Execution

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -108,18 +108,6 @@ public:
    */
   void setOutputLayout(const ir::IOIndex &index, ir::Layout layout);
   /**
-   * @brief     Set input type information
-   * @param[in] index     Input index
-   * @param[in] typeInfo  Input type information
-   */
-  void setInputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo);
-  /**
-   * @brief     Set output type information
-   * @param[in] index     Output index
-   * @param[in] typeInfo  Output type information
-   */
-  void setOutputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo);
-  /**
    * @brief  Execution
    * @note   It should be called after setting input and output buffer
    */

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -117,18 +117,6 @@ void Execution::setOutputLayout(const ir::IOIndex &index, ir::Layout layout)
   _ctx.desc.outputs.at(index.value())->layout = layout;
 }
 
-void Execution::setInputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo)
-{
-  _ctx.desc.inputs.at(index.value())->info.typeInfo(typeInfo);
-  _ctx.shape_updated = true;
-}
-
-void Execution::setOutputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo)
-{
-  _ctx.desc.outputs.at(index.value())->info.typeInfo(typeInfo);
-  _ctx.shape_updated = true;
-}
-
 void Execution::execute()
 {
   VERBOSE(Execution) << "Start execution" << std::endl;


### PR DESCRIPTION
This commit removes I/O type setting in Execution. 
Unittests are updated to change I/O type setting before compile, not in execution.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>