### PR TITLE
[onert] Clean up Execution API

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -70,37 +70,27 @@ public:
   void setInput(const ir::IOIndex &index, const void *buffer, size_t length);
 
   /**
-   * @brief     Set input data's information, especially to specify unknown dimensions on model
-   * build time.
-   * @param[in] index   Input index
-   * @param[in] shape   Input data's shape
-   * @param[in] buffer  Input data's buffer pointer
-   * @param[in] length  Input data's length
-   */
-  void setInput(const ir::IOIndex &index, const ir::Shape &shape, const void *buffer,
-                size_t length);
-  /**
    * @brief     Set output data's information
    * @param[in] index   Output index
    * @param[in] buffer  Output data's buffer pointer
    * @param[in] length  Output data's length
    */
   void setOutput(const ir::IOIndex &index, void *buffer, size_t length);
-  /**
-   * @brief     Set output data's information, especially to specify unknown dimensions on model
-   * build time.
-   * @param[in] index   Output index
-   * @param[in] shape   Output data's shape
-   * @param[in] buffer  Output data's buffer pointer
-   * @param[in] length  Output data's length
-   */
-  void setOutput(const ir::IOIndex &index, const ir::Shape &shape, void *buffer, size_t length);
+
   /**
    * @brief     Get the Input Info object
    * @param[in] index Input index
    * @return    Input info
    */
-  const ir::OperandInfo &getInputInfo(uint32_t index) { return _ctx.desc.inputs.at(index)->info; }
+  const ir::OperandInfo &inputInfo(uint32_t index) { return _ctx.desc.inputs.at(index).info; }
+
+  /**
+   * @brief     Get the Output Info object
+   * @param[in] index Output index
+   * @return    Output info
+   */
+  const ir::OperandInfo &outputInfo(uint32_t index) { return _ctx.desc.outputs.at(index).info; }
+
   /**
    * @brief  Execution
    * @note   It should be called after setting input and output buffer
@@ -151,24 +141,17 @@ public:
     const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)>
       &fn) const;
 
-  ir::Shape getInputShape(ir::IOIndex ind) const;
-  ir::Shape getOutputShape(ir::IOIndex ind) const;
-  size_t getInputTotalSize(ir::IOIndex ind) const;
-  size_t getOutputTotalSize(ir::IOIndex ind) const;
+  /**
+   * @brief   Get context of execution
+   * @return  Execution context
+   */
+  const ExecutionContext &context() const { return _ctx; }
 
   /**
-   * @brief     Get pointer of Input Buffer
-   * @param[in] index     Input index
-   * @return    Pointer of Input Buffer
+   * @brief     Set context of execution at once
+   * @param[in] ctx Execution context
    */
-  const void *getInputBuffer(ir::IOIndex ind) const;
-
-  /**
-   * @brief     Get pointer of Output Buffer
-   * @param[in] index     Output index
-   * @return    Pointer of Output Buffer
-   */
-  void *getOutputBuffer(ir::IOIndex ind);
+  void restoreContext(const ExecutionContext &ctx) { _ctx = ctx; }
 
   ExecutionOptions &executionOptions() { return _ctx.options; }
 

--- a/runtime/onert/core/include/exec/ExecutionContext.h
+++ b/runtime/onert/core/include/exec/ExecutionContext.h
@@ -49,8 +49,8 @@ struct OutputDesc
 
 struct IODescription
 {
-  std::vector<std::unique_ptr<InputDesc>> inputs;
-  std::vector<std::unique_ptr<OutputDesc>> outputs;
+  std::vector<InputDesc> inputs;
+  std::vector<OutputDesc> outputs;
 };
 
 struct ExecutionOptions

--- a/runtime/onert/core/include/exec/IExecutors.h
+++ b/runtime/onert/core/include/exec/IExecutors.h
@@ -98,10 +98,10 @@ public:
   virtual const backend::IPortableTensor *outputTensor(const ir::IOIndex &index) const = 0;
 
   /**
-   * @brief     Execute NN package executor set
-   * @param[in] ctx  Execution context
+   * @brief         Execute NN package executor set
+   * @param[inout]  ctx Execution context. It reflects execution result (ex. output shape inference)
    */
-  virtual void execute(const ExecutionContext &ctx) = 0;
+  virtual void execute(ExecutionContext &ctx) = 0;
 };
 
 } // namespace onert::exec

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -366,12 +366,14 @@ TEST(ExecInstance, neg_small_inoutsize)
 
   onert::exec::Execution execution{executors};
 
-  execution.setInput(input1, new_shape, reinterpret_cast<const void *>(input1_buffer), 8);
-  execution.setInput(input2, new_shape, reinterpret_cast<const void *>(input2_buffer), 2);
+  execution.changeInputShape(input1, new_shape);
+  execution.changeInputShape(input2, new_shape);
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 8);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 2);
   EXPECT_THROW(execution.execute(), std::exception);
 
   // Not throw exception because input shape is changed and output buffer is enough
-  execution.setInput(input2, new_shape, reinterpret_cast<const void *>(input2_buffer), 8);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 8);
   execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 16);
   execution.execute();
 
@@ -762,12 +764,9 @@ TEST(ExecInstance, multi_model_dequant_input_quant_output)
   auto executors = mockup.artifact->_executors;
 
   onert::exec::Execution execution{executors};
-  execution.setInput(input1, execution.getInputShape(input1),
-                     reinterpret_cast<const void *>(input1_buffer), 4);
-  execution.setInput(input2, execution.getInputShape(input2),
-                     reinterpret_cast<const void *>(input2_buffer), 4);
-  execution.setOutput(output, execution.getOutputShape(output),
-                      reinterpret_cast<void *>(output_buffer), 4);
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 4);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 4);
+  execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 4);
   execution.execute();
 
   for (auto i = 0; i < 4; i++)

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -192,12 +192,11 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
       find_input_index(_model_edges->pkg_inputs, model_index, subg_index, io_index);
     if (input_pkg_index == -1)
       throw std::runtime_error{"Cannot find multi model input index"};
-    auto input_desc = desc.inputs[input_pkg_index].get();
+    auto &input_desc = desc.inputs[input_pkg_index];
     // TODO Remove const_cast (we need const_cast as ITensor is writable)
     _pkg_input_tensors[pkg_input] = std::make_unique<backend::builtin::UserTensor>(
-      input_desc->info,
-      const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(input_desc->buffer)),
-      input_desc->size);
+      input_desc.info, const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(input_desc.buffer)),
+      input_desc.size);
   }
 
   for (const auto &pkg_output : _model_edges->pkg_outputs)
@@ -208,13 +207,13 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
       find_output_index(_model_edges->pkg_outputs, model_index, subg_index, io_index);
     if (output_pkg_index == -1)
       throw std::runtime_error{"Cannot find multi model output index"};
-    auto output_desc = desc.outputs[output_pkg_index].get();
+    auto &output_desc = desc.outputs[output_pkg_index];
     _pkg_output_tensors[pkg_output] = std::make_unique<backend::builtin::UserTensor>(
-      output_desc->info, reinterpret_cast<uint8_t *>(output_desc->buffer), output_desc->size);
+      output_desc.info, reinterpret_cast<uint8_t *>(output_desc.buffer), output_desc.size);
   }
 }
 
-void MultiModelExecutors::execute(const ExecutionContext &ctx)
+void MultiModelExecutors::execute(ExecutionContext &ctx)
 {
   // TODO: Enable to skip setting user tensor into IOTensor
   for (uint32_t i = 0; i < _model_edges->pkg_outputs.size(); ++i)

--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -80,7 +80,7 @@ public:
 
   const backend::IPortableTensor *outputTensor(const ir::IOIndex &index) const final;
 
-  void execute(const ExecutionContext &ctx) override;
+  void execute(ExecutionContext &ctx) override;
 
 private:
   void checkSupportedMultimodel() const;

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -60,7 +60,7 @@ const backend::IPortableTensor *SingleModelExecutors::outputTensor(const ir::IOI
   return entryExecutor()->outputTensor(index.value());
 }
 
-void SingleModelExecutors::execute(const ExecutionContext &ctx)
+void SingleModelExecutors::execute(ExecutionContext &ctx)
 {
   // UserTensor for Input/Output
   std::vector<std::unique_ptr<backend::builtin::UserTensor>> tensorpool;
@@ -75,11 +75,11 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
     auto &desc = ctx.desc.inputs[i];
 
     // Input is optional if buffer is nullptr, and optional input's size is 0
-    if (desc->buffer == nullptr && (desc->size != 0 || desc->info.total_size() != 0))
+    if (desc.buffer == nullptr && (desc.size != 0 || desc.info.total_size() != 0))
       throw std::runtime_error{"Input " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)), desc->size));
+      desc.info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc.buffer)), desc.size));
 
     inputs[i] = tensorpool.back().get();
   }
@@ -95,12 +95,12 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
     bool skip_set_output = output_io_tensor->hasBackendTensor();
 
     // Output is optional if buffer is nullptr, and optional output's size is 0
-    if (desc->buffer == nullptr && (desc->size != 0 || desc->info.total_size() != 0) &&
+    if (desc.buffer == nullptr && (desc.size != 0 || desc.info.total_size() != 0) &&
         !skip_set_output)
       throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, static_cast<uint8_t *>(desc->buffer), desc->size));
+      desc.info, static_cast<uint8_t *>(desc.buffer), desc.size));
     outputs[i] = tensorpool.back().get();
   }
 
@@ -110,13 +110,13 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   // Get dynamic shape inference result
   for (uint32_t i = 0; i < outputs.size(); i++)
   {
-    if (ctx.desc.outputs[i]->buffer == nullptr)
+    if (ctx.desc.outputs[i].buffer == nullptr)
     {
       // Output is optional if buffer is nullptr
       continue;
     }
 
-    ctx.desc.outputs[i]->info.shape(outputs[i]->getShape());
+    ctx.desc.outputs[i].info.shape(outputs[i]->getShape());
   }
 }
 

--- a/runtime/onert/core/src/exec/SingleModelExecutors.h
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.h
@@ -60,7 +60,7 @@ public:
 
   const backend::IPortableTensor *outputTensor(const ir::IOIndex &index) const final;
 
-  void execute(const ExecutionContext &ctx) override;
+  void execute(ExecutionContext &ctx) override;
 
 private:
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>> _executors;

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -61,7 +61,7 @@ const backend::IPortableTensor *TrainableExecutors::outputTensor(const ir::IOInd
   return entryExecutor()->outputTensor(index.value());
 }
 
-void TrainableExecutors::execute(const ExecutionContext &ctx)
+void TrainableExecutors::execute(ExecutionContext &ctx)
 {
   if (_executors.size() > 1)
     throw std::runtime_error("TrainableExecutors does not support multiple executors yet");
@@ -104,11 +104,11 @@ void TrainableExecutors::forward(
     auto &desc = ctx.desc.inputs[i];
 
     // Input is optional if buffer is nullptr, and optional input's size is 0
-    if (desc->buffer == nullptr && (desc->size != 0 || desc->info.total_size() != 0))
+    if (desc.buffer == nullptr && (desc.size != 0 || desc.info.total_size() != 0))
       throw std::runtime_error{"Input " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)), desc->size));
+      desc.info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc.buffer)), desc.size));
     inputs[i] = tensorpool.back().get();
   }
 
@@ -120,7 +120,7 @@ void TrainableExecutors::forward(
     // If training, output buffer may not be used
     // So don't check optional
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, static_cast<uint8_t *>(desc->buffer), desc->size));
+      desc.info, static_cast<uint8_t *>(desc.buffer), desc.size));
     outputs[i] = tensorpool.back().get();
   }
 

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.h
@@ -67,7 +67,7 @@ public:
 
   const backend::IPortableTensor *outputTensor(const ir::IOIndex &index) const final;
 
-  void execute(const ExecutionContext &ctx) override;
+  void execute(ExecutionContext &ctx) override;
 
   /**
    * @brief Train


### PR DESCRIPTION
This commit cleans up Execution API
- Add API to access I/O info
- Remove APIs which can be handled by new API
- Remove setInput/setOutput API used for NNAPI only
- Change IExecutors context paramter as inout and remove const to return shape inference result
- Change IODescription vector element type: use raw type instead of unique_ptr for simple copy

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>