### PR TITLE
[onert] Enable multimodel profile

### DIFF
--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -86,7 +86,13 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
     // Mode check
     // TODO handle option for each model
     if (_options->he_profiling_mode)
-      throw std::runtime_error("NYI: Profiling mode for multiple model is not supported yet");
+    {
+      if (!_options->he_scheduler)
+        throw std::runtime_error("Heterogeneous scheduler must be enabled during profiling.");
+
+      if (_options->executor != "Dataflow")
+        throw std::runtime_error("Profiling mode works only with 'Dataflow' executor");
+    }
 
     _options->forceInternalOptions();
     _options->verboseOptions();


### PR DESCRIPTION
This commit enables profiling for multimodel package.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>