### PR TITLE
Draft: Support internal output allocation on multimodel

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -70,37 +70,27 @@ public:
   void setInput(const ir::IOIndex &index, const void *buffer, size_t length);
 
   /**
-   * @brief     Set input data's information, especially to specify unknown dimensions on model
-   * build time.
-   * @param[in] index   Input index
-   * @param[in] shape   Input data's shape
-   * @param[in] buffer  Input data's buffer pointer
-   * @param[in] length  Input data's length
-   */
-  void setInput(const ir::IOIndex &index, const ir::Shape &shape, const void *buffer,
-                size_t length);
-  /**
    * @brief     Set output data's information
    * @param[in] index   Output index
    * @param[in] buffer  Output data's buffer pointer
    * @param[in] length  Output data's length
    */
   void setOutput(const ir::IOIndex &index, void *buffer, size_t length);
-  /**
-   * @brief     Set output data's information, especially to specify unknown dimensions on model
-   * build time.
-   * @param[in] index   Output index
-   * @param[in] shape   Output data's shape
-   * @param[in] buffer  Output data's buffer pointer
-   * @param[in] length  Output data's length
-   */
-  void setOutput(const ir::IOIndex &index, const ir::Shape &shape, void *buffer, size_t length);
+
   /**
    * @brief     Get the Input Info object
    * @param[in] index Input index
    * @return    Input info
    */
-  const ir::OperandInfo &getInputInfo(uint32_t index) { return _ctx.desc.inputs.at(index)->info; }
+  const ir::OperandInfo &inputInfo(uint32_t index) { return _ctx.desc.inputs.at(index).info; }
+
+  /**
+   * @brief     Get the Output Info object
+   * @param[in] index Output index
+   * @return    Output info
+   */
+  const ir::OperandInfo &outputInfo(uint32_t index) { return _ctx.desc.outputs.at(index).info; }
+
   /**
    * @brief  Execution
    * @note   It should be called after setting input and output buffer
@@ -151,24 +141,17 @@ public:
     const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)>
       &fn) const;
 
-  ir::Shape getInputShape(ir::IOIndex ind) const;
-  ir::Shape getOutputShape(ir::IOIndex ind) const;
-  size_t getInputTotalSize(ir::IOIndex ind) const;
-  size_t getOutputTotalSize(ir::IOIndex ind) const;
+  /**
+   * @brief   Get context of execution
+   * @return  Execution context
+   */
+  const ExecutionContext &context() const { return _ctx; }
 
   /**
-   * @brief     Get pointer of Input Buffer
-   * @param[in] index     Input index
-   * @return    Pointer of Input Buffer
+   * @brief     Set context of execution at once
+   * @param[in] ctx Execution context
    */
-  const void *getInputBuffer(ir::IOIndex ind) const;
-
-  /**
-   * @brief     Get pointer of Output Buffer
-   * @param[in] index     Output index
-   * @return    Pointer of Output Buffer
-   */
-  void *getOutputBuffer(ir::IOIndex ind);
+  void restoreContext(const ExecutionContext &ctx) { _ctx = ctx; }
 
   ExecutionOptions &executionOptions() { return _ctx.options; }
 

--- a/runtime/onert/core/include/exec/ExecutionContext.h
+++ b/runtime/onert/core/include/exec/ExecutionContext.h
@@ -49,8 +49,8 @@ struct OutputDesc
 
 struct IODescription
 {
-  std::vector<std::unique_ptr<InputDesc>> inputs;
-  std::vector<std::unique_ptr<OutputDesc>> outputs;
+  std::vector<InputDesc> inputs;
+  std::vector<OutputDesc> outputs;
 };
 
 struct ExecutionOptions

--- a/runtime/onert/core/include/exec/IExecutors.h
+++ b/runtime/onert/core/include/exec/IExecutors.h
@@ -98,10 +98,10 @@ public:
   virtual const backend::IPortableTensor *outputTensor(const ir::IOIndex &index) const = 0;
 
   /**
-   * @brief     Execute NN package executor set
-   * @param[in] ctx  Execution context
+   * @brief         Execute NN package executor set
+   * @param[inout]  ctx Execution context. It reflects execution result (ex. output shape inference)
    */
-  virtual void execute(const ExecutionContext &ctx) = 0;
+  virtual void execute(ExecutionContext &ctx) = 0;
 };
 
 } // namespace onert::exec

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -32,13 +32,12 @@ Execution::Execution(const std::shared_ptr<IExecutors> &executors) : _executors{
   assert(executors->entryExecutor() != nullptr);
 
   // Initialize I/O description
-  _ctx.desc.inputs.resize(_executors->inputSize());
+  // _ctx.desc.inputs.resize(_executors->inputSize());
   for (uint32_t i = 0; i < _executors->inputSize(); ++i)
-    _ctx.desc.inputs.at(i) = std::make_unique<InputDesc>(_executors->inputInfo(ir::IOIndex(i)));
+    _ctx.desc.inputs.emplace_back(_executors->inputInfo(ir::IOIndex(i)));
 
-  _ctx.desc.outputs.resize(_executors->outputSize());
   for (uint32_t i = 0; i < _executors->outputSize(); ++i)
-    _ctx.desc.outputs.at(i) = std::make_unique<OutputDesc>(_executors->outputInfo(ir::IOIndex(i)));
+    _ctx.desc.outputs.emplace_back(_executors->outputInfo(ir::IOIndex(i)));
   _ctx.shape_updated = false;
 
   _is_internal_output_tensor.resize(_executors->outputSize());
@@ -62,9 +61,9 @@ void Execution::changeInputShape(const ir::IOIndex &index, const ir::Shape &new_
   // Note that 'compiled' model will not be updated with new_shape
   // but new_shape will change model input shape while 'running' the model
   auto &input_desc = _ctx.desc.inputs.at(index.value());
-  if (new_shape != input_desc->info.shape())
+  if (new_shape != input_desc.info.shape())
   {
-    input_desc->info.shape(new_shape);
+    input_desc.info.shape(new_shape);
     _ctx.shape_updated = true;
 
     VERBOSE(Execution) << "Model input shape will be changed at the start of execute()"
@@ -77,15 +76,8 @@ void Execution::setInput(const ir::IOIndex &index, const void *buffer, size_t le
 {
   // Length validation in execute(): datatype can be changed by API call
   auto &input_desc = _ctx.desc.inputs.at(index.value());
-  input_desc->buffer = buffer;
-  input_desc->size = length;
-}
-
-void Execution::setInput(const ir::IOIndex &index, const ir::Shape &shape, const void *buffer,
-                         size_t length)
-{
-  changeInputShape(index, shape);
-  setInput(index, buffer, length);
+  input_desc.buffer = buffer;
+  input_desc.size = length;
 }
 
 void Execution::setOutput(const ir::IOIndex &index, void *buffer, size_t length)
@@ -94,17 +86,8 @@ void Execution::setOutput(const ir::IOIndex &index, void *buffer, size_t length)
   // - datatype can be changed by API call
   // - shape can be changed by dynamic shape inference
   auto &output_desc = _ctx.desc.outputs.at(index.value());
-  output_desc->buffer = buffer;
-  output_desc->size = length;
-}
-
-void Execution::setOutput(const ir::IOIndex &index, const ir::Shape &shape, void *buffer,
-                          size_t length)
-{
-  auto &output_desc = _ctx.desc.outputs.at(index.value());
-  output_desc->info.shape(shape);
-
-  setOutput(index, buffer, length);
+  output_desc.buffer = buffer;
+  output_desc.size = length;
 }
 
 void Execution::execute()
@@ -114,7 +97,7 @@ void Execution::execute()
   // Input length validation check
   for (const auto &input : _ctx.desc.inputs)
   {
-    if (input->info.total_size() > input->size)
+    if (input.info.total_size() > input.size)
       throw std::runtime_error{"Too small input buffer length"};
   }
 
@@ -126,9 +109,9 @@ void Execution::execute()
     {
       const bool is_managed_internally = _is_internal_output_tensor.at(i);
       const auto &output = _ctx.desc.outputs.at(i);
-      if (!is_managed_internally && output->info.total_size() > output->size)
+      if (!is_managed_internally && output.info.total_size() > output.size)
         throw std::runtime_error{"Too small output buffer length"};
-      if (is_managed_internally && output->buffer != nullptr)
+      if (is_managed_internally && output.buffer != nullptr)
         VERBOSE(Execution) << "Warning: Output buffer was set from API even though the output "
                               "tensor was allocated internally"
                            << std::endl;
@@ -191,43 +174,6 @@ void Execution::iterateTrainableTensors(
     throw std::runtime_error{"Supported only TrainableExecutors"};
   }
   execs->iterateTrainableTensors(fn);
-}
-
-ir::Shape Execution::getInputShape(ir::IOIndex ind) const
-{
-  return _ctx.desc.inputs.at(ind.value())->info.shape();
-}
-
-// NNAPI return fail if ANeuralNetworksExecution_getOutputOperandRank or
-// ANeuralNetworksExecution_getOutputOperandDimensions is called before execution.
-// On the other hand, NNFW API return static shape inference result if nnfw_output_tensorinfo is
-// called before execution.
-// To handle both case, this method retun static shape inference result and fail will be handled on
-// NNAPI frontend.
-ir::Shape Execution::getOutputShape(ir::IOIndex ind) const
-{
-  return _ctx.desc.outputs.at(ind.value())->info.shape();
-}
-
-size_t Execution::getInputTotalSize(ir::IOIndex ind) const
-{
-  // TODO Support dynamic shape
-  return _ctx.desc.inputs.at(ind.value())->info.total_size();
-}
-
-size_t Execution::getOutputTotalSize(ir::IOIndex ind) const
-{
-  return _ctx.desc.outputs.at(ind.value())->info.total_size();
-}
-
-const void *Execution::getInputBuffer(ir::IOIndex ind) const
-{
-  return _ctx.desc.inputs.at(ind.value())->buffer;
-}
-
-void *Execution::getOutputBuffer(ir::IOIndex ind)
-{
-  return _ctx.desc.outputs.at(ind.value())->buffer;
 }
 
 } // namespace onert::exec

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -389,7 +389,7 @@ TEST(ExecInstance, internaloutput_shapeinf)
   execution.execute();
 
   const float *output_buffer = reinterpret_cast<const float *>(executors->outputBuffer(output));
-  EXPECT_EQ(executors->outputInfo(output).shape(), new_shape);
+  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
   for (auto i = 0; i < 8; i++)
   {
     EXPECT_EQ(output_buffer[i], output_expected[i]);

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -357,7 +357,7 @@ TEST(ExecInstance, shapeinf)
   execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 32);
   execution.execute();
 
-  EXPECT_EQ(execution.getOutputShape(output), new_shape);
+  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
   for (auto i = 0; i < 8; i++)
   {
     EXPECT_EQ(output_buffer[i], output_expected[i]);
@@ -720,7 +720,7 @@ TEST(ExecInstance, multi_model_shapeinf)
   execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 32);
   execution.execute();
 
-  EXPECT_EQ(execution.getOutputShape(output), new_shape);
+  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
   for (auto i = 0; i < 8; i++)
   {
     EXPECT_EQ(output_buffer[i], output_expected[i]);
@@ -752,9 +752,9 @@ TEST(ExecInstance, multi_model_internaloutput_shapeinf)
   execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 32);
   execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 32);
   execution.execute();
-  float *output_buffer = reinterpret_cast<float *>(execution.getOutputBuffer(output));
+  const float *output_buffer = reinterpret_cast<const float *>(executors->outputBuffer(output));
 
-  EXPECT_EQ(execution.getOutputShape(output), new_shape);
+  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
   for (auto i = 0; i < 8; i++)
   {
     EXPECT_EQ(output_buffer[i], output_expected[i]);

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -693,6 +693,74 @@ TEST(ExecInstance, multi_model_simple)
   }
 }
 
+TEST(ExecInstance, multi_model_shapeinf)
+{
+  auto mockup = MockUpMultiModel();
+  mockup.compile();
+  auto executors = mockup.artifact->_executors;
+
+  auto input1 = IOIndex{0};
+  auto input2 = IOIndex{1};
+  auto output = IOIndex{0};
+
+  onert::ir::Shape new_shape{2, 2, 2, 1};
+  const float input1_buffer[8] = {1, 0, -1, -2, 1, 2, 0, -1};
+  const float input2_buffer[8] = {1, -3, 2, -4, 4, -2, 3, 1};
+  float output_buffer[8] = {};
+  // result1 = {2, -3, 1, -6, 5, 0, 3, 0}
+  // result2 = {5, -2, 0, -1, 8, 1, 2, 5}
+  const float output_expected[8] = {7, -5, 1, -7, 13, 1, 5, 5};
+
+  onert::exec::Execution execution{executors};
+  execution.changeInputShape(input1, new_shape);
+  execution.changeInputShape(input2, new_shape);
+
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 32);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 32);
+  execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 32);
+  execution.execute();
+
+  EXPECT_EQ(execution.getOutputShape(output), new_shape);
+  for (auto i = 0; i < 8; i++)
+  {
+    EXPECT_EQ(output_buffer[i], output_expected[i]);
+  }
+}
+
+TEST(ExecInstance, multi_model_internaloutput_shapeinf)
+{
+  auto mockup = MockUpMultiModel();
+  mockup.coptions->internal_output_alloc = true;
+  mockup.compile();
+  auto executors = mockup.artifact->_executors;
+
+  auto input1 = IOIndex{0};
+  auto input2 = IOIndex{1};
+  auto output = IOIndex{0};
+
+  onert::ir::Shape new_shape{2, 2, 2, 1};
+  const float input1_buffer[8] = {1, 0, -1, -2, 1, 2, 0, -1};
+  const float input2_buffer[8] = {1, -3, 2, -4, 4, -2, 3, 1};
+  // result1 = {2, -3, 1, -6, 5, 0, 3, 0}
+  // result2 = {5, -2, 0, -1, 8, 1, 2, 5}
+  const float output_expected[8] = {7, -5, 1, -7, 13, 1, 5, 5};
+
+  onert::exec::Execution execution{executors};
+  execution.changeInputShape(input1, new_shape);
+  execution.changeInputShape(input2, new_shape);
+
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 32);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 32);
+  execution.execute();
+  float *output_buffer = reinterpret_cast<float *>(execution.getOutputBuffer(output));
+
+  EXPECT_EQ(execution.getOutputShape(output), new_shape);
+  for (auto i = 0; i < 8; i++)
+  {
+    EXPECT_EQ(output_buffer[i], output_expected[i]);
+  }
+}
+
 TEST(ExecInstance, multi_model_twoCompile)
 {
   auto mockup = MockUpMultiModel();

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -366,12 +366,14 @@ TEST(ExecInstance, neg_small_inoutsize)
 
   onert::exec::Execution execution{executors};
 
-  execution.setInput(input1, new_shape, reinterpret_cast<const void *>(input1_buffer), 8);
-  execution.setInput(input2, new_shape, reinterpret_cast<const void *>(input2_buffer), 2);
+  execution.changeInputShape(input1, new_shape);
+  execution.changeInputShape(input2, new_shape);
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 8);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 2);
   EXPECT_THROW(execution.execute(), std::exception);
 
   // Not throw exception because input shape is changed and output buffer is enough
-  execution.setInput(input2, new_shape, reinterpret_cast<const void *>(input2_buffer), 8);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 8);
   execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 16);
   execution.execute();
 
@@ -762,12 +764,9 @@ TEST(ExecInstance, multi_model_dequant_input_quant_output)
   auto executors = mockup.artifact->_executors;
 
   onert::exec::Execution execution{executors};
-  execution.setInput(input1, execution.getInputShape(input1),
-                     reinterpret_cast<const void *>(input1_buffer), 4);
-  execution.setInput(input2, execution.getInputShape(input2),
-                     reinterpret_cast<const void *>(input2_buffer), 4);
-  execution.setOutput(output, execution.getOutputShape(output),
-                      reinterpret_cast<void *>(output_buffer), 4);
+  execution.setInput(input1, reinterpret_cast<const void *>(input1_buffer), 4);
+  execution.setInput(input2, reinterpret_cast<const void *>(input2_buffer), 4);
+  execution.setOutput(output, reinterpret_cast<void *>(output_buffer), 4);
   execution.execute();
 
   for (auto i = 0; i < 4; i++)

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -192,12 +192,11 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
       find_input_index(_model_edges->pkg_inputs, model_index, subg_index, io_index);
     if (input_pkg_index == -1)
       throw std::runtime_error{"Cannot find multi model input index"};
-    auto input_desc = desc.inputs[input_pkg_index].get();
+    auto &input_desc = desc.inputs[input_pkg_index];
     // TODO Remove const_cast (we need const_cast as ITensor is writable)
     _pkg_input_tensors[pkg_input] = std::make_unique<backend::builtin::UserTensor>(
-      input_desc->info,
-      const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(input_desc->buffer)),
-      input_desc->size);
+      input_desc.info, const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(input_desc.buffer)),
+      input_desc.size);
   }
 
   for (const auto &pkg_output : _model_edges->pkg_outputs)
@@ -208,13 +207,13 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
       find_output_index(_model_edges->pkg_outputs, model_index, subg_index, io_index);
     if (output_pkg_index == -1)
       throw std::runtime_error{"Cannot find multi model output index"};
-    auto output_desc = desc.outputs[output_pkg_index].get();
+    auto &output_desc = desc.outputs[output_pkg_index];
     _pkg_output_tensors[pkg_output] = std::make_unique<backend::builtin::UserTensor>(
-      output_desc->info, reinterpret_cast<uint8_t *>(output_desc->buffer), output_desc->size);
+      output_desc.info, reinterpret_cast<uint8_t *>(output_desc.buffer), output_desc.size);
   }
 }
 
-void MultiModelExecutors::execute(const ExecutionContext &ctx)
+void MultiModelExecutors::execute(ExecutionContext &ctx)
 {
   // TODO: Enable to skip setting user tensor into IOTensor
   for (uint32_t i = 0; i < _model_edges->pkg_outputs.size(); ++i)

--- a/runtime/onert/core/src/exec/MultiModelExecutors.cc
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.cc
@@ -207,7 +207,20 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
       find_output_index(_model_edges->pkg_outputs, model_index, subg_index, io_index);
     if (output_pkg_index == -1)
       throw std::runtime_error{"Cannot find multi model output index"};
+
+    const auto output_io_tensor = dynamic_cast<const backend::builtin::IOTensor *>(
+      at(model_index, subg_index)->outputTensor(io_index.value()));
+    if (!output_io_tensor)
+      throw std::runtime_error{"Output tensor must be IOTensor"};
+    bool skip_set_output = output_io_tensor->hasBackendTensor();
     auto &output_desc = desc.outputs[output_pkg_index];
+    // If buffer is nullptr, output is optional or internally allocated buffer,
+    // and optional output's size is 0
+    if (output_desc.buffer == nullptr &&
+        (output_desc.size != 0 || output_desc.info.total_size() != 0) && !skip_set_output)
+      throw std::runtime_error{"Output " + std::to_string(output_pkg_index) +
+                               "'s buffer is not set."};
+
     _pkg_output_tensors[pkg_output] = std::make_unique<backend::builtin::UserTensor>(
       output_desc.info, reinterpret_cast<uint8_t *>(output_desc.buffer), output_desc.size);
   }
@@ -215,18 +228,6 @@ void MultiModelExecutors::CreatePkgIOTensors(const IODescription &desc)
 
 void MultiModelExecutors::execute(ExecutionContext &ctx)
 {
-  // TODO: Enable to skip setting user tensor into IOTensor
-  for (uint32_t i = 0; i < _model_edges->pkg_outputs.size(); ++i)
-  {
-    const auto output_io_tensor =
-      dynamic_cast<const backend::builtin::IOTensor *>(outputTensor(ir::IOIndex{i}));
-    if (!output_io_tensor)
-      throw std::runtime_error{"Output tensor must be IOTensor"};
-    if (output_io_tensor->hasBackendTensor())
-      throw std::runtime_error(
-        "MultiModelExecutors does not support allocating output tensors internally");
-  }
-
   auto &desc = ctx.desc;
 
   // Check supported multi model package
@@ -328,6 +329,23 @@ void MultiModelExecutors::execute(ExecutionContext &ctx)
         // Decrease reference count of `from` tensor if input tensor is the `from` tensor
         const auto from_iodesc = find_from(model_index, ir::SubgraphIndex{0}, ir::IOIndex{i});
         _edge_tensors[from_iodesc]->decrease_ref();
+      }
+    }
+
+    // Get dynamic shape inference result
+    for (uint32_t i = 0; i < output_size; i++)
+    {
+      const auto output_pkg_index = find_output_index(_model_edges->pkg_outputs, model_index,
+                                                      ir::SubgraphIndex{0}, ir::IOIndex{i});
+
+      if (output_pkg_index != -1)
+      {
+        const auto output_io_tensor =
+          dynamic_cast<const backend::builtin::IOTensor *>(outputTensor(ir::IOIndex{i}));
+        if (!output_io_tensor)
+          throw std::runtime_error{"Output tensor must be IOTensor"};
+
+        ctx.desc.outputs[output_pkg_index].info.shape(output_io_tensor->get_info().shape());
       }
     }
   }

--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -80,7 +80,7 @@ public:
 
   const backend::IPortableTensor *outputTensor(const ir::IOIndex &index) const final;
 
-  void execute(const ExecutionContext &ctx) override;
+  void execute(ExecutionContext &ctx) override;
 
 private:
   void checkSupportedMultimodel() const;

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -60,7 +60,7 @@ const backend::IPortableTensor *SingleModelExecutors::outputTensor(const ir::IOI
   return entryExecutor()->outputTensor(index.value());
 }
 
-void SingleModelExecutors::execute(const ExecutionContext &ctx)
+void SingleModelExecutors::execute(ExecutionContext &ctx)
 {
   // UserTensor for Input/Output
   std::vector<std::unique_ptr<backend::builtin::UserTensor>> tensorpool;
@@ -75,11 +75,11 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
     auto &desc = ctx.desc.inputs[i];
 
     // Input is optional if buffer is nullptr, and optional input's size is 0
-    if (desc->buffer == nullptr && (desc->size != 0 || desc->info.total_size() != 0))
+    if (desc.buffer == nullptr && (desc.size != 0 || desc.info.total_size() != 0))
       throw std::runtime_error{"Input " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)), desc->size));
+      desc.info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc.buffer)), desc.size));
 
     inputs[i] = tensorpool.back().get();
   }
@@ -95,12 +95,12 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
     bool skip_set_output = output_io_tensor->hasBackendTensor();
 
     // Output is optional if buffer is nullptr, and optional output's size is 0
-    if (desc->buffer == nullptr && (desc->size != 0 || desc->info.total_size() != 0) &&
+    if (desc.buffer == nullptr && (desc.size != 0 || desc.info.total_size() != 0) &&
         !skip_set_output)
       throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, static_cast<uint8_t *>(desc->buffer), desc->size));
+      desc.info, static_cast<uint8_t *>(desc.buffer), desc.size));
     outputs[i] = tensorpool.back().get();
   }
 
@@ -110,13 +110,13 @@ void SingleModelExecutors::execute(const ExecutionContext &ctx)
   // Get dynamic shape inference result
   for (uint32_t i = 0; i < outputs.size(); i++)
   {
-    if (ctx.desc.outputs[i]->buffer == nullptr)
+    if (ctx.desc.outputs[i].buffer == nullptr)
     {
       // Output is optional if buffer is nullptr
       continue;
     }
 
-    ctx.desc.outputs[i]->info.shape(outputs[i]->getShape());
+    ctx.desc.outputs[i].info.shape(outputs[i]->getShape());
   }
 }
 

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -94,7 +94,8 @@ void SingleModelExecutors::execute(ExecutionContext &ctx)
       throw std::runtime_error{"Output tensor must be IOTensor"};
     bool skip_set_output = output_io_tensor->hasBackendTensor();
 
-    // Output is optional if buffer is nullptr, and optional output's size is 0
+    // If buffer is nullptr, output is optional or internally allocated buffer,
+    // and optional output's size is 0
     if (desc.buffer == nullptr && (desc.size != 0 || desc.info.total_size() != 0) &&
         !skip_set_output)
       throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
@@ -110,13 +111,15 @@ void SingleModelExecutors::execute(ExecutionContext &ctx)
   // Get dynamic shape inference result
   for (uint32_t i = 0; i < outputs.size(); i++)
   {
-    if (ctx.desc.outputs[i].buffer == nullptr)
-    {
-      // Output is optional if buffer is nullptr
-      continue;
-    }
+    const auto output_io_tensor =
+      dynamic_cast<const backend::builtin::IOTensor *>(outputTensor(ir::IOIndex{i}));
+    if (!output_io_tensor)
+      throw std::runtime_error{"Output tensor must be IOTensor"};
 
-    ctx.desc.outputs[i].info.shape(outputs[i]->getShape());
+    // if (output_io_tensor->hasBackendTensor())
+    ctx.desc.outputs[i].info.shape(output_io_tensor->get_info().shape());
+    // else
+    // ctx.desc.outputs[i].info.shape(outputs[i]->getShape());
   }
 }
 

--- a/runtime/onert/core/src/exec/SingleModelExecutors.h
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.h
@@ -60,7 +60,7 @@ public:
 
   const backend::IPortableTensor *outputTensor(const ir::IOIndex &index) const final;
 
-  void execute(const ExecutionContext &ctx) override;
+  void execute(ExecutionContext &ctx) override;
 
 private:
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>> _executors;

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -61,7 +61,7 @@ const backend::IPortableTensor *TrainableExecutors::outputTensor(const ir::IOInd
   return entryExecutor()->outputTensor(index.value());
 }
 
-void TrainableExecutors::execute(const ExecutionContext &ctx)
+void TrainableExecutors::execute(ExecutionContext &ctx)
 {
   if (_executors.size() > 1)
     throw std::runtime_error("TrainableExecutors does not support multiple executors yet");
@@ -104,11 +104,11 @@ void TrainableExecutors::forward(
     auto &desc = ctx.desc.inputs[i];
 
     // Input is optional if buffer is nullptr, and optional input's size is 0
-    if (desc->buffer == nullptr && (desc->size != 0 || desc->info.total_size() != 0))
+    if (desc.buffer == nullptr && (desc.size != 0 || desc.info.total_size() != 0))
       throw std::runtime_error{"Input " + std::to_string(i) + "'s buffer is not set."};
 
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc->buffer)), desc->size));
+      desc.info, const_cast<uint8_t *>(static_cast<const uint8_t *>(desc.buffer)), desc.size));
     inputs[i] = tensorpool.back().get();
   }
 
@@ -120,7 +120,7 @@ void TrainableExecutors::forward(
     // If training, output buffer may not be used
     // So don't check optional
     tensorpool.emplace_back(std::make_unique<backend::builtin::UserTensor>(
-      desc->info, static_cast<uint8_t *>(desc->buffer), desc->size));
+      desc.info, static_cast<uint8_t *>(desc.buffer), desc.size));
     outputs[i] = tensorpool.back().get();
   }
 

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.h
@@ -67,7 +67,7 @@ public:
 
   const backend::IPortableTensor *outputTensor(const ir::IOIndex &index) const final;
 
-  void execute(const ExecutionContext &ctx) override;
+  void execute(ExecutionContext &ctx) override;
 
   /**
    * @brief Train


### PR DESCRIPTION
- Clean up execution API
- Handle shape inference result for output tensor
- Handle shape inference result for output tensor with internal output allocation