### PR TITLE
[onert] Use MultiModelCompiler for single model package

### DIFF
--- a/runtime/onert/core/src/compiler/CompilerFactory.cc
+++ b/runtime/onert/core/src/compiler/CompilerFactory.cc
@@ -38,9 +38,6 @@ std::unique_ptr<ICompiler> CompilerFactory::create(std::unique_ptr<ir::NNPkg> nn
     return std::make_unique<train::TrainingCompiler>(std::move(nnpkg), copts, *training_info);
 
   // Returing compiler for inference
-  if (nnpkg->model_count() == 1)
-    return std::make_unique<Compiler>(std::move(nnpkg), copts);
-
   return std::make_unique<MultiModelCompiler>(std::move(nnpkg), copts);
 }
 

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -26,6 +26,7 @@
 #include "pass/UnusedOperandEliminationPass.h"
 #include "../dumper/dot/DotDumper.h"
 #include "../exec/MultiModelExecutors.h"
+#include "../exec/SingleModelExecutors.h"
 #include "../ir/OperationDumper.h"
 #include "../ir/verifier/Verifier.h"
 
@@ -217,7 +218,13 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
   /*************************************************************
    *  Backend independent analysis & optimization phase finished
    *************************************************************/
-  auto executors = std::make_shared<exec::MultiModelExecutors>(std::move(model_edges));
+  std::shared_ptr<exec::IExecutors> executors = nullptr;
+  const auto &pkg_outputs = model_edges->pkg_outputs;
+  if (model_count == 1)
+    executors = std::make_shared<exec::SingleModelExecutors>();
+  else
+    executors = std::make_shared<exec::MultiModelExecutors>(std::move(model_edges));
+
   for (auto &&pair : lowered_subgs)
   {
     auto const &model_index = pair.first;
@@ -241,7 +248,6 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
       args.custom_kernel_builder = custom_kernel_builders[model_index];
       if (_options->internal_output_alloc)
       {
-        const auto &pkg_outputs = _nnpkg->model_edges().pkg_outputs;
         for (const auto &desc : pkg_outputs)
         {
           // Only outputs of this entry


### PR DESCRIPTION
This commit updates CompilerFactory and MultiModelCompiler to use MultiModelCompiler for single model package.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15872