### PR TITLE
[onert/test] Support small error tolerance in integer comparison

### DIFF
--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/DepthwiseConv2D.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/DepthwiseConv2D.test.cc
@@ -465,6 +465,7 @@ TEST_P(DepthwiseConv2DQuantTestU8, Test)
   std::vector<uint8_t> ref_input(input64.begin(), input64.begin() + param.input_depth * 4);
   _context->addTestCase(uniformTCD<uint8_t>({ref_input}, {param.ref_output}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->allowSmallError();
 
   SUCCEED();
 }


### PR DESCRIPTION
This commit adds `allow_small_error` to context to allow error 1 from different backend kernel implementation.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>