### PR TITLE
[onert] Make TRIX request timeout configurable

### DIFF
--- a/runtime/infra/cmake/CfgOptionFlags.cmake
+++ b/runtime/infra/cmake/CfgOptionFlags.cmake
@@ -18,6 +18,7 @@ option(ASAN_BUILD "Address Sanitizer build" OFF)
 # Default build configuration for runtime
 #
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" ON)
+set(TRIX_REQ_TIMEOUT_SEC 60 CACHE STRING "Timeout for TRIX request")
 
 #
 # Default build configuration for tests

--- a/runtime/infra/cmake/options/options_x86_64-linux.cmake
+++ b/runtime/infra/cmake/options/options_x86_64-linux.cmake
@@ -4,3 +4,5 @@
 option(BUILD_XNNPACK "Build XNNPACK" OFF)
 option(DOWNLOAD_PYBIND11 "Download Pybind11 source" ON)
 option(BUILD_PYTHON_BINDING "Build python binding" ON)
+# Assume x86-64 linux trix backend is used on TRIX simulator
+set(TRIX_REQ_TIMEOUT_SEC 180 CACHE STRING "Timeout for TRIX request")

--- a/runtime/onert/backend/trix/CMakeLists.txt
+++ b/runtime/onert/backend/trix/CMakeLists.txt
@@ -15,6 +15,9 @@ target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE onert_core)
 target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE trix-engine)
 target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE nnfw_common)
 target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE nnfw_coverage)
+# Default TRIX_REQ_TIMEOUT_SEC is set as cmake option default setting
+# If user want to change this value, please use cmake option -DTRIX_REQ_TIMEOUT_SEC=<value> when build. (ex: -DTRIX_REQ_TIMEOUT_SEC=100)
+target_compile_definitions(${LIB_ONERT_BACKEND_TRIX} PRIVATE TIMEOUT_SEC=${TRIX_REQ_TIMEOUT_SEC})
 
 set_target_properties(${LIB_ONERT_BACKEND_TRIX} PROPERTIES
   OUTPUT_NAME backend_trix

--- a/runtime/onert/backend/trix/DevContext.cc
+++ b/runtime/onert/backend/trix/DevContext.cc
@@ -20,6 +20,11 @@
 
 #include <stdexcept>
 
+#ifndef TIMEOUT_SEC
+// Throw build error
+#error "TIMEOUT_SEC must be defined"
+#endif // TIMEOUT_SEC
+
 namespace onert::backend::trix
 {
 
@@ -267,7 +272,7 @@ void DevContext::runOneBatch(uint32_t dev_num, ModelID model_id, input_buffers *
   std::packaged_task<int(npudev_h, int)> task(submitNPU_request);
   auto f = task.get_future();
   std::thread thread_submit_request(std::move(task), dev_handle, req_id);
-  auto status = f.wait_until(std::chrono::system_clock::now() + std::chrono::seconds(60));
+  auto status = f.wait_until(std::chrono::system_clock::now() + std::chrono::seconds(TIMEOUT_SEC));
   if (status == std::future_status::timeout)
   {
     // There is no way to terminate hanging submitNPU_request from the outside.


### PR DESCRIPTION
This commit replaces hardcoded TRIX request timeout with configurable build option.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #15961 