### PR TITLE
[onert] Use NNPkg in single model compiler

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -37,14 +37,8 @@
 namespace onert::compiler
 {
 
-Compiler::Compiler(const std::shared_ptr<ir::Model> &model, CompilerOptions *copts)
-  : _model{model}, _options{copts}
-{
-  // DO NOTHING
-}
-
 Compiler::Compiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts)
-  : _model{nnpkg->primary_model()}, _options{copts}
+  : _nnpkg{nnpkg}, _options{copts}
 {
   // Use for single model only
   assert(nnpkg->model_count() == 1);
@@ -69,7 +63,10 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
       throw std::runtime_error("Profiling mode works only with 'Dataflow' executor");
   }
 
-  if (!_model->hasOnly<ir::Graph>())
+  // Single model
+  const auto model = _nnpkg->primary_model();
+
+  if (!model->hasOnly<ir::Graph>())
   {
     throw std::runtime_error("Compiler can only compile models for inference.");
   }
@@ -77,9 +74,9 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   _options->forceInternalOptions();
   _options->verboseOptions();
 
-  auto custom_kernel_builder = _model->getKernelBuilder();
+  auto custom_kernel_builder = model->getKernelBuilder();
 
-  _model->iterate([&](const ir::SubgraphIndex &, ir::IGraph &graph) {
+  model->iterate([&](const ir::SubgraphIndex &, ir::IGraph &graph) {
     auto &subg = nnfw::misc::polymorphic_downcast<ir::Graph &>(graph);
 
     // Mandatory passes
@@ -106,7 +103,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<compiler::LoweredGraph>> lowered_subgs;
   {
-    _model->iterate([&](const ir::SubgraphIndex &subg_index, ir::IGraph &graph) {
+    model->iterate([&](const ir::SubgraphIndex &subg_index, ir::IGraph &graph) {
       auto &subg = nnfw::misc::polymorphic_downcast<ir::Graph &>(graph);
 
       // Lower: Assign backend
@@ -117,7 +114,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
     });
   }
 
-  _model.reset();
+  _nnpkg.reset();
 
   for (const auto &[subg_index, lowered_subg] : lowered_subgs)
   {

--- a/runtime/onert/core/src/compiler/Compiler.h
+++ b/runtime/onert/core/src/compiler/Compiler.h
@@ -36,13 +36,6 @@ class Compiler : public ICompiler
 {
 public:
   /**
-   * @brief     Construct a new Compiler object for single model
-   * @param[in] model model to compile
-   * @param[in] copts Compiler Options
-   */
-  Compiler(const std::shared_ptr<ir::Model> &model, CompilerOptions *copts);
-
-  /**
    * @brief     Construct a new Compiler object for NN package
    * @param[in] nnpkg NN package to compile
    * @param[in] copts Compiler option for package
@@ -63,7 +56,7 @@ public:
   std::shared_ptr<CompilerArtifact> compile(void);
 
 private:
-  std::shared_ptr<ir::Model> _model;
+  std::shared_ptr<ir::NNPkg> _nnpkg;
   CompilerOptions *_options;
 };
 

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -81,7 +81,7 @@ public:
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, graph);
     coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-    onert::compiler::Compiler compiler{model, coptions.get()};
+    onert::compiler::Compiler compiler{std::make_shared<NNPkg>(model), coptions.get()};
     artifact = compiler.compile();
   }
 
@@ -286,7 +286,7 @@ public:
     coptions->input_type.insert_or_assign(IOIndex{0}, TypeInfo(DataType::FLOAT32));
     coptions->input_type.insert_or_assign(IOIndex{1}, TypeInfo(DataType::FLOAT32));
     coptions->output_type.insert_or_assign(IOIndex{0}, TypeInfo(DataType::FLOAT32));
-    onert::compiler::Compiler compiler{model, coptions.get()};
+    onert::compiler::Compiler compiler{std::make_shared<NNPkg>(model), coptions.get()};
     artifact = compiler.compile();
   }
 
@@ -402,7 +402,7 @@ TEST(ExecInstance, twoCompile)
   auto model = std::make_shared<onert::ir::Model>();
   model->push(onert::ir::SubgraphIndex{0}, graph);
   auto coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-  onert::compiler::Compiler compiler{model, coptions.get()};
+  onert::compiler::Compiler compiler{std::make_shared<NNPkg>(model), coptions.get()};
   std::shared_ptr<onert::compiler::CompilerArtifact> artifact = compiler.compile();
   onert::exec::Execution execution2{artifact->_executors};
 


### PR DESCRIPTION
This commit removes Compiler class constructor from direct Model and use NNPkg instead. 
Compiler class owns NNPkg and uses it to get Model.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15872