### PR TITLE
[onert] Add QSYMM16 data type conversion support to ACL backend

### DIFF
--- a/runtime/onert/backend/acl_common/Convert.cc
+++ b/runtime/onert/backend/acl_common/Convert.cc
@@ -270,6 +270,8 @@ ir::DataType asRuntimeDataType(::arm_compute::DataType data_type)
       return ir::DataType::FLOAT16;
     case ::arm_compute::DataType::S64:
       return ir::DataType::INT64;
+    case ::arm_compute::DataType::QSYMM16:
+      return ir::DataType::QUANT_INT16_SYMM;
     default:
       throw std::runtime_error{"Not supported acl data type, yet"};
       break;

--- a/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Add.test.cc
+++ b/runtime/tests/nnfw_api/src/GenModelTests/one_op_tests/Add.test.cc
@@ -283,7 +283,7 @@ TEST_F(GenModelTest, neg_OneOp_Add_VarToVarSize0_InvalidShape)
   SUCCEED();
 }
 
-TEST_F(GenModelTest, neg_OneOp_Add_VarToVarInt16)
+TEST_F(GenModelTest, OneOp_Add_VarToVarInt16)
 {
   CircleGen cgen;
   int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT16}, 1., 0);
@@ -293,9 +293,8 @@ TEST_F(GenModelTest, neg_OneOp_Add_VarToVarInt16)
   cgen.setInputsAndOutputs({lhs, rhs}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(uniformTCD<int8_t>({{1, 3, 2, 4}, {5, -4, -7, 4}}, {{22, -10, -24, 24}}));
-  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->expectFailCompile();
+  _context->addTestCase(uniformTCD<int16_t>({{1, 3, 2, 4}, {5, -4, -7, 4}}, {{22, -10, -24, 24}}));
+  _context->setBackends({"acl_cl", "acl_neon"});
 
   SUCCEED();
 }


### PR DESCRIPTION
This commit adds conversion for ACL's QSYMM16 data type to runtime's QUANT_INT16_SYMM. 
This commit includes update Add test case to use INT16 and expect success instead of failure.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>