### PR TITLE
[onert] Introduce signature run API

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -210,12 +210,12 @@ NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYP
  *
  * {@link nnfw_prepare} will prepare all entries if this function is never called or
  * called for some part of entries. So user can select signature on {@link nnfw_set_signature_run}
- * which does not used by this function.
+ * which is not used by this function.
  *
  * If this function is not called, default entry (ex. 0th subgraph in circle/tflite model)
  * will be selected.
  *
- * @note TODO: Support selected signature entry's I/O tensorinfo setting
+ * @note TODO: Support selected entry signature's I/O tensorinfo setting
  *
  * @param[in] session   session to set the entry signature
  * @param[in] signature name of the entry signature


### PR DESCRIPTION
This commit introduces APIs to select signature to run or to prepare.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/15929
Related issue: https://github.com/Samsung/ONE/issues/15369