### PR TITLE
[onert] Remove supported operator nnapi gtest skip

### DIFF
--- a/runtime/tests/nnapi/nnapi_gtest.skip.aarch64-linux.cpu
+++ b/runtime/tests/nnapi/nnapi_gtest.skip.aarch64-linux.cpu
@@ -1,4 +1,3 @@
-GeneratedTests.abs_
 GeneratedTests.cast_float16_to_float16
 GeneratedTests.cast_float16_to_float32
 GeneratedTests.cast_float16_to_float32_relaxed
@@ -20,9 +19,6 @@ GeneratedTests.dequantize_v1_2_zero_sized_float16
 GeneratedTests.embedding_lookup
 GeneratedTests.embedding_lookup_2d_nnfw
 GeneratedTests.embedding_lookup_4d_nnfw
-GeneratedTests.equal_broadcast_float_nnfw
-GeneratedTests.exp_
-GeneratedTests.floor_
 GeneratedTests.gather_float16
 GeneratedTests.gather_float16_2
 GeneratedTests.gather_float16_3
@@ -41,7 +37,6 @@ GeneratedTests.local_response_norm_float_1
 GeneratedTests.local_response_norm_float_2
 GeneratedTests.local_response_norm_float_3
 GeneratedTests.local_response_norm_float_4
-GeneratedTests.logical_not
 GeneratedTests.lsh_projection
 GeneratedTests.lsh_projection_2
 GeneratedTests.lsh_projection_weights_as_inputs
@@ -54,9 +49,6 @@ GeneratedTests.maximum_simple_quant8
 GeneratedTests.minimum_broadcast_quant8
 GeneratedTests.minimum_overflow
 GeneratedTests.minimum_simple_quant8
-GeneratedTests.neg
-GeneratedTests.neg_3D_int_nnfw
-GeneratedTests.neg_4D_int_nnfw
 GeneratedTests.prelu
 GeneratedTests.prelu_broadcast_float_1_nnfw
 GeneratedTests.prelu_broadcast_quant8_1_nnfw
@@ -178,11 +170,6 @@ GeneratedTests.slice_6
 GeneratedTests.slice_8
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
-GeneratedTests.sqrt_
-GeneratedTests.sqrt_1D_float_nnfw
-GeneratedTests.sqrt_2D_float_nnfw
-GeneratedTests.sqrt_3D_float_nnfw
-GeneratedTests.sqrt_4D_float_nnfw
 GeneratedTests.strided_slice_qaunt8_10
 GeneratedTests.strided_slice_qaunt8_11
 GeneratedTests.strided_slice_quant8_1

--- a/runtime/tests/nnapi/nnapi_gtest.skip.armv7l-linux.cpu
+++ b/runtime/tests/nnapi/nnapi_gtest.skip.armv7l-linux.cpu
@@ -1,4 +1,3 @@
-GeneratedTests.abs_
 GeneratedTests.cast_float16_to_float16
 GeneratedTests.cast_float16_to_float32
 GeneratedTests.cast_float16_to_float32_relaxed
@@ -20,9 +19,6 @@ GeneratedTests.dequantize_v1_2_zero_sized_float16
 GeneratedTests.embedding_lookup
 GeneratedTests.embedding_lookup_2d_nnfw
 GeneratedTests.embedding_lookup_4d_nnfw
-GeneratedTests.equal_broadcast_float_nnfw
-GeneratedTests.exp_
-GeneratedTests.floor_
 GeneratedTests.gather_float16
 GeneratedTests.gather_float16_2
 GeneratedTests.gather_float16_3
@@ -41,7 +37,6 @@ GeneratedTests.local_response_norm_float_1
 GeneratedTests.local_response_norm_float_2
 GeneratedTests.local_response_norm_float_3
 GeneratedTests.local_response_norm_float_4
-GeneratedTests.logical_not
 GeneratedTests.lsh_projection
 GeneratedTests.lsh_projection_2
 GeneratedTests.lsh_projection_weights_as_inputs
@@ -54,9 +49,6 @@ GeneratedTests.maximum_simple_quant8
 GeneratedTests.minimum_broadcast_quant8
 GeneratedTests.minimum_overflow
 GeneratedTests.minimum_simple_quant8
-GeneratedTests.neg
-GeneratedTests.neg_3D_int_nnfw
-GeneratedTests.neg_4D_int_nnfw
 GeneratedTests.prelu
 GeneratedTests.prelu_broadcast_float_1_nnfw
 GeneratedTests.prelu_broadcast_quant8_1_nnfw
@@ -178,11 +170,6 @@ GeneratedTests.slice_6
 GeneratedTests.slice_8
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
-GeneratedTests.sqrt_
-GeneratedTests.sqrt_1D_float_nnfw
-GeneratedTests.sqrt_2D_float_nnfw
-GeneratedTests.sqrt_3D_float_nnfw
-GeneratedTests.sqrt_4D_float_nnfw
 GeneratedTests.strided_slice_qaunt8_10
 GeneratedTests.strided_slice_qaunt8_11
 GeneratedTests.strided_slice_quant8_1

--- a/runtime/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
+++ b/runtime/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
@@ -1,4 +1,3 @@
-GeneratedTests.abs_
 GeneratedTests.cast_float16_to_float16
 GeneratedTests.cast_float16_to_float32
 GeneratedTests.cast_float16_to_float32_relaxed
@@ -20,9 +19,6 @@ GeneratedTests.dequantize_v1_2_zero_sized_float16
 GeneratedTests.embedding_lookup
 GeneratedTests.embedding_lookup_2d_nnfw
 GeneratedTests.embedding_lookup_4d_nnfw
-GeneratedTests.equal_broadcast_float_nnfw
-GeneratedTests.exp_
-GeneratedTests.floor_
 GeneratedTests.gather_float16
 GeneratedTests.gather_float16_2
 GeneratedTests.gather_float16_3
@@ -41,7 +37,6 @@ GeneratedTests.local_response_norm_float_1
 GeneratedTests.local_response_norm_float_2
 GeneratedTests.local_response_norm_float_3
 GeneratedTests.local_response_norm_float_4
-GeneratedTests.logical_not
 GeneratedTests.lsh_projection
 GeneratedTests.lsh_projection_2
 GeneratedTests.lsh_projection_weights_as_inputs
@@ -51,13 +46,9 @@ GeneratedTests.lstm2_state2
 GeneratedTests.maximum_broadcast_quant8
 GeneratedTests.maximum_overflow
 GeneratedTests.maximum_simple_quant8
-GeneratedTests.minimum_int32
 GeneratedTests.minimum_broadcast_quant8
 GeneratedTests.minimum_overflow
 GeneratedTests.minimum_simple_quant8
-GeneratedTests.neg
-GeneratedTests.neg_3D_int_nnfw
-GeneratedTests.neg_4D_int_nnfw
 GeneratedTests.prelu
 GeneratedTests.prelu_broadcast_float_1_nnfw
 GeneratedTests.prelu_broadcast_quant8_1_nnfw
@@ -179,11 +170,6 @@ GeneratedTests.slice_6
 GeneratedTests.slice_8
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
-GeneratedTests.sqrt_
-GeneratedTests.sqrt_1D_float_nnfw
-GeneratedTests.sqrt_2D_float_nnfw
-GeneratedTests.sqrt_3D_float_nnfw
-GeneratedTests.sqrt_4D_float_nnfw
 GeneratedTests.strided_slice_qaunt8_10
 GeneratedTests.strided_slice_qaunt8_11
 GeneratedTests.strided_slice_quant8_1


### PR DESCRIPTION
This commit updates nnapi gtest skiplist to test supported operator on cpu backend.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>