### PR TITLE
[infra] Update Protobuf to 3.21.12

### DIFF
--- a/infra/cmake/packages/ProtobufConfig.cmake
+++ b/infra/cmake/packages/ProtobufConfig.cmake
@@ -24,7 +24,7 @@ endfunction(_Protobuf_module_import)
 function(_Protobuf_import)
   # Let's use find_package here not to export unnecessary definitions
   # NOTE Here we use "exact" match to avoid possible infinite loop
-  find_package(protobuf EXACT 3.20.2.0 QUIET)
+  find_package(protobuf EXACT 3.21.12.0 QUIET)
 
   if(NOT protobuf_FOUND)
     set(Protobuf_FOUND FALSE PARENT_SCOPE)
@@ -65,7 +65,7 @@ function(_Protobuf_build)
                       INSTALL_DIR ${EXT_OVERLAY_DIR}
                       BUILD_FLAGS -fPIC
                       EXTRA_OPTS  -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_WITH_ZLIB=OFF
-                      IDENTIFIER  "3.20.2.0"
+                      IDENTIFIER  "3.21.12.0"
                       PKG_NAME    "PROTOBUF")
 
 endfunction(_Protobuf_build)

--- a/infra/cmake/packages/ProtobufSourceConfig.cmake
+++ b/infra/cmake/packages/ProtobufSourceConfig.cmake
@@ -8,7 +8,7 @@ function(_ProtobufSource_import)
   nnas_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
-  envoption(PROTOBUF_URL ${EXTERNAL_DOWNLOAD_SERVER}/protocolbuffers/protobuf/archive/v3.20.2.tar.gz)
+  envoption(PROTOBUF_URL ${EXTERNAL_DOWNLOAD_SERVER}/protocolbuffers/protobuf/archive/v3.21.12.tar.gz)
 
   ExternalSource_Download(PROTOBUF ${PROTOBUF_URL})
 


### PR DESCRIPTION
This commit updates the Protobuf library to a newer version due to the fixes this version contains.

In particular this version contains a fix for a linker error: 
```/usr/bin/ld: libtriv2_lib_manifest.a(Manifest.pb.cc.o): in function google::protobuf::MessageLite::~MessageLite()': /__w/NPU_Compiler/NPU_Compiler/build/overlay/include/google/protobuf/message_lite.h:171: undefined reference to google::protobuf::internal::InternalMetadata::~InternalMetadata()'```

ONE-DCO-1.0-Signed-off-by: Tomasz Dołbniak <t.dolbniak@partner.samsung.com>