### PR TITLE
[onert] Remove layout info from Executor and Tensor

### DIFF
--- a/runtime/onert/core/include/exec/ExecutionContext.h
+++ b/runtime/onert/core/include/exec/ExecutionContext.h
@@ -32,13 +32,9 @@ struct InputDesc
   ir::OperandInfo info;
   const void *buffer;
   size_t size;
-  ir::Layout layout;
 
   InputDesc(void) = delete;
-  InputDesc(const ir::OperandInfo &info)
-    : info(info), buffer(nullptr), size(0), layout(ir::Layout::NHWC)
-  {
-  }
+  InputDesc(const ir::OperandInfo &info) : info(info), buffer(nullptr), size(0) {}
 };
 
 struct OutputDesc
@@ -46,13 +42,9 @@ struct OutputDesc
   ir::OperandInfo info;
   void *buffer;
   size_t size;
-  ir::Layout layout;
 
   OutputDesc(void) = delete;
-  OutputDesc(const ir::OperandInfo &info)
-    : info(info), buffer(nullptr), size(0), layout(ir::Layout::NHWC)
-  {
-  }
+  OutputDesc(const ir::OperandInfo &info) : info(info), buffer(nullptr), size(0) {}
 };
 
 struct IODescription

--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -101,20 +101,6 @@ struct IExecutor
   virtual const ir::OperandInfo &outputInfo(uint32_t index) const = 0;
 
   /**
-   * @brief     Get input layout at index
-   * @param[in] index Index of input
-   * @return    Input operand layout
-   */
-  virtual ir::Layout inputLayout(uint32_t index) const = 0;
-
-  /**
-   * @brief     Get output layout at index
-   * @param[in] index Index of output
-   * @return    Output operand layout
-   */
-  virtual ir::Layout outputLayout(uint32_t index) const = 0;
-
-  /**
    * @brief     Get output buffer at index
    * @param[in] index Index of output
    * @return    Output buffer

--- a/runtime/onert/core/src/backend/builtin/IOTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.cc
@@ -27,8 +27,7 @@ IOTensor::~IOTensor() {}
 
 IOTensor::IOTensor(const ir::OperandInfo &info)
   : IPortableTensor{info}, _tensor{nullptr},
-    _orig{std::make_unique<UserTensor>(info, ir::Layout::NHWC, (uint8_t *)nullptr, 0)},
-    _has_backend_tensor{false}
+    _orig{std::make_unique<UserTensor>(info, (uint8_t *)nullptr, 0)}, _has_backend_tensor{false}
 {
   _tensor = _orig.get();
 }

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -54,7 +54,6 @@ public:
 
 public:
   uint8_t *buffer() const override { return _tensor->buffer(); }
-  ir::Layout layout() const { return _orig->layout(); }
   void set_dynamic() override
   {
     _info.setDynamic();

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -34,20 +34,18 @@ namespace onert::backend::builtin
 class UserTensor : public IPortableTensor
 {
 public:
-  UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
-    : IPortableTensor{info}, _layout{layout}, _buffer{buffer}, _size{size}
+  UserTensor(const ir::OperandInfo &info, uint8_t *buffer, size_t size)
+    : IPortableTensor{info}, _buffer{buffer}, _size{size}
   {
   }
 
 public:
   uint8_t *buffer() const override { return _buffer; }
-  ir::Layout layout() const { return _layout; }
   void set_dynamic() override { _info.setDynamic(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
   bool applyShape(const ir::Shape &) override;
 
 private:
-  ir::Layout _layout;
   uint8_t *_buffer;
   size_t _size;
 };

--- a/runtime/onert/core/src/exec/EdgeTensor.h
+++ b/runtime/onert/core/src/exec/EdgeTensor.h
@@ -27,14 +27,12 @@ namespace onert::exec
 class EdgeTensor : public backend::IPortableTensor
 {
 public:
-  EdgeTensor(const ir::OperandInfo &info, ir::Layout layout)
-    : IPortableTensor(info), _layout{layout}, _buffer{nullptr}, _ref_count{0}
+  EdgeTensor(const ir::OperandInfo &info) : IPortableTensor(info), _buffer{nullptr}, _ref_count{0}
   {
   }
   ~EdgeTensor() = default;
 
   uint8_t *buffer() const override { return _buffer.get(); }
-  ir::Layout layout() const { return _layout; }
   void set_dynamic() override { _info.setDynamic(); }
   bool applyShape(const ir::Shape &new_shape) override;
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
@@ -59,7 +57,6 @@ public:
   }
 
 private:
-  ir::Layout _layout;
   std::unique_ptr<uint8_t[]> _buffer;
   int32_t _ref_count;
 };

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -69,13 +69,6 @@ public:
     return _output_tensors[index]->get_info();
   }
 
-  ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
-
-  ir::Layout outputLayout(uint32_t index) const override
-  {
-    return _output_tensors[index]->layout();
-  }
-
   const uint8_t *outputBuffer(uint32_t index) const final
   {
     return _output_tensors[index]->buffer();

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -176,8 +176,7 @@ void MultiModelExecutors::createEdgeQuantLayers()
 
     const auto from_executor = _executors.at({from_model_index, from_subg_index}).get();
     const auto &from_info = from_executor->outputInfo(from_io_index.value());
-    const auto from_layout = from_executor->outputLayout(from_io_index.value());
-    _edge_tensors[from_iodesc] = std::make_unique<EdgeTensor>(from_info, from_layout);
+    _edge_tensors[from_iodesc] = std::make_unique<EdgeTensor>(from_info);
   }
 
   // Append type-aware quantization layer for edges between executors
@@ -201,7 +200,6 @@ void MultiModelExecutors::createEdgeQuantLayers()
 
           const auto to_executor = _executors.at({to_model_index, to_subg_index}).get();
           const auto &to_info = to_executor->inputInfo(to_io_index.value());
-          const auto to_layout = to_executor->inputLayout(to_io_index.value());
 
           // TODO Unify tensors with the same `from` tensor and same type
           if (from_tensor->data_type() != to_info.typeInfo().type())
@@ -209,7 +207,7 @@ void MultiModelExecutors::createEdgeQuantLayers()
             assert(inputs.size() == outputs.size());
             inputs.emplace_back(from_tensor);
 
-            auto type_aware_quant_tensor = std::make_unique<EdgeTensor>(to_info, to_layout);
+            auto type_aware_quant_tensor = std::make_unique<EdgeTensor>(to_info);
             outputs.emplace_back(type_aware_quant_tensor.get());
 
             // No layout change on edge
@@ -242,7 +240,7 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
     auto input_desc = desc.inputs[input_pkg_index].get();
     // TODO Remove const_cast (we need const_cast as ITensor is writable)
     _pkg_input_tensors[pkg_input] = std::make_unique<backend::builtin::UserTensor>(
-      input_desc->info, input_desc->layout,
+      input_desc->info,
       const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(input_desc->buffer)),
       input_desc->size);
   }
@@ -257,8 +255,7 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
       throw std::runtime_error{"Cannot find multi model output index"};
     auto output_desc = desc.outputs[output_pkg_index].get();
     _pkg_output_tensors[pkg_output] = std::make_unique<backend::builtin::UserTensor>(
-      output_desc->info, output_desc->layout, reinterpret_cast<uint8_t *>(output_desc->buffer),
-      output_desc->size);
+      output_desc->info, reinterpret_cast<uint8_t *>(output_desc->buffer), output_desc->size);
   }
 }
 

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -86,8 +86,7 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       throw std::runtime_error{"Input " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, desc->layout, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)),
-      desc->size));
+      desc->info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)), desc->size));
 
     inputs[i] = tensorpool.back().get();
   }
@@ -108,7 +107,7 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
       throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, desc->layout, static_cast<uint8_t *>(desc->buffer), desc->size));
+      desc->info, static_cast<uint8_t *>(desc->buffer), desc->size));
     outputs[i] = tensorpool.back().get();
   }
 

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -73,13 +73,6 @@ public:
     return _output_tensors[index]->get_info();
   }
 
-  ir::Layout inputLayout(uint32_t index) const override { return _input_tensors[index]->layout(); }
-
-  ir::Layout outputLayout(uint32_t index) const override
-  {
-    return _output_tensors[index]->layout();
-  }
-
   const uint8_t *outputBuffer(uint32_t index) const final
   {
     return _output_tensors[index]->buffer();

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -108,8 +108,7 @@ void TrainableExecutors::forward(
       throw std::runtime_error{"Input " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, desc->layout, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)),
-      desc->size));
+      desc->info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)), desc->size));
     inputs[i] = tensorpool.back().get();
   }
 
@@ -121,7 +120,7 @@ void TrainableExecutors::forward(
     // If training, output buffer may not be used
     // So don't check optional
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, desc->layout, static_cast<uint8_t *>(desc->buffer), desc->size));
+      desc->info, static_cast<uint8_t *>(desc->buffer), desc->size));
     outputs[i] = tensorpool.back().get();
   }
 


### PR DESCRIPTION
This commit removes meaning less layout information from Executor and Tensor.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/13645
Draft: https://github.com/Samsung/ONE/pull/13679