### PR TITLE
[onert] Remove outdated comment about layout

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -361,7 +361,6 @@ void KernelGenerator::visit(const ir::operation::Squeeze &node)
   // Squeeze is identical to reshape except that it has an optional dimensions input.
   // In addition, optional dims_index is ignored since output tensor already has squeezed shape
   // by freezer and toco
-  // TODO Support multi-layout for frontend and backend
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Squeeze::Input::INPUT)};
   const auto dims{node.param().dims};

--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -48,7 +48,6 @@ public:
    * @brief     Register tensor information to allocate on ACL-CL backend
    * @param[in] ind    Operand index
    * @param[in] info   Tensor information
-   * @param[in] layout Tensor data layout
    */
   void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info);
 

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -1126,7 +1126,6 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   }
 
   // Set mask bits such as order of inputData
-  // FIXME Take the layouts into account.
   const auto begin_mask = acl_common::ReorderBits<int32_t>(node.param().begin_mask, input_rank);
   const auto end_mask = acl_common::ReorderBits<int32_t>(node.param().end_mask, input_rank);
   const auto shrink_axis_mask =

--- a/runtime/onert/core/include/backend/basic/Tensor.h
+++ b/runtime/onert/core/include/backend/basic/Tensor.h
@@ -28,7 +28,6 @@ namespace onert::backend::basic
 
 class DynamicMemoryManager;
 
-// Always NHWC layout
 class Tensor : public IPortableTensor
 {
 public:
@@ -136,7 +135,7 @@ private:
  *        instead of allocating and copying the data. (ex. constant data from model file)
  *        ExternalTensor's data pointer points to an address of memory such as where memory is
  *        already allocated, or mmapped area. This is meaning that ExternalTensor can take all of
- *        types' ir::Data. To support this, assume below things no padding, always NHWC layout,
+ *        types' ir::Data. To support this, assume below things no padding,
  *        constant tensor and not dynamic.
  */
 class ExternalTensor : public Tensor

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -116,7 +116,7 @@ public:
 
 private:
   IPortableTensor *_tensor{nullptr}; //< The actual tensor that is indirected
-  // "_orig" has UserTensor type original tensor's info with nullptr buffer and layout,
+  // "_orig" has UserTensor type original tensor's info with nullptr buffer,
   // and "_tensor" points to "_user_tensor".
   // After 1st setTensor(tensor) call, "_tensor" is updated to actual tensor
   std::unique_ptr<UserTensor> _orig; //< If it is a user tensor, it is managed by this object

--- a/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/TrainableConstantInsertionPass.cc
@@ -40,8 +40,8 @@ void TrainableConstantInsertionPass::callback(const ir::OperationIndex &node_ind
       if (use_index == node_index)
         continue;
 
-      // NOTE The PermuteFactor(backend and layout) of the current node and the use node may be
-      //      different. But there is no problem because both nodes' constant operand will have
+      // NOTE The PermuteFactor(backend) of the current node and the use node may be different.
+      //      But there is no problem because both nodes' constant operand will have
       //      only one use node.
       const auto new_index = insertNewOperand(object);
       updateUseDef(input, new_index, use_index);


### PR DESCRIPTION
This commit removes outdated comment about backend layout.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>