### PR TITLE
[onert] Rename MultiModelCompiler to Compiler

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "MultiModelCompiler.h"
+#include "Compiler.h"
 
 #include "CompilerHelpers.h"
 #include "ExecutorFactory.h"
@@ -38,13 +38,13 @@
 namespace onert::compiler
 {
 
-MultiModelCompiler::MultiModelCompiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts)
+Compiler::Compiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts)
   : _nnpkg{std::move(nnpkg)}, _options{copts}
 {
   // DO NOTHING
 }
 
-CompilerOptions MultiModelCompiler::optionForSingleModel(const ir::ModelIndex &model_index)
+CompilerOptions Compiler::optionForSingleModel(const ir::ModelIndex &model_index)
 {
   CompilerOptions model_opts = CompilerOptions(*_options); // Copy options
   model_opts.input_layout.clear();
@@ -75,7 +75,7 @@ CompilerOptions MultiModelCompiler::optionForSingleModel(const ir::ModelIndex &m
   return model_opts;
 }
 
-std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
+std::shared_ptr<CompilerArtifact> Compiler::compile(void)
 {
   /***************************************************
    * Prepare compilation phase
@@ -104,7 +104,7 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
   for (uint16_t i = 0; i < model_count; i++)
   {
     if (!_nnpkg->model(ir::ModelIndex{i})->hasOnly<ir::Graph>())
-      throw std::runtime_error("MultiModelCompiler can only compile models for inference.");
+      throw std::runtime_error("Compiler can only compile models for inference.");
   }
 
   std::unordered_map<ir::ModelIndex, CompilerOptions> model_options;

--- a/runtime/onert/core/src/compiler/Compiler.h
+++ b/runtime/onert/core/src/compiler/Compiler.h
@@ -15,12 +15,12 @@
  */
 
 /**
- * @file  MultiModelCompiler.h
- * @brief This file contains MultiModelCompiler class to define and run compilation phase
+ * @file  Compiler.h
+ * @brief This file contains Compiler class to define and run compilation phase
  */
 
-#ifndef __ONERT_COMPILER_MULTI_MODEL_COMPILER_H__
-#define __ONERT_COMPILER_MULTI_MODEL_COMPILER_H__
+#ifndef __ONERT_COMPILER_COMPILER_H__
+#define __ONERT_COMPILER_COMPILER_H__
 
 #include "compiler/CompilerOptions.h"
 #include "compiler/ICompiler.h"
@@ -32,7 +32,7 @@ namespace onert::compiler
 /**
  * @brief Class to compile NN package
  */
-class MultiModelCompiler final : public ICompiler
+class Compiler final : public ICompiler
 {
 public:
   /**
@@ -40,12 +40,12 @@ public:
    * @param[in] nnpkg NN package to compile
    * @param[in] copts Compiler option for package
    */
-  MultiModelCompiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts);
+  Compiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOptions *copts);
 
   /**
-   * @brief Destroy the MultiModelCompiler object
+   * @brief Destroy the Compiler object
    */
-  ~MultiModelCompiler() = default;
+  ~Compiler() = default;
 
 public:
   /**
@@ -65,4 +65,4 @@ private:
 
 } // namespace onert::compiler
 
-#endif // __ONERT_COMPILER_MULTI_MODEL_COMPILER_H__
+#endif // __ONERT_COMPILER_COMPILER_H__

--- a/runtime/onert/core/src/compiler/CompilerFactory.cc
+++ b/runtime/onert/core/src/compiler/CompilerFactory.cc
@@ -16,7 +16,7 @@
 
 #include "compiler/CompilerFactory.h"
 
-#include "MultiModelCompiler.h"
+#include "Compiler.h"
 #include "train/TrainingCompiler.h"
 
 namespace onert::compiler
@@ -37,7 +37,7 @@ std::unique_ptr<ICompiler> CompilerFactory::create(std::unique_ptr<ir::NNPkg> nn
     return std::make_unique<train::TrainingCompiler>(std::move(nnpkg), copts, *training_info);
 
   // Returing compiler for inference
-  return std::make_unique<MultiModelCompiler>(std::move(nnpkg), copts);
+  return std::make_unique<Compiler>(std::move(nnpkg), copts);
 }
 
 } // namespace onert::compiler


### PR DESCRIPTION
This commit renames MultiModelCompiler to Compiler. 
Now MultiModelCompiler can handle multiple models and single model package.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15872