### PR TITLE
Draft: [onert] Use nnpkg in single model compiler

### DIFF
--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -63,7 +63,7 @@ public:
   std::shared_ptr<CompilerArtifact> compile(void);
 
 private:
-  std::shared_ptr<ir::Model> _model;
+  std::shared_ptr<ir::NNPkg> _nnpkg;
   CompilerOptions *_options;
 };
 

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -167,7 +167,8 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
     });
   }
 
-  _nnpkg.reset();
+  if (!_options->internal_output_alloc)
+    _nnpkg.reset();
 
   for (const auto &[model_index, model_lsubg] : lowered_subgs)
   {
@@ -241,19 +242,8 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
       args.model_index = model_index;
       args.custom_kernel_builder = custom_kernel_builders[model_index];
       if (_options->internal_output_alloc)
-      {
-        const auto &pkg_outputs = _nnpkg->model_edges().pkg_outputs;
-        for (const auto &desc : pkg_outputs)
-        {
-          // Only outputs of this entry
-          if (const auto &[m, s, io] = desc; m == model_index && s == subg_index)
-          {
-            // Map IOIndex to OperandIndex
-            auto idx = lowered_subg->graph().getOutputs().at(io);
-            args.internal_io_indexes.add(idx);
-          }
-        }
-      }
+        args.internal_io_indexes = _nnpkg->getPkgOutputs(model_index, subg_index);
+
       auto executor = std::unique_ptr<exec::IExecutor>{
         ExecutorFactory::get().create(std::move(lowered_subg), executors, args)};
       executor->setIndexedRanks(indexed_ranks);


### PR DESCRIPTION
Use nnpkg, not model in single model compiler

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>