### PR TITLE
[onert] Support internal output allocation on MultiModelExecutors

### DIFF
--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -621,6 +621,74 @@ TEST(ExecInstance, multi_model_simple)
   }
 }
 
+TEST(ExecInstance, multi_model_shapeinf)
+{
+  auto mockup = MockUpMultiModel();
+  mockup.compile();
+  auto executors = mockup.artifact->_executors;
+
+  auto input1 = IOIndex{0};
+  auto input2 = IOIndex{1};
+  auto output = IOIndex{0};
+
+  onert::ir::Shape new_shape{2, 2, 2, 1};
+  const float input1_buffer[8] = {1, 0, -1, -2, 1, 2, 0, -1};
+  const float input2_buffer[8] = {1, -3, 2, -4, 4, -2, 3, 1};
+  float output_buffer[8] = {};
+  // result1 = {2, -3, 1, -6, 5, 0, 3, 0}
+  // result2 = {5, -2, 0, -1, 8, 1, 2, 5}
+  const float output_expected[8] = {7, -5, 1, -7, 13, 1, 5, 5};
+
+  onert::exec::Execution execution{executors};
+  execution.changeInputShape(input1, new_shape);
+  execution.changeInputShape(input2, new_shape);
+
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 32);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 32);
+  execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 32);
+  execution.execute();
+
+  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
+  for (auto i = 0; i < 8; i++)
+  {
+    EXPECT_EQ(output_buffer[i], output_expected[i]);
+  }
+}
+
+TEST(ExecInstance, multi_model_internaloutput_shapeinf)
+{
+  auto mockup = MockUpMultiModel();
+  mockup.coptions->internal_output_alloc = true;
+  mockup.compile();
+  auto executors = mockup.artifact->_executors;
+
+  auto input1 = IOIndex{0};
+  auto input2 = IOIndex{1};
+  auto output = IOIndex{0};
+
+  onert::ir::Shape new_shape{2, 2, 2, 1};
+  const float input1_buffer[8] = {1, 0, -1, -2, 1, 2, 0, -1};
+  const float input2_buffer[8] = {1, -3, 2, -4, 4, -2, 3, 1};
+  // result1 = {2, -3, 1, -6, 5, 0, 3, 0}
+  // result2 = {5, -2, 0, -1, 8, 1, 2, 5}
+  const float output_expected[8] = {7, -5, 1, -7, 13, 1, 5, 5};
+
+  onert::exec::Execution execution{executors};
+  execution.changeInputShape(input1, new_shape);
+  execution.changeInputShape(input2, new_shape);
+
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 32);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 32);
+  execution.execute();
+  const float *output_buffer = reinterpret_cast<const float *>(executors->outputBuffer(output));
+
+  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
+  for (auto i = 0; i < 8; i++)
+  {
+    EXPECT_EQ(output_buffer[i], output_expected[i]);
+  }
+}
+
 TEST(ExecInstance, multi_model_twoCompile)
 {
   auto mockup = MockUpMultiModel();

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -635,17 +635,15 @@ TEST(ExecInstance, multi_model_shapeinf)
   const float input1_buffer[8] = {1, 0, -1, -2, 1, 2, 0, -1};
   const float input2_buffer[8] = {1, -3, 2, -4, 4, -2, 3, 1};
   float output_buffer[8] = {};
-  // result1 = {2, -3, 1, -6, 5, 0, 3, 0}
-  // result2 = {5, -2, 0, -1, 8, 1, 2, 5}
   const float output_expected[8] = {7, -5, 1, -7, 13, 1, 5, 5};
 
   onert::exec::Execution execution{executors};
   execution.changeInputShape(input1, new_shape);
   execution.changeInputShape(input2, new_shape);
 
-  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 32);
-  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 32);
-  execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 32);
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), sizeof(input1_buffer));
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), sizeof(input2_buffer));
+  execution.setOutput(output, reinterpret_cast<void *>(output_buffer), sizeof(output_buffer));
   execution.execute();
 
   EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
@@ -669,16 +667,14 @@ TEST(ExecInstance, multi_model_internaloutput_shapeinf)
   onert::ir::Shape new_shape{2, 2, 2, 1};
   const float input1_buffer[8] = {1, 0, -1, -2, 1, 2, 0, -1};
   const float input2_buffer[8] = {1, -3, 2, -4, 4, -2, 3, 1};
-  // result1 = {2, -3, 1, -6, 5, 0, 3, 0}
-  // result2 = {5, -2, 0, -1, 8, 1, 2, 5}
   const float output_expected[8] = {7, -5, 1, -7, 13, 1, 5, 5};
 
   onert::exec::Execution execution{executors};
   execution.changeInputShape(input1, new_shape);
   execution.changeInputShape(input2, new_shape);
 
-  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 32);
-  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 32);
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), sizeof(input1_buffer));
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), sizeof(input2_buffer));
   execution.execute();
   const float *output_buffer = reinterpret_cast<const float *>(executors->outputBuffer(output));
 


### PR DESCRIPTION
This commit supports internal output allocation on MultiModelExecutors.
This commit includes two multimodel shape inference tests and update to pass tests
- External output buffer (default)
- Internal output buffer allocation

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15928