### PR TITLE
[onert] Implement signature-based execution support

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -242,7 +242,8 @@ nnfw_session::nnfw_session()
   : _nnpkg{nullptr}, _coptions{onert::compiler::CompilerOptions::fromGlobalConfig()},
     _compiler_artifact{nullptr}, _execution{nullptr}, _kernel_registry{nullptr},
     _train_info{nullptr}, _quant_manager{std::make_unique<onert::odc::QuantizeManager>()},
-    _codegen_manager{std::make_unique<onert::odc::CodegenManager>()}, _model_path{}
+    _codegen_manager{std::make_unique<onert::odc::CodegenManager>()}, _model_path{},
+    _signature_map{}
 {
   // DO NOTHING
 }
@@ -1000,7 +1001,17 @@ NNFW_STATUS nnfw_session::set_signature_run(const char *signature)
     return NNFW_STATUS_INVALID_STATE;
   }
 
-  std::cerr << "Error during nnfw_session::set_signature_run : NYI" << std::endl;
+  for (auto &sig : _signature_map)
+  {
+    if (sig.second == std::string(signature))
+    {
+      _execution =
+        std::make_unique<onert::exec::Execution>(_compiler_artifact->_executors, sig.first);
+      return NNFW_STATUS_NO_ERROR;
+    }
+  }
+
+  std::cerr << "Error during nnfw_session::set_signature_run : cannot find signature" << std::endl;
   return NNFW_STATUS_ERROR;
 }
 
@@ -1106,6 +1117,7 @@ NNFW_STATUS nnfw_session::loadModelFile(const std::string &model_file_path,
   if (model == nullptr)
     return NNFW_STATUS_ERROR;
 
+  _signature_map = model->signatureMap();
   _nnpkg = std::make_unique<onert::ir::NNPkg>(std::move(model));
   _model_path = std::filesystem::path(model_file_path);
   _compiler_artifact.reset();

--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -233,6 +233,7 @@ private:
   //     const uint8 *buf;
   //   }
   std::filesystem::path _model_path;
+  std::unordered_map<onert::ir::SubgraphIndex, std::string> _signature_map;
 };
 
 #endif // __API_NNFW_SESSION_H__

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -47,6 +47,13 @@ public:
    */
   Execution(const std::shared_ptr<IExecutors> &executors);
 
+  /**
+   * @brief     Construct a new Execution object for signature
+   * @param[in] executors   Model executors
+   * @param[in] entry_index Entry subgraph index
+   */
+  Execution(const std::shared_ptr<IExecutors> &executors, const ir::SubgraphIndex &entry_index);
+
 public:
   /**
    * @brief   Returns primary graph object

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -16,6 +16,7 @@
 
 #include "exec/Execution.h"
 
+#include "SignatureExecutors.h"
 #include "../backend/builtin/IOTensor.h"
 #include "ir/DataType.h"
 #include "train/TrainableExecutors.h"
@@ -43,7 +44,7 @@ Execution::Execution(const std::shared_ptr<IExecutors> &executors) : _executors{
   for (uint32_t i = 0; i < _executors->outputSize(); ++i)
   {
     const auto output_tensor =
-      dynamic_cast<const backend::builtin::IOTensor *>(executors->outputTensor(ir::IOIndex{i}));
+      dynamic_cast<const backend::builtin::IOTensor *>(_executors->outputTensor(ir::IOIndex{i}));
     if (!output_tensor)
       throw std::runtime_error("Output tensor must be IOTensor");
 
@@ -52,6 +53,13 @@ Execution::Execution(const std::shared_ptr<IExecutors> &executors) : _executors{
 
   // Initialize options
   ExecutionOptions::fromGlobalConfig(_ctx.options);
+}
+
+Execution::Execution(const std::shared_ptr<IExecutors> &executors,
+                     const ir::SubgraphIndex &entry_index)
+  : Execution(std::make_shared<SignatureExecutors>(executors, entry_index))
+{
+  // DO NOTHING
 }
 
 void Execution::changeInputShape(const ir::IOIndex &index, const ir::Shape &new_shape)


### PR DESCRIPTION
This commit Implements signature-based execution
- Add signature mapping to nnfw_session class to store subgraph index to signature
- Update set_signature_run to create Execution with the correct subgraph index for the given signature
- Add new Execution constructor that accepts entry subgraph index for signature execution by creating SignatureExecutors and point it internally

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/15929
Related issue: https://github.com/Samsung/ONE/issues/15369