### PR TITLE
[luci/pass] Check quantization-unfriendly values during weights quantization

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.cpp
+++ b/compiler/luci/pass/src/QuantizationUtils.cpp
@@ -651,4 +651,23 @@ void cal_minmax_per_channel(CircleConst *node, std::vector<float> &min, std::vec
   iterate_per_channel(node, channel_dim_index, cal_minmax);
 }
 
+void check_quant_unfriendly_values(const luci::CircleConst *node)
+{
+  assert(node); // FIX_CALLER_UNLESS
+
+  if (node->dtype() != loco::DataType::FLOAT32)
+    return;
+
+  for (uint32_t i = 0; i < node->size<loco::DataType::FLOAT32>(); i++)
+  {
+    const auto val = node->at<loco::DataType::FLOAT32>(i);
+
+    if (val == std::numeric_limits<float>::lowest())
+      throw std::runtime_error(node->name() + " includes -inf");
+
+    if (val == std::numeric_limits<float>::max())
+      throw std::runtime_error(node->name() + " includes inf");
+  }
+}
+
 } // namespace luci

--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -113,6 +113,9 @@ using IterFunc = std::function<void(uint32_t *, loco::TensorShape &, int32_t)>;
 void iterate_per_channel(CircleConst *node, int32_t &channel_dim_index, IterFunc func);
 void iterate_per_channel(CircleConst *node, IterFunc func);
 
+// Throw exception if constant node contains quantization-unfrinedly values
+void check_quant_unfriendly_values(const luci::CircleConst *node);
+
 } // namespace luci
 
 #endif // __LUCI_QUANTIZATION_UTILS_H__

--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -264,6 +264,8 @@ private:
 private:
   void fake_quantize(luci::CircleConst *weights) const
   {
+    check_quant_unfriendly_values(weights);
+
     switch (granularity)
     {
       case luci::QuantizationGranularity::ChannelWise:

--- a/compiler/luci/pass/src/QuantizeWeights.cpp
+++ b/compiler/luci/pass/src/QuantizeWeights.cpp
@@ -289,6 +289,8 @@ namespace luci
 
 void QuantizeWeights::quantize_weights(luci::CircleConst *weights)
 {
+  check_quant_unfriendly_values(weights);
+
   // Find min/max per channel-wise
   if (granularity == QuantizationGranularity::ChannelWise)
   {

--- a/compiler/luci/pass/src/QuantizeWeightsOnly.cpp
+++ b/compiler/luci/pass/src/QuantizeWeightsOnly.cpp
@@ -77,6 +77,8 @@ namespace luci
 
 void QuantizeWeightsOnly::quantize_weights(luci::CircleConst *weights)
 {
+  check_quant_unfriendly_values(weights);
+
   // Find min/max per channel-wise
   if (granularity == QuantizationGranularity::ChannelWise)
   {


### PR DESCRIPTION
This checks quantization-unfriendly values during weights quantization.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/15867