### PR TITLE
[res] Recipe added to test fusing Mul with RmsNorm

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_RmsNorm_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_RmsNorm_001/test.recipe
@@ -1,0 +1,149 @@
+operand {
+  name: "Input"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 4
+  }
+}
+operand {
+  name: "RmsNorm/Mul/Square"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 4
+  }
+}
+operand {
+  name: "RmsNorm/Mean/Axis"
+  type: INT32
+  shape {
+  }
+  filler {
+    tag: "explicit"
+    arg: "-1"
+  }
+}
+operand {
+  name: "RmsNorm/Mean/MeanSquare"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1
+  }
+}
+operand {
+  name: "RmsNorm/Add/Epsilon"
+  type: FLOAT32
+  shape {
+  }
+  filler {
+    tag: "explicit"
+    arg: "1e-06"
+  }
+}
+operand {
+  name: "RmsNorm/Add/MeanSquare_plus_eps"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1
+  }
+}
+operand {
+  name: "RmsNorm/Sqrt/RMS"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 1
+  }
+}
+operand {
+  name: "RmsNorm/Mul/RmsNorm"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 4
+  }
+}
+operand {
+  name: "RmsNorm/Mul/Weight"
+  type: FLOAT32
+  shape {
+    dim: 4
+  }
+  filler {
+    tag: "explicit"
+    arg: "1.125"
+    arg: "1.25"
+    arg: "1.375"
+    arg: "0.875"
+  }
+}
+operand {
+  name: "RmsNorm/Mul/RmsNorm_with_weight"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 4
+  }
+}
+operation {
+  type: "Mul"
+  input: "Input"
+  input: "Input"
+  output: "RmsNorm/Mul/Square"
+  mul_options {
+    activation: NONE
+  }
+}
+operation {
+  type: "Mean"
+  input: "RmsNorm/Mul/Square"
+  input: "RmsNorm/Mean/Axis"
+  output: "RmsNorm/Mean/MeanSquare"
+  mean_options {
+    keep_dims: true
+  }
+}
+operation {
+  type: "Add"
+  input: "RmsNorm/Mean/MeanSquare"
+  input: "RmsNorm/Add/Epsilon"
+  output: "RmsNorm/Add/MeanSquare_plus_eps"
+  add_options {
+    activation: NONE
+  }
+}
+operation {
+  type: "Rsqrt"
+  input: "RmsNorm/Add/MeanSquare_plus_eps"
+  output: "RmsNorm/Sqrt/RMS"
+}
+operation {
+  type: "Mul"
+  input: "Input"
+  input: "RmsNorm/Sqrt/RMS"
+  output: "RmsNorm/Mul/RmsNorm"
+  mul_options {
+    activation: NONE
+  }
+}
+operation {
+  type: "Mul"
+  input: "RmsNorm/Mul/RmsNorm"
+  input: "RmsNorm/Mul/Weight"
+  output: "RmsNorm/Mul/RmsNorm_with_weight"
+  mul_options {
+    activation: NONE
+  }
+}
+input: "Input"
+output: "RmsNorm/Mul/RmsNorm_with_weight"

--- a/res/TensorFlowLiteRecipes/Net_RmsNorm_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_RmsNorm_001/test.rule
@@ -1,0 +1,7 @@
+# To check if this network is converted to circle RmsNorm op
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "RMS_NORM_EXIST"          $(op_count RMS_NORM) '=' 1
+RULE    "NO_ADD"                  $(op_count ADD) '=' 0
+RULE    "NO_MUL"                  $(op_count MUL) '=' 0


### PR DESCRIPTION
This commit adds recipe to test fusing Mul with preceding RmsNorm.

ONE-DCO-1.0-Signed-off-by: Seockho Kim seockho.kim@samsung.com

issue: https://github.com/Samsung/ONE/issues/15891
draft: https://github.com/Samsung/ONE/pull/15930