### PR TITLE
[onert] Move Compiler.h

### DIFF
--- a/runtime/onert/core/include/compiler/LoweredGraph.h
+++ b/runtime/onert/core/include/compiler/LoweredGraph.h
@@ -18,7 +18,7 @@
 #define __ONERT_COMPILER_LOWERED_GRAPH_H__
 
 #include "compiler/BackendResolver.h"
-#include "compiler/Compiler.h"
+#include "compiler/CompilerOptions.h"
 #include "compiler/GraphLowerInfo.h"
 #include "compiler/ILoweredGraph.h"
 #include "ir/Graph.h"

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "compiler/Compiler.h"
+#include "Compiler.h"
 
 #include "CompilerHelpers.h"
 #include "ExecutorFactory.h"

--- a/runtime/onert/core/src/compiler/Compiler.h
+++ b/runtime/onert/core/src/compiler/Compiler.h
@@ -22,8 +22,8 @@
 #ifndef __ONERT_COMPILER_COMPILE_H_
 #define __ONERT_COMPILER_COMPILE_H_
 
-#include "CompilerOptions.h"
-#include "ICompiler.h"
+#include "compiler/CompilerOptions.h"
+#include "compiler/ICompiler.h"
 #include "ir/NNPkg.h"
 
 namespace onert::compiler

--- a/runtime/onert/core/src/compiler/CompilerFactory.cc
+++ b/runtime/onert/core/src/compiler/CompilerFactory.cc
@@ -16,9 +16,9 @@
 
 #include "compiler/CompilerFactory.h"
 
+#include "Compiler.h"
 #include "MultiModelCompiler.h"
 #include "train/TrainingCompiler.h"
-#include "compiler/Compiler.h"
 
 namespace onert::compiler
 {

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -25,6 +25,7 @@
 #include "compiler/train/LoweredTrainableGraph.h"
 #include "exec/IExecutors.h"
 #include "ir/train/TrainingInfo.h"
+#include "util/TracingCtx.h"
 
 #include <deque>
 #include <unordered_map>

--- a/runtime/onert/core/src/compiler/HEScheduler.h
+++ b/runtime/onert/core/src/compiler/HEScheduler.h
@@ -29,7 +29,7 @@
 
 #include <backend/Backend.h>
 #include <compiler/BackendManager.h>
-#include <compiler/Compiler.h>
+#include <compiler/CompilerOptions.h>
 #include <ir/Graph.h>
 #include <ir/OperationIndexMap.h>
 

--- a/runtime/onert/core/src/compiler/ManualScheduler.h
+++ b/runtime/onert/core/src/compiler/ManualScheduler.h
@@ -17,8 +17,8 @@
 #ifndef __ONERT_CORE_COMPILER_MANUAL_SCHEDULER_H__
 #define __ONERT_CORE_COMPILER_MANUAL_SCHEDULER_H__
 
+#include "Compiler.h"
 #include "IScheduler.h"
-#include "compiler/Compiler.h"
 
 namespace onert::compiler
 {

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -16,7 +16,7 @@
 
 #include "exec/Execution.h"
 
-#include "compiler/Compiler.h"
+#include "../compiler/Compiler.h"
 #include "compiler/CompilerFactory.h"
 #include "ir/Graph.h"
 #include "ir/operation/BinaryArithmetic.h"

--- a/runtime/tests/nnapi/bridge/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/tests/nnapi/bridge/wrapper/ANeuralNetworksCompilation.cc
@@ -16,6 +16,7 @@
 
 #include "ANeuralNetworksCompilation.h"
 
+#include "compiler/CompilerFactory.h"
 #include "util/logging.h"
 
 using namespace onert;
@@ -23,7 +24,8 @@ using namespace onert;
 // TODO Support multiple subgraphs
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model)
   : _model{model->getModel()}, _coptions{compiler::CompilerOptions::fromGlobalConfig()},
-    _compiler{std::make_shared<compiler::Compiler>(_model, _coptions.get())}
+    _compiler{
+      compiler::CompilerFactory::get().create(std::make_shared<ir::NNPkg>(_model), _coptions.get())}
 {
   if (model->allowedToFp16())
     _coptions->fp16_enable = true;

--- a/runtime/tests/nnapi/bridge/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/tests/nnapi/bridge/wrapper/ANeuralNetworksCompilation.h
@@ -19,7 +19,8 @@
 
 #include "ANeuralNetworksModel.h"
 
-#include "compiler/Compiler.h"
+#include "compiler/CompilerOptions.h"
+#include "compiler/ICompiler.h"
 #include "ir/Graph.h"
 #include "ir/Model.h"
 #include "exec/IExecutors.h"
@@ -42,7 +43,7 @@ public:
 private:
   std::shared_ptr<onert::ir::Model> _model;
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
-  std::shared_ptr<onert::compiler::Compiler> _compiler;
+  std::shared_ptr<onert::compiler::ICompiler> _compiler;
   std::shared_ptr<onert::compiler::CompilerArtifact> _artifact;
 };
 


### PR DESCRIPTION
This commit moves Compiler.h file from include into src directory. ICompiler.h is used as public header. 
Compiler.h and MultiModelCompiler.h are used as internal headers.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15872