### PR TITLE
[onert] Handle type-aware quantization for edge on Compiler

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -80,8 +80,8 @@ CompilerOptions Compiler::optionForSingleModel(const ir::ModelIndex &model_index
   // for the same `from` tensor and same type
   for (const auto &[from, to] : _nnpkg->model_edges().edges)
   {
-    const auto [from_model, from_subg, from_io] = from;
-    const auto [to_model, to_subg, to_io] = to;
+    const auto &[from_model, from_subg, from_io] = from;
+    const auto &[to_model, to_subg, to_io] = to;
     if (to_model == model_index)
     {
       const auto from_index =

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -72,6 +72,25 @@ CompilerOptions Compiler::optionForSingleModel(const ir::ModelIndex &model_index
   option_for_model(_options->output_type, model_opts.output_type, model_index,
                    [this](uint32_t idx) { return _nnpkg->output(idx); });
 
+  // Pass input type info for edges because edge's from_tensor info can be different
+  // with its to_tensor info.
+  // Permutation node will be inserted on PermutationIOPass.
+  // Optimization pass will remove permutation node if it's unnecessary
+  // TODO Optimize if tensors for type-aware quantization unified
+  // for the same `from` tensor and same type
+  for (const auto &[from, to] : _nnpkg->model_edges().edges)
+  {
+    const auto [from_model, from_subg, from_io] = from;
+    const auto [to_model, to_subg, to_io] = to;
+    if (to_model == model_index)
+    {
+      const auto from_index =
+        _nnpkg->model(from_model)->primary_subgraph()->getOutputs().at(from_io);
+      model_opts.input_type.insert_or_assign(
+        to_io, _nnpkg->model(from_model)->primary_subgraph()->operands().at(from_index).typeInfo());
+    }
+  }
+
   return model_opts;
 }
 

--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -49,9 +49,8 @@ class MultiModelExecutors : public IExecutors
 public:
   MultiModelExecutors(void) = delete;
   MultiModelExecutors(std::unique_ptr<ir::ModelEdges> model_edges)
-    : _executors{}, _model_edges{std::move(model_edges)}, _edge_quant_layers{},
-      _edge_quant_tensors{}, _edge_tensors{}, _is_created_edge_quant_layers{false},
-      _pkg_input_tensors{}, _pkg_output_tensors{}
+    : _executors{}, _model_edges{std::move(model_edges)}, _edge_tensors{},
+      _is_created_edge_tensors{false}, _pkg_input_tensors{}, _pkg_output_tensors{}
   {
     for (const auto &edge : _model_edges->edges)
     {
@@ -85,7 +84,7 @@ public:
 
 private:
   void checkSupportedMultimodel() const;
-  void createEdgeQuantLayers();
+  void createEdgeTensors();
   void CreatePkgIOTensors(const IODescription &desc);
   uint16_t modelCount() const;
 
@@ -96,26 +95,6 @@ private:
   // NOTE _model_edges may use different struct type for executor implementation
   std::unique_ptr<ir::ModelEdges> _model_edges;
   std::unordered_map<ir::IODesc, std::vector<ir::IODesc>> _edge_map;
-
-  /**
-   * @brief Type-aware quantization layers for edges between executors
-   *
-   */
-  // TODO Move variables related to type-aware quantization for edges into compilation stage
-  // TODO Replace PermuteLayer with backend::builtin::kernel::PermuteLayer
-  std::unordered_map<std::pair<ir::ModelIndex, ir::SubgraphIndex>, std::unique_ptr<PermuteLayer>>
-    _edge_quant_layers;
-
-  /**
-   * @brief Tensors for type-aware quantization of edges
-   *        Key: `to` IODesc, Value: EdgeTensor
-   */
-  //
-  // Q: Why is Key `to` IODesc
-  // A: these tensors are currently created depending on the type of `to`
-  // TODO Unify tensors with the same `from` tensor and same type
-  // NOTE The incomplete type 'EdgeTensor' cannot be declared as unique_ptr.
-  std::unordered_map<ir::IODesc, std::shared_ptr<EdgeTensor>> _edge_quant_tensors;
 
   /**
    * @brief Tensors for edges between executors that are not related to type-aware quantization
@@ -129,9 +108,8 @@ private:
    * @brief Whether type-aware quantization layers for edges between executors are created
    *
    */
-  // TODO Remove this member after the creation of type-aware quantization layers for edges
-  //      is moved into compilation stage
-  bool _is_created_edge_quant_layers;
+  // TODO Remove this member after the creation of edges tensors is moved into compilation stage
+  bool _is_created_edge_tensors;
 
   // IOTensors for user buffer
   std::unordered_map<ir::IODesc, std::unique_ptr<backend::builtin::UserTensor>> _pkg_input_tensors;


### PR DESCRIPTION
This commit updates Compiler to handle type-aware quantization for edge by setting input data type info in compile option for each model. 
It includes removing type-aware quantization layer and tensor in MultiModelExecutors.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>