### PR TITLE
[onert] Allow small error in DepthwiseConv2D test

### DIFF
--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/DepthwiseConv2D.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/DepthwiseConv2D.test.cc
@@ -549,6 +549,7 @@ TEST_P(DepthwiseConv2DQuantTestI8, Test)
   std::vector<int8_t> ref_input(input64.begin(), input64.begin() + param.input_depth * 4);
   _context->addTestCase(uniformTCD<int8_t>({ref_input}, {param.ref_output}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->allowSmallError();
 
   SUCCEED();
 }


### PR DESCRIPTION
This commit allows small error in acl-cl backend test compared to expected value in DepthwiseConv2D int8 quantized test.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>