### PR TITLE
[onert/test] Disable AveragePool2D_U8_000 test in acl-cl/neon lists

### DIFF
--- a/runtime/tests/scripts/list/nnpkg_test_list.armv7l-linux.acl_cl
+++ b/runtime/tests/scripts/list/nnpkg_test_list.armv7l-linux.acl_cl
@@ -4,7 +4,7 @@ Add_000.opt
 #ArgMax_002.opt
 #ArgMax_003.opt
 AveragePool2D_000.opt
-AveragePool2D_U8_000.opt
+#AveragePool2D_U8_000.opt
 Concatenation_000.opt
 Conv2D_000.opt
 Conv2D_001.opt

--- a/runtime/tests/scripts/list/nnpkg_test_list.armv7l-linux.acl_neon
+++ b/runtime/tests/scripts/list/nnpkg_test_list.armv7l-linux.acl_neon
@@ -4,7 +4,7 @@ Add_000.opt
 #ArgMax_002.opt
 #ArgMax_003.opt
 AveragePool2D_000.opt
-AveragePool2D_U8_000.opt
+#AveragePool2D_U8_000.opt
 Concatenation_000.opt
 Conv2D_000.opt
 Conv2D_001.opt


### PR DESCRIPTION
This commit comments out AveragePool2D_U8_000 test in acl-cl/neon nnpackage test lists.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Workaround for failure https://github.com/Samsung/ONE/issues/15030#issuecomment-3166309846