### PR TITLE
[common-artifacts] Exclude CircleFullyConnected_U4_003

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -183,6 +183,7 @@ tcgenerate(CircleBatchMatMul_MXINT8_000)
 tcgenerate(CircleFullyConnected_U4_000)
 tcgenerate(CircleFullyConnected_U4_001)
 tcgenerate(CircleFullyConnected_U4_002)
+tcgenerate(CircleFullyConnected_U4_003)
 tcgenerate(GRU_000) # luci-interpreter does not support custom GRU
 tcgenerate(InstanceNorm_000)
 tcgenerate(InstanceNorm_001)


### PR DESCRIPTION
This excludes CircleFullyConnected_U4_003 from tcgenerate.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Draft PR: https://github.com/Samsung/ONE/pull/15869