### PR TITLE
[github] Update PyPI publish workflow to test setup.py

### DIFF
--- a/.github/workflows/pub-onert-pypi.yml
+++ b/.github/workflows/pub-onert-pypi.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
     paths:
       - '.github/workflows/pub-onert-pypi.yml'
+      - 'runtime/infra/python/**'
+      - '!**/*.md'
   workflow_dispatch:
     inputs:
       official:


### PR DESCRIPTION
This commit updates PyPI publish workflow to add PR test triggering path for python packaging files.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>