### PR TITLE
[onert] Fix API comments for I/O tensor info getter

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw.h
+++ b/runtime/onert/api/nnfw/include/nnfw.h
@@ -422,10 +422,8 @@ NNFW_STATUS nnfw_set_output_layout(nnfw_session *session, uint32_t index, NNFW_L
 /**
  * @brief       Get i-th input tensor info
  *
- * <p>Before {@link nnfw_prepare} is invoked, this function return tensor info in model,
- * so updated tensor info by {@link nnfw_set_input_tensorinfo} is not returned.</p>
- *
- * <p>After {@link nnfw_prepare} is invoked, this function return updated tensor info
+ * <p>This function can be called after {@link nnfw_load_model_from_file} is invoked.
+ * This function return input tensor info in model or updated input tensor info
  * if tensor info is updated by {@link nnfw_set_input_tensorinfo}.</p>
  *
  * @param[in]   session     Session from input information is to be extracted
@@ -440,8 +438,11 @@ NNFW_STATUS nnfw_input_tensorinfo(nnfw_session *session, uint32_t index,
 /**
  * @brief     Get i-th output tensor info
  *
+ * <p>This function can be called after {@link nnfw_load_model_from_file} is invoked.</p>
+ *
  * <p>After {@link nnfw_load_model_from_file} and before {@link nnfw_prepare} is invoked, it returns
- * tensor info in the model.</p>
+ * tensor info in the model. Propagated tensor info by {@link nnfw_set_input_tensorinfo}
+ * is not returned.</p>
  *
  * <p>After {@link nnfw_prepare} and before {@link nnfw_run} is invoked, this function returns
  * updated tensor info if tensor info is updated by {@link nnfw_set_input_tensorinfo}.</p>


### PR DESCRIPTION
This commit fixes API outdated comments I/O tensor info getter.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>