### PR TITLE
[circle-mlir/dialect] Relocate ComputeConvWindowedOutputSize

### DIFF
--- a/circle-mlir/circle-mlir/lib/dialect/src/ShapeInference.cpp
+++ b/circle-mlir/circle-mlir/lib/dialect/src/ShapeInference.cpp
@@ -22,6 +22,7 @@
 
 #include "utils/DynamicShapeUtils.h"
 #include "utils/Padding.h"
+#include "utils/KernelShapeUtil.h"
 
 #include <mlir/IR/Matchers.h>
 
@@ -29,12 +30,6 @@ namespace mlir
 {
 namespace Circle
 {
-
-// To reuse calculation for shape inference from CircleDialect.cpp
-// TODO relocate to some header
-LogicalResult ComputeConvWindowedOutputSize(int64_t input_size, int64_t filter_size,
-                                            int64_t dilation_rate, int64_t stride,
-                                            Circle::Padding padding, int64_t *output_size);
 
 namespace
 {

--- a/circle-mlir/circle-mlir/lib/dialect/src/ops/Conv2DOp.h
+++ b/circle-mlir/circle-mlir/lib/dialect/src/ops/Conv2DOp.h
@@ -38,21 +38,6 @@ void Conv2DOp::getCanonicalizationPatterns(RewritePatternSet &results, MLIRConte
   // results.add<RemoveOptionalZeroBias<Conv2DOp>>(context);
 }
 
-LogicalResult ComputeConvWindowedOutputSize(int64_t input_size, int64_t filter_size,
-                                            int64_t dilation_rate, int64_t stride,
-                                            Circle::Padding padding, int64_t *output_size)
-{
-  int64_t pad_low;
-  int64_t pad_high;
-
-  Status status = Circle::GetWindowedOutputSizeVerboseV2(
-    input_size, filter_size, dilation_rate, stride, padding, output_size, &pad_low, &pad_high);
-  // Return failure if expected_output_size could not be calculated.
-  if (!status.ok())
-    return failure();
-  return success();
-}
-
 LogicalResult Conv2DOp::inferReturnTypes(MLIRContext *, std::optional<Location> location,
                                          ValueRange operands, DictionaryAttr attr,
                                          OpaqueProperties properties, RegionRange,

--- a/circle-mlir/circle-mlir/lib/dialect/utils/KernelShapeUtil.cpp
+++ b/circle-mlir/circle-mlir/lib/dialect/utils/KernelShapeUtil.cpp
@@ -146,3 +146,27 @@ Status Get3dOutputSizeV2(const std::array<int64_t, 3> &input, const std::array<i
 
 } // namespace Circle
 } // namespace mlir
+
+namespace mlir
+{
+namespace Circle
+{
+
+// NOTE relocated from dialect/src/ops/Conv2DOp.h to reduce MCD
+LogicalResult ComputeConvWindowedOutputSize(int64_t input_size, int64_t filter_size,
+                                            int64_t dilation_rate, int64_t stride,
+                                            Circle::Padding padding, int64_t *output_size)
+{
+  int64_t pad_low;
+  int64_t pad_high;
+
+  Status status = Circle::GetWindowedOutputSizeVerboseV2(
+    input_size, filter_size, dilation_rate, stride, padding, output_size, &pad_low, &pad_high);
+  // Return failure if expected_output_size could not be calculated.
+  if (!status.ok())
+    return failure();
+  return success();
+}
+
+} // namespace Circle
+} // namespace mlir

--- a/circle-mlir/circle-mlir/lib/dialect/utils/KernelShapeUtil.h
+++ b/circle-mlir/circle-mlir/lib/dialect/utils/KernelShapeUtil.h
@@ -22,6 +22,8 @@
 
 #include "Padding.h"
 
+#include <mlir/IR/BuiltinTypes.h>
+
 #include <array>
 
 namespace mlir
@@ -143,6 +145,18 @@ Status Get3dOutputSizeV2(const std::array<int64_t, 3> &input, const std::array<i
                          const std::array<int64_t, 3> &dilations,
                          const std::array<int64_t, 3> &strides, Padding padding_type,
                          std::array<int64_t, 3> *output_ptr, std::array<int64_t, 3> *padding_ptr);
+
+} // namespace Circle
+} // namespace mlir
+
+namespace mlir
+{
+namespace Circle
+{
+
+LogicalResult ComputeConvWindowedOutputSize(int64_t input_size, int64_t filter_size,
+                                            int64_t dilation_rate, int64_t stride,
+                                            Circle::Padding padding, int64_t *output_size);
 
 } // namespace Circle
 } // namespace mlir


### PR DESCRIPTION
This will relocate ComputeConvWindowedOutputSize method
to reduce MCD(Module Circular Dependency) of analysis tool.
