### PR TITLE
[onert] Support builtin RUN_MODEL operator

### DIFF
--- a/runtime/libs/circle-schema/include/circle_schema_generated.h
+++ b/runtime/libs/circle-schema/include/circle_schema_generated.h
@@ -679,6 +679,10 @@ struct RoPEOptions;
 struct RoPEOptionsBuilder;
 struct RoPEOptionsT;
 
+struct RunModelOptions;
+struct RunModelOptionsBuilder;
+struct RunModelOptionsT;
+
 struct OperatorCode;
 struct OperatorCodeBuilder;
 struct OperatorCodeT;
@@ -1135,6 +1139,7 @@ inline const char *EnumNameCompressionType(CompressionType e)
 
 enum BuiltinOperator : int32_t
 {
+  BuiltinOperator_RUN_MODEL = -8,
   BuiltinOperator_ROPE = -7,
   BuiltinOperator_RMS_NORM = -6,
   BuiltinOperator_GRU = -5,
@@ -1347,13 +1352,14 @@ enum BuiltinOperator : int32_t
   BuiltinOperator_DILATE = 203,
   BuiltinOperator_STABLEHLO_RNG_BIT_GENERATOR = 204,
   BuiltinOperator_REDUCE_WINDOW = 205,
-  BuiltinOperator_MIN = BuiltinOperator_ROPE,
+  BuiltinOperator_MIN = BuiltinOperator_RUN_MODEL,
   BuiltinOperator_MAX = BuiltinOperator_REDUCE_WINDOW
 };
 
-inline const BuiltinOperator (&EnumValuesBuiltinOperator())[212]
+inline const BuiltinOperator (&EnumValuesBuiltinOperator())[213]
 {
-  static const BuiltinOperator values[] = {BuiltinOperator_ROPE,
+  static const BuiltinOperator values[] = {BuiltinOperator_RUN_MODEL,
+                                           BuiltinOperator_ROPE,
                                            BuiltinOperator_RMS_NORM,
                                            BuiltinOperator_GRU,
                                            BuiltinOperator_BCQ_GATHER,
@@ -1570,7 +1576,8 @@ inline const BuiltinOperator (&EnumValuesBuiltinOperator())[212]
 
 inline const char *const *EnumNamesBuiltinOperator()
 {
-  static const char *const names[214] = {"ROPE",
+  static const char *const names[215] = {"RUN_MODEL",
+                                         "ROPE",
                                          "RMS_NORM",
                                          "GRU",
                                          "BCQ_GATHER",
@@ -1789,9 +1796,9 @@ inline const char *const *EnumNamesBuiltinOperator()
 
 inline const char *EnumNameBuiltinOperator(BuiltinOperator e)
 {
-  if (::flatbuffers::IsOutRange(e, BuiltinOperator_ROPE, BuiltinOperator_REDUCE_WINDOW))
+  if (::flatbuffers::IsOutRange(e, BuiltinOperator_RUN_MODEL, BuiltinOperator_REDUCE_WINDOW))
     return "";
-  const size_t index = static_cast<size_t>(e) - static_cast<size_t>(BuiltinOperator_ROPE);
+  const size_t index = static_cast<size_t>(e) - static_cast<size_t>(BuiltinOperator_RUN_MODEL);
   return EnumNamesBuiltinOperator()[index];
 }
 
@@ -1924,6 +1931,7 @@ enum BuiltinOptions : uint8_t
   BuiltinOptions_BitcastOptions = 124,
   BuiltinOptions_BitwiseXorOptions = 125,
   BuiltinOptions_RightShiftOptions = 126,
+  BuiltinOptions_RunModelOptions = 248,
   BuiltinOptions_RoPEOptions = 249,
   BuiltinOptions_RmsNormOptions = 250,
   BuiltinOptions_GRUOptions = 251,
@@ -1934,7 +1942,7 @@ enum BuiltinOptions : uint8_t
   BuiltinOptions_MAX = BuiltinOptions_InstanceNormOptions
 };
 
-inline const BuiltinOptions (&EnumValuesBuiltinOptions())[133]
+inline const BuiltinOptions (&EnumValuesBuiltinOptions())[134]
 {
   static const BuiltinOptions values[] = {BuiltinOptions_NONE,
                                           BuiltinOptions_Conv2DOptions,
@@ -2063,6 +2071,7 @@ inline const BuiltinOptions (&EnumValuesBuiltinOptions())[133]
                                           BuiltinOptions_BitcastOptions,
                                           BuiltinOptions_BitwiseXorOptions,
                                           BuiltinOptions_RightShiftOptions,
+                                          BuiltinOptions_RunModelOptions,
                                           BuiltinOptions_RoPEOptions,
                                           BuiltinOptions_RmsNormOptions,
                                           BuiltinOptions_GRUOptions,
@@ -2322,7 +2331,7 @@ inline const char *const *EnumNamesBuiltinOptions()
                                          "",
                                          "",
                                          "",
-                                         "",
+                                         "RunModelOptions",
                                          "RoPEOptions",
                                          "RmsNormOptions",
                                          "GRUOptions",
@@ -2974,6 +2983,11 @@ template <> struct BuiltinOptionsTraits<circle::BitwiseXorOptions>
 template <> struct BuiltinOptionsTraits<circle::RightShiftOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_RightShiftOptions;
+};
+
+template <> struct BuiltinOptionsTraits<circle::RunModelOptions>
+{
+  static const BuiltinOptions enum_value = BuiltinOptions_RunModelOptions;
 };
 
 template <> struct BuiltinOptionsTraits<circle::RoPEOptions>
@@ -3639,6 +3653,11 @@ template <> struct BuiltinOptionsUnionTraits<circle::BitwiseXorOptionsT>
 template <> struct BuiltinOptionsUnionTraits<circle::RightShiftOptionsT>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_RightShiftOptions;
+};
+
+template <> struct BuiltinOptionsUnionTraits<circle::RunModelOptionsT>
+{
+  static const BuiltinOptions enum_value = BuiltinOptions_RunModelOptions;
 };
 
 template <> struct BuiltinOptionsUnionTraits<circle::RoPEOptionsT>
@@ -5166,6 +5185,18 @@ struct BuiltinOptionsUnion
   {
     return type == BuiltinOptions_RightShiftOptions
              ? reinterpret_cast<const circle::RightShiftOptionsT *>(value)
+             : nullptr;
+  }
+  circle::RunModelOptionsT *AsRunModelOptions()
+  {
+    return type == BuiltinOptions_RunModelOptions
+             ? reinterpret_cast<circle::RunModelOptionsT *>(value)
+             : nullptr;
+  }
+  const circle::RunModelOptionsT *AsRunModelOptions() const
+  {
+    return type == BuiltinOptions_RunModelOptions
+             ? reinterpret_cast<const circle::RunModelOptionsT *>(value)
              : nullptr;
   }
   circle::RoPEOptionsT *AsRoPEOptions()
@@ -18096,6 +18127,93 @@ CreateRoPEOptions(::flatbuffers::FlatBufferBuilder &_fbb,
 CreateRoPEOptions(::flatbuffers::FlatBufferBuilder &_fbb, const RoPEOptionsT *_o,
                   const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
+struct RunModelOptionsT : public ::flatbuffers::NativeTable
+{
+  typedef RunModelOptions TableType;
+  std::string location{};
+  std::string signature{};
+};
+
+struct RunModelOptions FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table
+{
+  typedef RunModelOptionsT NativeTableType;
+  typedef RunModelOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
+  {
+    VT_LOCATION = 4,
+    VT_SIGNATURE = 6
+  };
+  const ::flatbuffers::String *location() const
+  {
+    return GetPointer<const ::flatbuffers::String *>(VT_LOCATION);
+  }
+  const ::flatbuffers::String *signature() const
+  {
+    return GetPointer<const ::flatbuffers::String *>(VT_SIGNATURE);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const
+  {
+    return VerifyTableStart(verifier) && VerifyOffset(verifier, VT_LOCATION) &&
+           verifier.VerifyString(location()) && VerifyOffset(verifier, VT_SIGNATURE) &&
+           verifier.VerifyString(signature()) && verifier.EndTable();
+  }
+  RunModelOptionsT *UnPack(const ::flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(RunModelOptionsT *_o,
+                const ::flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static ::flatbuffers::Offset<RunModelOptions>
+  Pack(::flatbuffers::FlatBufferBuilder &_fbb, const RunModelOptionsT *_o,
+       const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct RunModelOptionsBuilder
+{
+  typedef RunModelOptions Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_location(::flatbuffers::Offset<::flatbuffers::String> location)
+  {
+    fbb_.AddOffset(RunModelOptions::VT_LOCATION, location);
+  }
+  void add_signature(::flatbuffers::Offset<::flatbuffers::String> signature)
+  {
+    fbb_.AddOffset(RunModelOptions::VT_SIGNATURE, signature);
+  }
+  explicit RunModelOptionsBuilder(::flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
+  {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<RunModelOptions> Finish()
+  {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<RunModelOptions>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<RunModelOptions>
+CreateRunModelOptions(::flatbuffers::FlatBufferBuilder &_fbb,
+                      ::flatbuffers::Offset<::flatbuffers::String> location = 0,
+                      ::flatbuffers::Offset<::flatbuffers::String> signature = 0)
+{
+  RunModelOptionsBuilder builder_(_fbb);
+  builder_.add_signature(signature);
+  builder_.add_location(location);
+  return builder_.Finish();
+}
+
+inline ::flatbuffers::Offset<RunModelOptions>
+CreateRunModelOptionsDirect(::flatbuffers::FlatBufferBuilder &_fbb, const char *location = nullptr,
+                            const char *signature = nullptr)
+{
+  auto location__ = location ? _fbb.CreateString(location) : 0;
+  auto signature__ = signature ? _fbb.CreateString(signature) : 0;
+  return circle::CreateRunModelOptions(_fbb, location__, signature__);
+}
+
+::flatbuffers::Offset<RunModelOptions>
+CreateRunModelOptions(::flatbuffers::FlatBufferBuilder &_fbb, const RunModelOptionsT *_o,
+                      const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
 struct OperatorCodeT : public ::flatbuffers::NativeTable
 {
   typedef OperatorCode TableType;
@@ -19014,6 +19132,12 @@ struct Operator FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table
   {
     return builtin_options_type() == circle::BuiltinOptions_RightShiftOptions
              ? static_cast<const circle::RightShiftOptions *>(builtin_options())
+             : nullptr;
+  }
+  const circle::RunModelOptions *builtin_options_as_RunModelOptions() const
+  {
+    return builtin_options_type() == circle::BuiltinOptions_RunModelOptions
+             ? static_cast<const circle::RunModelOptions *>(builtin_options())
              : nullptr;
   }
   const circle::RoPEOptions *builtin_options_as_RoPEOptions() const
@@ -20049,6 +20173,12 @@ inline const circle::RightShiftOptions *
 Operator::builtin_options_as<circle::RightShiftOptions>() const
 {
   return builtin_options_as_RightShiftOptions();
+}
+
+template <>
+inline const circle::RunModelOptions *Operator::builtin_options_as<circle::RunModelOptions>() const
+{
+  return builtin_options_as_RunModelOptions();
 }
 
 template <>
@@ -29468,6 +29598,56 @@ CreateRoPEOptions(::flatbuffers::FlatBufferBuilder &_fbb, const RoPEOptionsT *_o
   return circle::CreateRoPEOptions(_fbb, _mode);
 }
 
+inline RunModelOptionsT *
+RunModelOptions::UnPack(const ::flatbuffers::resolver_function_t *_resolver) const
+{
+  auto _o = std::unique_ptr<RunModelOptionsT>(new RunModelOptionsT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
+}
+
+inline void RunModelOptions::UnPackTo(RunModelOptionsT *_o,
+                                      const ::flatbuffers::resolver_function_t *_resolver) const
+{
+  (void)_o;
+  (void)_resolver;
+  {
+    auto _e = location();
+    if (_e)
+      _o->location = _e->str();
+  }
+  {
+    auto _e = signature();
+    if (_e)
+      _o->signature = _e->str();
+  }
+}
+
+inline ::flatbuffers::Offset<RunModelOptions>
+RunModelOptions::Pack(::flatbuffers::FlatBufferBuilder &_fbb, const RunModelOptionsT *_o,
+                      const ::flatbuffers::rehasher_function_t *_rehasher)
+{
+  return CreateRunModelOptions(_fbb, _o, _rehasher);
+}
+
+inline ::flatbuffers::Offset<RunModelOptions>
+CreateRunModelOptions(::flatbuffers::FlatBufferBuilder &_fbb, const RunModelOptionsT *_o,
+                      const ::flatbuffers::rehasher_function_t *_rehasher)
+{
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs
+  {
+    ::flatbuffers::FlatBufferBuilder *__fbb;
+    const RunModelOptionsT *__o;
+    const ::flatbuffers::rehasher_function_t *__rehasher;
+  } _va = {&_fbb, _o, _rehasher};
+  (void)_va;
+  auto _location = _o->location.empty() ? 0 : _fbb.CreateString(_o->location);
+  auto _signature = _o->signature.empty() ? 0 : _fbb.CreateString(_o->signature);
+  return circle::CreateRunModelOptions(_fbb, _location, _signature);
+}
+
 inline OperatorCodeT *
 OperatorCode::UnPack(const ::flatbuffers::resolver_function_t *_resolver) const
 {
@@ -31328,6 +31508,11 @@ inline bool VerifyBuiltinOptions(::flatbuffers::Verifier &verifier, const void *
       auto ptr = reinterpret_cast<const circle::RightShiftOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
+    case BuiltinOptions_RunModelOptions:
+    {
+      auto ptr = reinterpret_cast<const circle::RunModelOptions *>(obj);
+      return verifier.VerifyTable(ptr);
+    }
     case BuiltinOptions_RoPEOptions:
     {
       auto ptr = reinterpret_cast<const circle::RoPEOptions *>(obj);
@@ -32018,6 +32203,11 @@ inline void *BuiltinOptionsUnion::UnPack(const void *obj, BuiltinOptions type,
       auto ptr = reinterpret_cast<const circle::RightShiftOptions *>(obj);
       return ptr->UnPack(resolver);
     }
+    case BuiltinOptions_RunModelOptions:
+    {
+      auto ptr = reinterpret_cast<const circle::RunModelOptions *>(obj);
+      return ptr->UnPack(resolver);
+    }
     case BuiltinOptions_RoPEOptions:
     {
       auto ptr = reinterpret_cast<const circle::RoPEOptions *>(obj);
@@ -32689,6 +32879,11 @@ BuiltinOptionsUnion::Pack(::flatbuffers::FlatBufferBuilder &_fbb,
     {
       auto ptr = reinterpret_cast<const circle::RightShiftOptionsT *>(value);
       return CreateRightShiftOptions(_fbb, ptr, _rehasher).Union();
+    }
+    case BuiltinOptions_RunModelOptions:
+    {
+      auto ptr = reinterpret_cast<const circle::RunModelOptionsT *>(value);
+      return CreateRunModelOptions(_fbb, ptr, _rehasher).Union();
     }
     case BuiltinOptions_RoPEOptions:
     {
@@ -33419,6 +33614,11 @@ inline BuiltinOptionsUnion::BuiltinOptionsUnion(const BuiltinOptionsUnion &u)
     {
       value =
         new circle::RightShiftOptionsT(*reinterpret_cast<circle::RightShiftOptionsT *>(u.value));
+      break;
+    }
+    case BuiltinOptions_RunModelOptions:
+    {
+      value = new circle::RunModelOptionsT(*reinterpret_cast<circle::RunModelOptionsT *>(u.value));
       break;
     }
     case BuiltinOptions_RoPEOptions:
@@ -34216,6 +34416,12 @@ inline void BuiltinOptionsUnion::Reset()
     case BuiltinOptions_RightShiftOptions:
     {
       auto ptr = reinterpret_cast<circle::RightShiftOptionsT *>(value);
+      delete ptr;
+      break;
+    }
+    case BuiltinOptions_RunModelOptions:
+    {
+      auto ptr = reinterpret_cast<circle::RunModelOptionsT *>(value);
       delete ptr;
       break;
     }


### PR DESCRIPTION
This commit supports builtin RUN_MODEL operator in CircleLoader. 
It includes removing RUN_MODEL custom OP support.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15704
Related issue: https://github.com/Samsung/ONE/issues/15676