### PR TITLE
[onert] Implement signature selection support for prepare

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -234,6 +234,7 @@ private:
   //   }
   std::filesystem::path _model_path;
   std::unordered_map<onert::ir::SubgraphIndex, std::string> _signature_map;
+  onert::ir::SubgraphIndex _selected_signature;
 };
 
 #endif // __API_NNFW_SESSION_H__

--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -231,6 +231,13 @@ public:
                                : _edges.pkg_inputs.size();
   }
 
+  uint32_t inputSize(SubgraphIndex subg_index) const
+  {
+    // signature entry is supported for single model only
+    assert(_models.size() == 1);
+    return primary_model()->at(subg_index)->getInputs().size();
+  }
+
   /**
    * @brief   Get model output size
    */
@@ -238,6 +245,13 @@ public:
   {
     return _models.size() == 1 ? primary_model()->primary_subgraph()->getOutputs().size()
                                : _edges.pkg_outputs.size();
+  }
+
+  uint32_t outputSize(SubgraphIndex subg_index) const
+  {
+    // signature entry is supported for single model only
+    assert(_models.size() == 1);
+    return primary_model()->at(subg_index)->getOutputs().size();
   }
 
   /**
@@ -255,6 +269,16 @@ public:
     auto const &desc = input(index);
     auto const graph = model(std::get<ModelIndex>(desc))->primary_subgraph();
     auto const operand_index = graph->getInputs().at(std::get<IOIndex>(desc).value());
+    return graph->operands().at(operand_index).info();
+  }
+
+  const OperandInfo &inputInfo(SubgraphIndex subg_index, uint32_t index) const
+  {
+    // signature entry is supported for single model only
+    assert(_models.size() == 1);
+
+    auto const graph = primary_model()->at(subg_index);
+    auto const operand_index = graph->getInputs().at(index);
     return graph->operands().at(operand_index).info();
   }
 
@@ -276,6 +300,17 @@ public:
     return graph->operands().at(operand_index).info();
   }
 
+  const OperandInfo &outputInfo(SubgraphIndex subg_index, uint32_t index) const
+  {
+    // signature entry is supported for single model only
+    assert(_models.size() == 1);
+
+    auto const graph = primary_model()->at(subg_index);
+
+    auto const operand_index = graph->getOutputs().at(index);
+    return graph->operands().at(operand_index).info();
+  }
+
   void changeInputShape(const ir::IOIndex &index, const ir::Shape &new_shape)
   {
     if (_models.size() == 1)
@@ -290,6 +325,17 @@ public:
     auto graph = model(std::get<ModelIndex>(desc))->primary_subgraph();
     auto const operand_index = graph->getInputs().at(std::get<IOIndex>(desc).value());
     graph->changeShape(operand_index, new_shape);
+  }
+
+  void changeInputShape(SubgraphIndex subg_index, uint32_t index, const ir::Shape &new_shape)
+  {
+    // signature entry is supported for single model only
+    assert(_models.size() == 1);
+
+    auto graph = primary_model()->at(subg_index);
+    auto const operand_index = graph->getInputs().at(index);
+    graph->changeShape(operand_index, new_shape);
+    return;
   }
 
   /**


### PR DESCRIPTION
This commit implements signature selection and related input/output getter/setter APIs.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/15929
Related issue: https://github.com/Samsung/ONE/issues/15369