### PR TITLE
[onert] Refactor NNPkg ownership to use unique_ptr in compiler workflow

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -210,7 +210,7 @@ private:
 
 private:
   State _state{State::INITIALIZED};
-  std::shared_ptr<onert::ir::NNPkg> _nnpkg;
+  std::unique_ptr<onert::ir::NNPkg> _nnpkg;
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
   std::shared_ptr<onert::compiler::CompilerArtifact> _compiler_artifact;
   std::unique_ptr<onert::exec::Execution> _execution;

--- a/runtime/onert/core/include/compiler/CompilerFactory.h
+++ b/runtime/onert/core/include/compiler/CompilerFactory.h
@@ -32,7 +32,20 @@ public:
   static CompilerFactory &get();
 
 public:
-  std::unique_ptr<ICompiler> create(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts,
+  /**
+   * @brief     Create ICompiler instance. Ownership of nnpkg is moved to ICompiler instance
+   *
+   * Compiler is designed on assumption that caller will not use nnpkg after calling this function.
+   * So ownership of nnpkg is moved to ICompiler instance to handle memory overhead of nnpkg.
+   * If caller want to maintain nnpkg after calling this function,
+   * caller should clone nnpkg before calling this function.
+   *
+   * @param[in] nnpkg         Package to compile
+   * @param[in] copts         Compiler options
+   * @param[in] training_info Training info if it is a training model, otherwise nullptr
+   * @return    ICompiler instance pointer which owns nnpkg
+   */
+  std::unique_ptr<ICompiler> create(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts,
                                     const ir::train::TrainingInfo *training_info = nullptr);
 
 private:

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -37,11 +37,11 @@
 namespace onert::compiler
 {
 
-Compiler::Compiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts)
-  : _nnpkg{nnpkg}, _options{copts}
+Compiler::Compiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts)
+  : _nnpkg{std::move(nnpkg)}, _options{copts}
 {
   // Use for single model only
-  assert(nnpkg->model_count() == 1);
+  assert(_nnpkg->model_count() == 1);
 }
 
 std::shared_ptr<CompilerArtifact> Compiler::compile(void)

--- a/runtime/onert/core/src/compiler/Compiler.h
+++ b/runtime/onert/core/src/compiler/Compiler.h
@@ -40,7 +40,7 @@ public:
    * @param[in] nnpkg NN package to compile
    * @param[in] copts Compiler option for package
    */
-  Compiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts);
+  Compiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts);
 
   /**
    * @brief Destroy the Compiler object
@@ -56,7 +56,7 @@ public:
   std::shared_ptr<CompilerArtifact> compile(void);
 
 private:
-  std::shared_ptr<ir::NNPkg> _nnpkg;
+  std::unique_ptr<ir::NNPkg> _nnpkg;
   CompilerOptions *_options;
 };
 

--- a/runtime/onert/core/src/compiler/CompilerFactory.cc
+++ b/runtime/onert/core/src/compiler/CompilerFactory.cc
@@ -29,19 +29,19 @@ CompilerFactory &CompilerFactory::get()
   return singleton;
 }
 
-std::unique_ptr<ICompiler> CompilerFactory::create(const std::shared_ptr<ir::NNPkg> &nnpkg,
+std::unique_ptr<ICompiler> CompilerFactory::create(std::unique_ptr<ir::NNPkg> nnpkg,
                                                    CompilerOptions *copts,
                                                    const ir::train::TrainingInfo *training_info)
 {
   // Returing compiler for training
   if (training_info)
-    return std::make_unique<train::TrainingCompiler>(nnpkg, copts, *training_info);
+    return std::make_unique<train::TrainingCompiler>(std::move(nnpkg), copts, *training_info);
 
   // Returing compiler for inference
   if (nnpkg->model_count() == 1)
-    return std::make_unique<Compiler>(nnpkg, copts);
+    return std::make_unique<Compiler>(std::move(nnpkg), copts);
 
-  return std::make_unique<MultiModelCompiler>(nnpkg, copts);
+  return std::make_unique<MultiModelCompiler>(std::move(nnpkg), copts);
 }
 
 } // namespace onert::compiler

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -37,9 +37,8 @@
 namespace onert::compiler
 {
 
-MultiModelCompiler::MultiModelCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
-                                       CompilerOptions *copts)
-  : _nnpkg{nnpkg}, _options{copts}
+MultiModelCompiler::MultiModelCompiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts)
+  : _nnpkg{std::move(nnpkg)}, _options{copts}
 {
   // DO NOTHING
 }

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.h
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.h
@@ -40,7 +40,7 @@ public:
    * @param[in] nnpkg NN package to compile
    * @param[in] copts Compiler option for package
    */
-  MultiModelCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts);
+  MultiModelCompiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts);
 
   /**
    * @brief Destroy the MultiModelCompiler object
@@ -59,7 +59,7 @@ private:
   CompilerOptions optionForSingleModel(const ir::ModelIndex &model_index);
 
 private:
-  std::shared_ptr<ir::NNPkg> _nnpkg;
+  std::unique_ptr<ir::NNPkg> _nnpkg;
   CompilerOptions *_options;
 };
 

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -41,7 +41,7 @@
 namespace onert::compiler::train
 {
 
-TrainingCompiler::TrainingCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts,
+TrainingCompiler::TrainingCompiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts,
                                    const ir::train::TrainingInfo &training_info)
   : _model{nnpkg->primary_model()}, _options{copts}, _training_info{training_info}
 {

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.h
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.h
@@ -42,7 +42,7 @@ public:
    * @param[in] copts         compiler options
    * @param[in] training_info training information
    */
-  explicit TrainingCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts,
+  explicit TrainingCompiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts,
                             const ir::train::TrainingInfo &training_info);
 
   /**

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -81,7 +81,7 @@ public:
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, graph);
     coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-    onert::compiler::Compiler compiler{std::make_shared<NNPkg>(model), coptions.get()};
+    onert::compiler::Compiler compiler{std::make_unique<NNPkg>(model), coptions.get()};
     artifact = compiler.compile();
   }
 
@@ -221,7 +221,9 @@ public:
 public:
   void compile()
   {
-    auto compiler = onert::compiler::CompilerFactory::get().create(nnpkg, coptions.get());
+    // Compile copied nnpkg to handle multiple compilation
+    auto compiler = onert::compiler::CompilerFactory::get().create(
+      std::make_unique<onert::ir::NNPkg>(*nnpkg), coptions.get());
     artifact = compiler->compile();
   }
 
@@ -286,7 +288,7 @@ public:
     coptions->input_type.insert_or_assign(IOIndex{0}, TypeInfo(DataType::FLOAT32));
     coptions->input_type.insert_or_assign(IOIndex{1}, TypeInfo(DataType::FLOAT32));
     coptions->output_type.insert_or_assign(IOIndex{0}, TypeInfo(DataType::FLOAT32));
-    onert::compiler::Compiler compiler{std::make_shared<NNPkg>(model), coptions.get()};
+    onert::compiler::Compiler compiler{std::make_unique<NNPkg>(model), coptions.get()};
     artifact = compiler.compile();
   }
 
@@ -402,7 +404,7 @@ TEST(ExecInstance, twoCompile)
   auto model = std::make_shared<onert::ir::Model>();
   model->push(onert::ir::SubgraphIndex{0}, graph);
   auto coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-  onert::compiler::Compiler compiler{std::make_shared<NNPkg>(model), coptions.get()};
+  onert::compiler::Compiler compiler{std::make_unique<NNPkg>(model), coptions.get()};
   std::shared_ptr<onert::compiler::CompilerArtifact> artifact = compiler.compile();
   onert::exec::Execution execution2{artifact->_executors};
 

--- a/runtime/tests/nnapi/bridge/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/tests/nnapi/bridge/wrapper/ANeuralNetworksCompilation.cc
@@ -25,7 +25,7 @@ using namespace onert;
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model)
   : _model{model->getModel()}, _coptions{compiler::CompilerOptions::fromGlobalConfig()},
     _compiler{
-      compiler::CompilerFactory::get().create(std::make_shared<ir::NNPkg>(_model), _coptions.get())}
+      compiler::CompilerFactory::get().create(std::make_unique<ir::NNPkg>(_model), _coptions.get())}
 {
   if (model->allowedToFp16())
     _coptions->fp16_enable = true;


### PR DESCRIPTION
This commit refactors NNPkg from shared_ptr to unique_ptr and transfer ownership of NNPkg from session to compiler.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>