### PR TITLE
[onert] Initialize package I/O in single model NNPkg constructor

### DIFF
--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -90,7 +90,16 @@ public:
   NNPkg &operator=(NNPkg &&) = default;
   ~NNPkg() = default;
 
-  NNPkg(std::shared_ptr<Model> model) { _models[ModelIndex{0}] = model; }
+  NNPkg(std::shared_ptr<Model> model)
+  {
+    _models[ModelIndex{0}] = model;
+
+    // Fill pkg_inputs and pkg_outputs with primary model's inputs and outputs
+    for (uint32_t i = 0; i < model->primary_subgraph()->getInputs().size(); i++)
+      _edges.pkg_inputs.emplace_back(0, 0, IOIndex{i});
+    for (uint32_t i = 0; i < model->primary_subgraph()->getOutputs().size(); i++)
+      _edges.pkg_outputs.emplace_back(0, 0, IOIndex{i});
+  }
   std::shared_ptr<Model> primary_model() const { return _models.at(onert::ir::ModelIndex{0}); }
 
   /**


### PR DESCRIPTION
This commit updates single model NNPkg constructor to fill package I/O information based on the primary model's I/O.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/15872