### PR TITLE
[onert-micro] Fix incompatibility in tests.

### DIFF
--- a/onert-micro/onert-micro/include/execute/OMTestUtils.h
+++ b/onert-micro/onert-micro/include/execute/OMTestUtils.h
@@ -61,7 +61,7 @@ std::vector<U> checkKernel(uint32_t num_inputs,
     }
   }
 
-  interpreter.run(config);
+  EXPECT_TRUE(interpreter.run(config) == OMStatus::Ok);
 
   U *output_data = reinterpret_cast<U *>(interpreter.getOutputDataAt(0));
   const size_t num_elements = interpreter.getOutputSizeAt(0);


### PR DESCRIPTION
This PR fixes failed in `Debug` mode tests to fail in `Release` mode as well.

I may be wrong, but there is inconsistency in tests:
currently it's possible to have successful tests in `Release`, but failed in `Debug`.
This PR fixes this possibility

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>