### PR TITLE
[onert] Fix model reset in MultiModelCompiler

### DIFF
--- a/runtime/onert/core/include/compiler/CompilerFactory.h
+++ b/runtime/onert/core/include/compiler/CompilerFactory.h
@@ -32,6 +32,7 @@ public:
   static CompilerFactory &get();
 
 public:
+  // TODO Compiler should explicitly get ownership nnpkg without sharing by unique_ptr
   std::unique_ptr<ICompiler> create(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts,
                                     const ir::train::TrainingInfo *training_info = nullptr);
 

--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -292,6 +292,12 @@ public:
    */
   void replaceModel(std::shared_ptr<Model> model) { _models[ModelIndex{0}] = model; }
 
+  /**
+   * @brief Reset models to empty state (no model)
+   *        This is useful when we want to reduce the memory usage
+   */
+  void resetModels() { _models.clear(); }
+
   // TODO: Add iterate() or getter for edges
 
 private:

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -167,7 +167,8 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
     });
   }
 
-  _nnpkg.reset();
+  // Models are not used anymore after lower phase. Reset them to save memory.
+  _nnpkg->resetModels();
 
   for (const auto &[model_index, model_lsubg] : lowered_subgs)
   {

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -221,7 +221,10 @@ public:
 public:
   void compile()
   {
-    auto compiler = onert::compiler::CompilerFactory::get().create(nnpkg, coptions.get());
+    // To support multiple compilation,
+    // it needs to copy nnpkg because compiler changes nnpkg during compilation.
+    auto compiler = onert::compiler::CompilerFactory::get().create(
+      std::make_shared<onert::ir::NNPkg>(*nnpkg), coptions.get());
     artifact = compiler->compile();
   }
 


### PR DESCRIPTION
It fixes to reset models in `_nnpkg` in MultiModelCompiler after lowering, not all `_nnpkg`. 
Models are not used after lowering, but `_nnpkg` is used to find model output for internal output allocation.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15872