### PR TITLE
[onert] Use permute node type in KernelGenerator

### DIFF
--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -121,11 +121,7 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   // Add PermuteLayer
   std::vector<ITensor *> output_tensors{getTensor(output_index)};
   std::vector<ITensor *> input_tensors{getTensor(input_index)};
-  std::vector<ir::PermuteType> permute_types;
-
-  // Layout in graph is always NHWC, so layout is not changed
-  for (uint32_t i = 0; i < input_tensors.size(); i++)
-    permute_types.emplace_back(ir::PermuteType::SAME);
+  std::vector<ir::PermuteType> permute_types{node.getPermuteType()};
 
   auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, permute_types,
                                                    _external_context);

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -55,16 +55,12 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
 
   std::vector<ITensor *> output_back_prop_tensors;
   std::vector<ITensor *> input_back_prop_tensors;
-  std::vector<ir::PermuteType> permute_types;
+  std::vector<ir::PermuteType> permute_types{node.getPermuteType()};
 
   auto input_back_prop_tensor = getBackPropTensor(input_index);
   auto output_back_prop_tensor = getBackPropTensor(output_index);
   output_back_prop_tensors.emplace_back(output_back_prop_tensor);
   input_back_prop_tensors.emplace_back(input_back_prop_tensor);
-
-  // Layout in graph is always NHWC, so layout is not changed
-  for (uint32_t i = 0; i < input_tensors.size(); i++)
-    permute_types.emplace_back(ir::PermuteType::SAME);
 
   // NOTE The output buffers of IOTensors are not essential for training. If there
   //      is no output buffer provided by the user, permute is not performed.


### PR DESCRIPTION
This commit updates builtin KernelGenerator to use permute node type. 
KernelGenerator's input, output, type vector has only one element becasue permute node has only one input, output, and type.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #13679 