### PR TITLE
[onert] Set I/O layout before prepare

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -622,10 +622,10 @@ NNFW_STATUS nnfw_session::output_size(uint32_t *number)
 
 NNFW_STATUS nnfw_session::set_input_layout(uint32_t index, NNFW_LAYOUT layout)
 {
-  if (!isStatePreparedOrFinishedRun())
+  if (!isStateModelLoaded())
   {
     std::cerr << "Error during nnfw_session::set_input_layout : "
-              << "run should be run after prepare" << std::endl;
+              << "run should be run before prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -638,7 +638,8 @@ NNFW_STATUS nnfw_session::set_input_layout(uint32_t index, NNFW_LAYOUT layout)
       return NNFW_STATUS_ERROR;
     }
 
-    _execution->setInputLayout(onert::ir::IOIndex(index), convertLayout(layout));
+    // Insert if not exists, otherwise update the value
+    _coptions->input_layout[onert::ir::IOIndex{index}] = convertLayout(layout);
   }
   catch (const std::exception &e)
   {
@@ -650,10 +651,10 @@ NNFW_STATUS nnfw_session::set_input_layout(uint32_t index, NNFW_LAYOUT layout)
 
 NNFW_STATUS nnfw_session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
 {
-  if (!isStatePreparedOrFinishedRun())
+  if (!isStateModelLoaded())
   {
     std::cerr << "Error during nnfw_session::set_output_layout : "
-              << "run should be run after prepare" << std::endl;
+              << "run should be run before prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -667,7 +668,8 @@ NNFW_STATUS nnfw_session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
       return NNFW_STATUS_ERROR;
     }
 
-    _execution->setOutputLayout(onert::ir::IOIndex(index), convertLayout(layout));
+    // Insert if not exists, otherwise update the value
+    _coptions->output_layout[onert::ir::IOIndex{index}] = convertLayout(layout);
   }
   catch (const std::exception &e)
   {

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -96,18 +96,6 @@ public:
    */
   void setOutput(const ir::IOIndex &index, const ir::Shape &shape, void *buffer, size_t length);
   /**
-   * @brief     Set input data's data format
-   * @param[in] index   Input index
-   * @param[in] layout  Input data's data format
-   */
-  void setInputLayout(const ir::IOIndex &index, ir::Layout layout);
-  /**
-   * @brief     Set output data's data format
-   * @param[in] index   Output index
-   * @param[in] layout  Output data's data format
-   */
-  void setOutputLayout(const ir::IOIndex &index, ir::Layout layout);
-  /**
    * @brief  Execution
    * @note   It should be called after setting input and output buffer
    */

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -107,16 +107,6 @@ void Execution::setOutput(const ir::IOIndex &index, const ir::Shape &shape, void
   setOutput(index, buffer, length);
 }
 
-void Execution::setInputLayout(const ir::IOIndex &index, ir::Layout layout)
-{
-  _ctx.desc.inputs.at(index.value())->layout = layout;
-}
-
-void Execution::setOutputLayout(const ir::IOIndex &index, ir::Layout layout)
-{
-  _ctx.desc.outputs.at(index.value())->layout = layout;
-}
-
 void Execution::execute()
 {
   VERBOSE(Execution) << "Start execution" << std::endl;

--- a/runtime/tests/custom_op/FillFrom/FillFrom_runner.cc
+++ b/runtime/tests/custom_op/FillFrom/FillFrom_runner.cc
@@ -199,7 +199,6 @@ int main(const int argc, char **argv)
       inputs[i] = genData(input_num_elements);
       NNPR_ENSURE_STATUS(nnfw_set_input(session, i, NNFW_TYPE_TENSOR_FLOAT32, inputs[i].data(),
                                         sizeof(float) * input_num_elements));
-      NNPR_ENSURE_STATUS(nnfw_set_input_layout(session, i, NNFW_LAYOUT_CHANNELS_LAST));
     }
   };
 
@@ -218,7 +217,6 @@ int main(const int argc, char **argv)
     outputs[i].resize(output_num_elements);
     NNPR_ENSURE_STATUS(nnfw_set_output(session, i, NNFW_TYPE_TENSOR_FLOAT32, outputs[i].data(),
                                        sizeof(float) * output_num_elements));
-    NNPR_ENSURE_STATUS(nnfw_set_output_layout(session, i, NNFW_LAYOUT_CHANNELS_LAST));
   }
 
   uint64_t run_ms = NowMicros();

--- a/runtime/tests/tools/onert_run/src/onert_run.cc
+++ b/runtime/tests/tools/onert_run/src/onert_run.cc
@@ -173,7 +173,6 @@ int main(const int argc, char **argv)
           inputs[i].alloc(input_size_in_bytes, ti.dtype);
           NNPR_ENSURE_STATUS(
             nnfw_set_input(session, i, ti.dtype, inputs[i].data(), input_size_in_bytes));
-          NNPR_ENSURE_STATUS(nnfw_set_input_layout(session, i, NNFW_LAYOUT_CHANNELS_LAST));
         }
         for (uint32_t i = 0; i < num_outputs; i++)
         {
@@ -183,7 +182,6 @@ int main(const int argc, char **argv)
           outputs[i].alloc(output_size_in_bytes, ti.dtype);
           NNPR_ENSURE_STATUS(
             nnfw_set_output(session, i, ti.dtype, outputs[i].data(), output_size_in_bytes));
-          NNPR_ENSURE_STATUS(nnfw_set_output_layout(session, i, NNFW_LAYOUT_CHANNELS_LAST));
         }
 
         auto random_generator = RandomGenerator();

--- a/runtime/tests/tools/onert_train/src/h5formatter.cc
+++ b/runtime/tests/tools/onert_train/src/h5formatter.cc
@@ -149,7 +149,6 @@ void H5Formatter::loadInputs(const std::string &filename, std::vector<Allocation
           throw std::runtime_error("onert_run can load f32, i32, qasymm8, bool and uint8.");
       }
       NNPR_ENSURE_STATUS(nnfw_set_input(session_, i, ti.dtype, inputs[i].data(), bufsz));
-      NNPR_ENSURE_STATUS(nnfw_set_input_layout(session_, i, NNFW_LAYOUT_CHANNELS_LAST));
     }
   }
   catch (const H5::Exception &e)

--- a/runtime/tests/tools/onert_train/src/randomgen.cc
+++ b/runtime/tests/tools/onert_train/src/randomgen.cc
@@ -70,7 +70,6 @@ void RandomGenerator::generate(std::vector<Allocation> &inputs)
     }
     NNPR_ENSURE_STATUS(
       nnfw_set_input(session_, i, ti.dtype, inputs[i].data(), input_size_in_bytes));
-    NNPR_ENSURE_STATUS(nnfw_set_input_layout(session_, i, NNFW_LAYOUT_CHANNELS_LAST));
   }
 };
 

--- a/runtime/tests/tools/onert_train/src/rawformatter.cc
+++ b/runtime/tests/tools/onert_train/src/rawformatter.cc
@@ -61,7 +61,6 @@ void RawFormatter::loadInputs(const std::string &prefix, std::vector<Allocation>
       file.close();
 
       NNPR_ENSURE_STATUS(nnfw_set_input(session_, i, ti.dtype, inputs[i].data(), bufsz));
-      NNPR_ENSURE_STATUS(nnfw_set_input_layout(session_, i, NNFW_LAYOUT_CHANNELS_LAST));
     }
   }
   catch (const std::exception &e)


### PR DESCRIPTION
This commit updates API implementation to set I/O layout before prepare, not before inference.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/13645
Draft: https://github.com/Samsung/ONE/pull/13679