### PR TITLE
[onert] Remove unused operand layouts from TrainableBackendContext

### DIFF
--- a/runtime/onert/core/include/backend/train/TrainableBackendContext.h
+++ b/runtime/onert/core/include/backend/train/TrainableBackendContext.h
@@ -40,8 +40,6 @@ struct TrainableContextData
   std::vector<onert::ir::OperationIndex> op_order;
   /* Operands that are defined by other backends */
   util::Set<ir::OperandIndex> external_operands;
-  /* Operand layout info */
-  ir::OperandIndexMap<ir::Layout> operand_layouts;
   /* Custom kernel builder */
   std::shared_ptr<custom::IKernelBuilder> custom_kernel_builder;
   /* Is linear executor or not */
@@ -68,7 +66,6 @@ public:
 
   const ITrainableBackend *backend() const { return _backend; }
   const util::Set<ir::OperandIndex> &external_operands() const { return _tdata->external_operands; }
-  const ir::OperandIndexMap<ir::Layout> &operand_layouts() const { return _tdata->operand_layouts; }
 
   std::shared_ptr<ITensorRegistry> tensor_registry() { return _tensor_registry; }
 


### PR DESCRIPTION
This commit removes unused operand_layouts field and its accessor from TrainableContextData. 
Same field on different backends are already removed.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>