### PR TITLE
[logo-core] Fix a warning when building with clang

### DIFF
--- a/compiler/logo-core/include/logo/Phase.h
+++ b/compiler/logo-core/include/logo/Phase.h
@@ -39,7 +39,7 @@ enum class PhaseEvent
   PassEnd,
 };
 
-template <PhaseEvent E> struct PhaseEventInfo;
+template <PhaseEvent E> class PhaseEventInfo;
 
 template <> class PhaseEventInfo<PhaseEvent::PhaseBegin>
 {


### PR DESCRIPTION
This commit fixes a warning emitted by clang for the Phase.h header file

There's a mismatch between the original template declaration and the following specializations of the PhaseEventInfo class/struct. The changes in this commit fix the following warning (which causes a build break when compiling in strict mode)

`logo/Phase.h:44:13: error: 'PhaseEventInfo' defined as a class template here but previously declared as a struct template;`

This commit also increases the consistency of such templates because there are multiple files where the struct/struct usage is maintained, for example https://github.com/Samsung/ONE/blob/master/compiler/ann-ref/src/ops/internal/Fused.h#L40-L42

ONE-DCO-1.0-Signed-off-by: Tomasz Dołbniak <t.dolbniak@partner.samsung.com>