### PR TITLE
[onert] Introduce SignatureExecutors class

### DIFF
--- a/runtime/onert/core/include/exec/IExecutors.h
+++ b/runtime/onert/core/include/exec/IExecutors.h
@@ -55,7 +55,7 @@ public:
   virtual IExecutor *at(const ir::ModelIndex &model_index,
                         const ir::SubgraphIndex &subg_index) const = 0;
 
-  IExecutor *entryExecutor() const { return at(ir::ModelIndex{0}, ir::SubgraphIndex{0}); }
+  virtual IExecutor *entryExecutor() const { return at(ir::ModelIndex{0}, ir::SubgraphIndex{0}); }
 
   /**
    * @brief   Return executor set's number of input

--- a/runtime/onert/core/src/exec/SignatureExecutors.cc
+++ b/runtime/onert/core/src/exec/SignatureExecutors.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SignatureExecutors.h"
+
+namespace onert::exec
+{
+
+SignatureExecutors::SignatureExecutors(const std::shared_ptr<IExecutors> &executors,
+                                       const ir::SubgraphIndex &entry_index)
+  : _executors(executors), _entry_index(entry_index)
+{
+  // Check single model
+  // TODO Support multimodel
+  assert(dynamic_cast<SingleModelExecutors *>(executors.get()) != nullptr);
+}
+
+IExecutor *SignatureExecutors::entryExecutor() const
+{
+  return _executors->at(ir::ModelIndex{0}, _entry_index);
+}
+
+} // namespace onert::exec

--- a/runtime/onert/core/src/exec/SignatureExecutors.h
+++ b/runtime/onert/core/src/exec/SignatureExecutors.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXEC_SIGNATURE_EXECUTORS_H__
+#define __ONERT_EXEC_SIGNATURE_EXECUTORS_H__
+
+#include "exec/IExecutors.h"
+#include "ir/NNPkg.h"
+
+#include "SingleModelExecutors.h"
+
+namespace onert::exec
+{
+
+/**
+ * @brief Class to gather executor set for signature entry
+ *        Actually it is wrapper of IExecutors(SignatureExecutors)
+ */
+class SignatureExecutors : public SingleModelExecutors
+{
+public:
+  /**
+   * @brief Construct a new SignatureExecutors object
+   */
+  SignatureExecutors(void) = default;
+  SignatureExecutors(const SignatureExecutors &) = delete;
+  SignatureExecutors(SignatureExecutors &&) = default;
+
+  /**
+   * @brief Destroy the SignatureExecutors object
+   */
+  ~SignatureExecutors() = default;
+
+  /**
+   * @brief     Convert IExecutors to SignatureExecutors
+   * @param[in] executors Executors object to convert
+   * @param[in] index     subgraph index of the signature
+   */
+  SignatureExecutors(const std::shared_ptr<IExecutors> &executors,
+                     const ir::SubgraphIndex &entry_index);
+
+public:
+  IExecutor *entryExecutor() const override;
+
+private:
+  const std::shared_ptr<IExecutors> _executors;
+  ir::SubgraphIndex _entry_index;
+};
+
+} // namespace onert::exec
+
+#endif // __ONERT_EXEC_SIGNATURE_EXECUTORS_H__

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.h
@@ -53,7 +53,10 @@ public:
   TrainableExecutor *at(const ir::ModelIndex &model_index,
                         const ir::SubgraphIndex &subg_index) const override;
 
-  TrainableExecutor *entryExecutor() const { return at(ir::ModelIndex{0}, ir::SubgraphIndex{0}); }
+  TrainableExecutor *entryExecutor() const override
+  {
+    return at(ir::ModelIndex{0}, ir::SubgraphIndex{0});
+  }
 
   uint32_t inputSize() const override;
 


### PR DESCRIPTION
- Introduce SignatureExecutors class to start from a specified subgraph index instead of default (0)
- Make IExecutors::entryExecutor() virtual to allow overriding

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #15929
Related issue: #15369 