### PR TITLE
[ONERT] Support INT16_SYMM type for Concat and StridedSlice

### DIFF
--- a/runtime/onert/backend/cpu/ops/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.cc
@@ -121,6 +121,9 @@ void ConcatLayer::run()
     case OperandType::QUANT_INT8_ASYMM:
       concatenationGeneral<int8_t>();
       break;
+    case OperandType::QUANT_INT16_SYMM:
+      concatenationGeneral<int16_t>();
+      break;
     case OperandType::INT32:
       concatenationGeneral<int32_t>();
       break;

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
@@ -75,6 +75,10 @@ void StridedSliceLayer::run()
   {
     stridedSliceImpl<int64_t>();
   }
+  else if (_input->data_type() == OperandType::QUANT_INT16_SYMM)
+  {
+    stridedSliceImpl<int16_t>();
+  }
   else
   {
     throw std::runtime_error{"StridedSlice: unsupported data type"};

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -178,8 +178,9 @@ void OperationValidator::visit(const operation::Concat &node)
   {
     OP_REQUIRES(isSameType(input_index, output_index));
 
-    // Int8 quantization requires same scale and zero point
-    if (isValidType(output_index, DataType::QUANT_INT8_ASYMM))
+    // Int8 and Int16 quantization requires same scale and zero point
+    if (isValidType(output_index, DataType::QUANT_INT8_ASYMM) ||
+        isValidType(output_index, DataType::QUANT_INT16_SYMM))
     {
       OP_REQUIRES(isSameQuantParam(input_index, output_index));
     }


### PR DESCRIPTION
This commit supports `QUANT_INT16_SYMM` type for Concat and StridedSlice.