### PR TITLE
[onert] Add output shape synchronization for dynamic tensors

### DIFF
--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -51,6 +51,7 @@ public:
 public:
   void setTensor(IPortableTensor *tensor);
   void setBackendTensor(IPortableTensor *tensor);
+  const IPortableTensor *actualTensor() { return _tensor; }
 
 public:
   uint8_t *buffer() const override { return _tensor->buffer(); }

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -91,6 +91,9 @@ void ExecutorBase::execute(const std::vector<backend::IPortableTensor *> &inputs
     {
       assert(output_tensor->buffer() != nullptr);
       output_tensor->syncInfoFromBackendTensor();
+
+      // outputs[n] is not used, but update its shape to pass updated shape to caller
+      outputs[n]->setShape(output_tensor->actualTensor()->getShape());
     }
   }
 }

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -331,6 +331,18 @@ void MultiModelExecutors::execute(const ExecutionContext &ctx)
         _edge_tensors[from_iodesc]->decrease_ref();
       }
     }
+
+    // Get dynamic shape inference result
+    for (uint32_t i = 0; i < output_size; ++i)
+    {
+      if (ctx.desc.outputs[i]->buffer == nullptr)
+      {
+        // Output is optional if buffer is nullptr
+        continue;
+      }
+
+      ctx.desc.outputs[i]->info.shape(outputs_inter[i]->getShape());
+    }
   }
 }
 


### PR DESCRIPTION
This commit adds output shape synchronization for dynamic tensors on internally allocated outputs
- Add `actualTensor()` getter to IOTensor to access actual IPortableTensor type tensor
- Update output shapes in ExecutorBase to pass dynamic shape changes
- Implement shape inference result propagation in MultiModelExecutors: SingleModelExecutors already have this logic

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>