### PR TITLE
[luci-interpreter] Remove unnecessary pragma

### DIFF
--- a/compiler/luci-interpreter/src/kernels/UnidirectionalSequenceLSTM.cpp
+++ b/compiler/luci-interpreter/src/kernels/UnidirectionalSequenceLSTM.cpp
@@ -34,7 +34,6 @@ using namespace tflite;
 void UpdateLstmCellFloat(int n_batch, int n_cell, float *cell_state, const float *input_gate,
                          float *forget_gate, const float *cell_gate, bool use_cifg, float clip)
 {
-// NOTE tflite source is as is but will fail build with gcc-8 and above
   tensor_utils::VectorVectorCwiseProduct(forget_gate, cell_state, n_batch * n_cell, cell_state);
 
   if (use_cifg)

--- a/compiler/luci-interpreter/src/kernels/UnidirectionalSequenceLSTM.cpp
+++ b/compiler/luci-interpreter/src/kernels/UnidirectionalSequenceLSTM.cpp
@@ -35,8 +35,6 @@ void UpdateLstmCellFloat(int n_batch, int n_cell, float *cell_state, const float
                          float *forget_gate, const float *cell_gate, bool use_cifg, float clip)
 {
 // NOTE tflite source is as is but will fail build with gcc-8 and above
-// TODO remove #pragma
-#pragma GCC diagnostic ignored "-Wrestrict"
   tensor_utils::VectorVectorCwiseProduct(forget_gate, cell_state, n_batch * n_cell, cell_state);
 
   if (use_cifg)


### PR DESCRIPTION
This commit removes a #pragma statement from kernels/UnidirectionalSequenceLSTM.cpp

This pragma used to guard the build from warnings coming from the TF but the build now works fine on newer GCC versions with strict build enabled.

Additionally this pragma was never disabled (not scoped) with a #pragma pop statement which effectively ignored this warning for the rest of the project after this particular file was compiled.

ONE-DCO-1.0-Signed-off-by: Tomasz Dołbniak <t.dolbniak@partner.samsung.com>