### PR TITLE
[onert] Add signature setting API to nnfw_session

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -245,6 +245,18 @@ NNFW_STATUS nnfw_set_workspace(nnfw_session *session, const char *dir)
   return session->set_workspace(dir);
 }
 
+NNFW_STATUS nnfw_set_signature_for_tensorinfo(nnfw_session *session, const char *signature)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_signature_for_tensorinfo(signature);
+}
+
+NNFW_STATUS nnfw_set_signature_run(nnfw_session *session, const char *signature)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_signature_run(signature);
+}
+
 // Training
 
 NNFW_STATUS nnfw_train_get_traininfo(nnfw_session *session, nnfw_train_info *info)

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -973,6 +973,37 @@ NNFW_STATUS nnfw_session::set_workspace(const char *dir)
   return NNFW_STATUS_NO_ERROR;
 }
 
+NNFW_STATUS nnfw_session::set_signature_for_tensorinfo(const char *signature)
+{
+  if (!signature)
+    return NNFW_STATUS_UNEXPECTED_NULL;
+
+  if (!isStateModelLoaded())
+  {
+    std::cerr << "Error during nnfw_session::set_signature_for_tensorinfo : invalid state"
+              << std::endl;
+    return NNFW_STATUS_INVALID_STATE;
+  }
+
+  std::cerr << "Error during nnfw_session::set_signature_for_tensorinfo : NYI" << std::endl;
+  return NNFW_STATUS_ERROR;
+}
+
+NNFW_STATUS nnfw_session::set_signature_run(const char *signature)
+{
+  if (!signature)
+    return NNFW_STATUS_UNEXPECTED_NULL;
+
+  if (!isStatePreparedOrFinishedRun())
+  {
+    std::cerr << "Error during nnfw_session::set_signature_run : invalid state" << std::endl;
+    return NNFW_STATUS_INVALID_STATE;
+  }
+
+  std::cerr << "Error during nnfw_session::set_signature_run : NYI" << std::endl;
+  return NNFW_STATUS_ERROR;
+}
+
 NNFW_STATUS nnfw_session::deprecated(const char *msg)
 {
   std::cerr << msg << std::endl;

--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -132,6 +132,9 @@ public:
 
   NNFW_STATUS set_workspace(const char *dir);
 
+  NNFW_STATUS set_signature_for_tensorinfo(const char *signature);
+  NNFW_STATUS set_signature_run(const char *signature);
+
   static NNFW_STATUS deprecated(const char *msg);
 
   //


### PR DESCRIPTION
This commit adds signature setting API skeleton in nnfw_session and uses it in API implementation. 
The functions include parameter validation and state checking, but return NYI errors as the implementation is not complete yet.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/15929
Related issue: https://github.com/Samsung/ONE/issues/15369