### PR TITLE
[onert] Use IOIndex type for input/output indices

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -82,14 +82,20 @@ public:
    * @param[in] index Input index
    * @return    Input info
    */
-  const ir::OperandInfo &inputInfo(uint32_t index) { return _ctx.desc.inputs.at(index).info; }
+  const ir::OperandInfo &inputInfo(const ir::IOIndex &index)
+  {
+    return _ctx.desc.inputs.at(index.value()).info;
+  }
 
   /**
    * @brief     Get the Output Info object
    * @param[in] index Output index
    * @return    Output info
    */
-  const ir::OperandInfo &outputInfo(uint32_t index) { return _ctx.desc.outputs.at(index).info; }
+  const ir::OperandInfo &outputInfo(const ir::IOIndex &index)
+  {
+    return _ctx.desc.outputs.at(index.value()).info;
+  }
 
   /**
    * @brief     Get internally allocated output buffer

--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -138,14 +138,14 @@ public:
    * @param[in] index Index of pkg_input to be returned
    * @return IODesc at index
    */
-  const IODesc &input(uint32_t index) const { return _edges.pkg_inputs[index]; }
+  const IODesc &input(const ir::IOIndex &index) const { return _edges.pkg_inputs[index.value()]; }
   /**
    * @brief Get pkg_input at index
    *
    * @param[in] index Index of pkg_input to be returned
    * @return IODesc at index
    */
-  IODesc &input(uint32_t index) { return _edges.pkg_inputs[index]; }
+  IODesc &input(const ir::IOIndex &index) { return _edges.pkg_inputs[index.value()]; }
   /**
    * @brief Add input at the end
    *
@@ -159,14 +159,14 @@ public:
    * @param[in] index Index of pkg_output to be returned
    * @return IODesc at index
    */
-  const IODesc &output(uint32_t index) const { return _edges.pkg_outputs[index]; }
+  const IODesc &output(const ir::IOIndex &index) const { return _edges.pkg_outputs[index.value()]; }
   /**
    * @brief Get pkg_output at index
    *
    * @param[in] index Index of pkg_output to be returned
    * @return IODesc at index
    */
-  IODesc &output(uint32_t index) { return _edges.pkg_outputs[index]; }
+  IODesc &output(const ir::IOIndex &index) { return _edges.pkg_outputs[index.value()]; }
   /**
    * @brief Add output at the end
    *
@@ -243,7 +243,7 @@ public:
   /**
    * @brief   Get model input info
    */
-  const OperandInfo &inputInfo(uint32_t index) const
+  const OperandInfo &inputInfo(const ir::IOIndex &index) const
   {
     if (_models.size() == 1)
     {
@@ -261,7 +261,7 @@ public:
   /**
    * @brief   Get model output info
    */
-  const OperandInfo &outputInfo(uint32_t index) const
+  const OperandInfo &outputInfo(const ir::IOIndex &index) const
   {
     if (_models.size() == 1)
     {
@@ -276,7 +276,7 @@ public:
     return graph->operands().at(operand_index).info();
   }
 
-  void changeInputShape(uint32_t index, const ir::Shape &new_shape)
+  void changeInputShape(const ir::IOIndex &index, const ir::Shape &new_shape)
   {
     if (_models.size() == 1)
     {

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -57,20 +57,20 @@ CompilerOptions Compiler::optionForSingleModel(const ir::ModelIndex &model_index
                              auto io_desc_getter) {
     for (const auto &[index, val] : src_opt)
     {
-      const auto &io_desc = io_desc_getter(index.value());
+      const auto &io_desc = io_desc_getter(index);
       if (std::get<ir::ModelIndex>(io_desc) == model_index)
         dst_opt.insert_or_assign(std::get<ir::IOIndex>(io_desc), val);
     }
   };
 
   option_for_model(_options->input_layout, model_opts.input_layout, model_index,
-                   [this](uint32_t idx) { return _nnpkg->input(idx); });
+                   [this](const ir::IOIndex &idx) { return _nnpkg->input(idx); });
   option_for_model(_options->output_layout, model_opts.output_layout, model_index,
-                   [this](uint32_t idx) { return _nnpkg->output(idx); });
+                   [this](const ir::IOIndex &idx) { return _nnpkg->output(idx); });
   option_for_model(_options->input_type, model_opts.input_type, model_index,
-                   [this](uint32_t idx) { return _nnpkg->input(idx); });
+                   [this](const ir::IOIndex &idx) { return _nnpkg->input(idx); });
   option_for_model(_options->output_type, model_opts.output_type, model_index,
-                   [this](uint32_t idx) { return _nnpkg->output(idx); });
+                   [this](const ir::IOIndex &idx) { return _nnpkg->output(idx); });
 
   // Pass input type info for edges because edge's from_tensor info can be different
   // with its to_tensor info.

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -357,7 +357,7 @@ TEST(ExecInstance, shapeinf)
   execution.setOutput(output, output_buffer, sizeof(output_buffer));
   execution.execute();
 
-  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
+  EXPECT_EQ(execution.outputInfo(output).shape(), new_shape);
   for (auto i = 0; i < 8; i++)
   {
     EXPECT_EQ(output_buffer[i], output_expected[i]);
@@ -390,7 +390,7 @@ TEST(ExecInstance, internaloutput_shapeinf)
 
   const float *output_buffer = reinterpret_cast<const float *>(executors->outputBuffer(output));
   ASSERT_NE(output_buffer, nullptr);
-  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
+  EXPECT_EQ(execution.outputInfo(output).shape(), new_shape);
   for (auto i = 0; i < 8; i++)
   {
     EXPECT_EQ(output_buffer[i], output_expected[i]);
@@ -719,7 +719,7 @@ TEST(ExecInstance, multi_model_shapeinf)
   execution.setOutput(output, reinterpret_cast<void *>(output_buffer), sizeof(output_buffer));
   execution.execute();
 
-  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
+  EXPECT_EQ(execution.outputInfo(output).shape(), new_shape);
   for (auto i = 0; i < 8; i++)
   {
     EXPECT_EQ(output_buffer[i], output_expected[i]);
@@ -751,7 +751,7 @@ TEST(ExecInstance, multi_model_internaloutput_shapeinf)
   execution.execute();
   const float *output_buffer = reinterpret_cast<const float *>(executors->outputBuffer(output));
 
-  EXPECT_EQ(execution.outputInfo(0).shape(), new_shape);
+  EXPECT_EQ(execution.outputInfo(output).shape(), new_shape);
   for (auto i = 0; i < 8; i++)
   {
     EXPECT_EQ(output_buffer[i], output_expected[i]);

--- a/runtime/tests/nnapi/bridge/wrapper/ANeuralNetworksExecution.cc
+++ b/runtime/tests/nnapi/bridge/wrapper/ANeuralNetworksExecution.cc
@@ -163,7 +163,7 @@ bool ANeuralNetworksExecution::setOptionalInput(uint32_t index,
   {
     onert::ir::IOIndex input_index{index};
     const auto &shape =
-      (type != nullptr) ? NNAPIConvert::getShape(type) : _execution->inputInfo(index).shape();
+      (type != nullptr) ? NNAPIConvert::getShape(type) : _execution->inputInfo(input_index).shape();
 
     // ANeuralNetworksExecution::setInput() uses only shape information
     ANeuralNetworksOperandType optional_input_type;
@@ -255,7 +255,7 @@ bool ANeuralNetworksExecution::getOutputOperandRank(uint32_t index, uint32_t *ra
       return false;
     }
 
-    const auto shape = _execution->outputInfo(index).shape();
+    const auto shape = _execution->outputInfo(output_index).shape();
     if (shape.hasUnspecifiedDims())
     {
       throw std::runtime_error{"Internal error: Output tensor has unspecified dims"};
@@ -285,7 +285,7 @@ bool ANeuralNetworksExecution::getOutputOperandDimensions(uint32_t index, uint32
       return false;
     }
 
-    const auto shape = _execution->outputInfo(index).shape();
+    const auto shape = _execution->outputInfo(output_index).shape();
     if (shape.hasUnspecifiedDims())
     {
       throw std::runtime_error{"Internal error: Output tensor has unspecified dims"};


### PR DESCRIPTION
This commit replaces raw integer indices with IOIndex type when accessing input/output information in Execution and NNPkg classes.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/pull/15940#discussion_r2299568881