### PR TITLE
[onert] Use unique_ptr to manage CompilerArtifact

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -212,7 +212,7 @@ private:
   State _state{State::INITIALIZED};
   std::unique_ptr<onert::ir::NNPkg> _nnpkg;
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
-  std::shared_ptr<onert::compiler::CompilerArtifact> _compiler_artifact;
+  std::unique_ptr<onert::compiler::CompilerArtifact> _compiler_artifact;
   std::unique_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;
   std::vector<std::thread> _threads;

--- a/runtime/onert/core/include/compiler/ICompiler.h
+++ b/runtime/onert/core/include/compiler/ICompiler.h
@@ -50,9 +50,9 @@ public:
 
   /**
    * @brief   Do compilation
-   * @return  std::shared_ptr<CompilerArtifact> Executors as a result of compilation
+   * @return  std::unique_ptr<CompilerArtifact> Executors as a result of compilation
    */
-  virtual std::shared_ptr<CompilerArtifact> compile(void) = 0;
+  virtual std::unique_ptr<CompilerArtifact> compile(void) = 0;
 };
 
 } // namespace onert::compiler

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -75,7 +75,7 @@ CompilerOptions Compiler::optionForSingleModel(const ir::ModelIndex &model_index
   return model_opts;
 }
 
-std::shared_ptr<CompilerArtifact> Compiler::compile(void)
+std::unique_ptr<CompilerArtifact> Compiler::compile(void)
 {
   /***************************************************
    * Prepare compilation phase
@@ -275,7 +275,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   /********************************
    * Code generation phase finished
    ********************************/
-  return std::make_shared<CompilerArtifact>(executors, std::move(tracing_ctx));
+  return std::make_unique<CompilerArtifact>(executors, std::move(tracing_ctx));
 }
 
 } // namespace onert::compiler

--- a/runtime/onert/core/src/compiler/Compiler.h
+++ b/runtime/onert/core/src/compiler/Compiler.h
@@ -53,7 +53,7 @@ public:
    *
    * @return std::shared_ptr<CompilerArtifact> MultiModelExecutors as a result of compilation
    */
-  std::shared_ptr<CompilerArtifact> compile(void);
+  std::unique_ptr<CompilerArtifact> compile(void);
 
 private:
   CompilerOptions optionForSingleModel(const ir::ModelIndex &model_index);

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -52,7 +52,7 @@ TrainingCompiler::TrainingCompiler(std::unique_ptr<ir::NNPkg> nnpkg, CompilerOpt
     throw std::runtime_error("TrainingCompiler does not support multiple subgraphs yet");
 }
 
-std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
+std::unique_ptr<CompilerArtifact> TrainingCompiler::compile(void)
 {
   /***************************************************
    * Prepare compilation phase
@@ -295,7 +295,7 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
   /********************************
    * Code generation phase finished
    ********************************/
-  return std::make_shared<CompilerArtifact>(executors, std::move(tracing_ctx));
+  return std::make_unique<CompilerArtifact>(executors, std::move(tracing_ctx));
 }
 
 } // namespace onert::compiler::train

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.h
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.h
@@ -60,9 +60,9 @@ public:
   /**
    * @brief Do compilation with the options
    *
-   * @return std::shared_ptr<CompilerArtifact> Executors as a result of compilation
+   * @return std::unique_ptr<CompilerArtifact> Executors as a result of compilation
    */
-  std::shared_ptr<CompilerArtifact> compile(void);
+  std::unique_ptr<CompilerArtifact> compile(void);
 
 private:
   std::shared_ptr<ir::Model> _model;


### PR DESCRIPTION
This commit changes ownership management of CompilerArtifact from share_ptr to unique_ptr.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>