### PR TITLE
[luci/pass] Add missing quantization-unfriendly value check

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.cpp
+++ b/compiler/luci/pass/src/QuantizationUtils.cpp
@@ -419,6 +419,8 @@ void quant_const(luci::CircleConst *node, loco::DataType quant_type)
 {
   assert(node->dtype() == loco::DataType::FLOAT32);
 
+  check_quant_unfriendly_values(node);
+
   float min = std::numeric_limits<float>::max();
   float max = std::numeric_limits<float>::lowest();
   for (uint32_t i = 0; i < node->size<loco::DataType::FLOAT32>(); i++)


### PR DESCRIPTION
This commit adds missing quantization-unfriendly value check

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

For issue #15867