### PR TITLE
[onert] Access execution I/O size and buffer

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -915,12 +915,12 @@ NNFW_STATUS nnfw_session::get_output(uint32_t index, nnfw_tensorinfo *ti, const 
     }
 
     auto io_index = onert::ir::IOIndex{index};
-    const auto &info = _compiler_artifact->_executors->outputInfo(io_index);
+    const auto &info = _execution->outputInfo(index);
     const auto &shape = info.shape();
     const auto &dtype = info.typeInfo().type();
     fillTensorInfo(ti, shape, dtype);
 
-    *out_buffer = _compiler_artifact->_executors->outputBuffer(io_index);
+    *out_buffer = _execution->outputBuffer(io_index);
   }
   catch (const std::exception &e)
   {
@@ -1050,7 +1050,7 @@ uint32_t nnfw_session::getInputSize()
     return _nnpkg->inputSize();
 
   // Session is prepared (general inference)
-  return _compiler_artifact->_executors->inputSize();
+  return _execution->inputSize();
 }
 
 uint32_t nnfw_session::getOutputSize()
@@ -1062,7 +1062,7 @@ uint32_t nnfw_session::getOutputSize()
     return _nnpkg->outputSize();
 
   // Session is prepared (general inference)
-  return _compiler_artifact->_executors->outputSize();
+  return _execution->outputSize();
 }
 
 NNFW_STATUS nnfw_session::loadModelFile(const std::string &model_file_path,
@@ -2275,8 +2275,8 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         _quant_manager->exportModelPath().substr(dotidx + 1); // + 1 to exclude dot
 
       // Save initial (float) input and output buffers
-      auto input_size = _compiler_artifact->_executors->inputSize();
-      auto output_size = _compiler_artifact->_executors->outputSize();
+      auto input_size = _execution->inputSize();
+      auto output_size = _execution->outputSize();
 
       std::vector<const void *> _input_buffers;
       std::vector<void *> _output_buffers;

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -92,6 +92,28 @@ public:
   const ir::OperandInfo &outputInfo(uint32_t index) { return _ctx.desc.outputs.at(index).info; }
 
   /**
+   * @brief     Get internally allocated output buffer
+   * @param[in] index Output index
+   * @return    Buffer pointer
+   */
+  const void *outputBuffer(const ir::IOIndex &index) const
+  {
+    return entryExecutor()->outputBuffer(index.value());
+  }
+
+  /**
+   * @brief   Get input size
+   * @return  Input size
+   */
+  uint32_t inputSize() { return _ctx.desc.inputs.size(); }
+
+  /**
+   * @brief   Get output size
+   * @return  Output size
+   */
+  uint32_t outputSize() { return _ctx.desc.outputs.size(); }
+
+  /**
    * @brief  Execution
    * @note   It should be called after setting input and output buffer
    */


### PR DESCRIPTION
This commit adds methods to access execution I/O size and output buffer. 
It removes access executors directly in nnfw session implementation except Execution constructor.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15929