### PR TITLE
[onert] Fix input tensor info getter API to return updated tensor info

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -815,10 +815,8 @@ NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
     }
     else
     {
-      auto io_index = onert::ir::IOIndex{index};
-      auto shape = _execution->getInputShape(io_index);
-      auto dtype = _compiler_artifact->_executors->inputInfo(io_index).typeInfo().type();
-      fillTensorInfo(ti, shape, dtype);
+      const auto &info = _execution->getInputInfo(index);
+      fillTensorInfo(ti, info.shape(), info.typeInfo().type());
     }
   }
   catch (const std::exception &e)

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -96,6 +96,12 @@ public:
    */
   void setOutput(const ir::IOIndex &index, const ir::Shape &shape, void *buffer, size_t length);
   /**
+   * @brief     Get the Input Info object
+   * @param[in] index Input index
+   * @return    Input info
+   */
+  const ir::OperandInfo &getInputInfo(uint32_t index) { return _ctx.desc.inputs.at(index)->info; }
+  /**
    * @brief  Execution
    * @note   It should be called after setting input and output buffer
    */


### PR DESCRIPTION
This commit fixes input tensor info getter API implementation to return updated tensor info by `set_input_tensorinfo` after `nnfw_prepare` called.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>