### PR TITLE
[one-cmds] Revise TF converter_version

### DIFF
--- a/compiler/one-cmds/one-build.template.cfg
+++ b/compiler/one-cmds/one-build.template.cfg
@@ -15,7 +15,6 @@ output_path=inception_v3.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1
 model_format=graph_def
 
 [one-optimize]

--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -45,6 +45,7 @@ def _get_parser():
     ## tf2tfliteV2 arguments
     tf2tfliteV2_group = parser.add_argument_group('converter arguments')
 
+    # TODO deprecate converter_version
     # converter version
     converter_version = tf2tfliteV2_group.add_mutually_exclusive_group()
     converter_version.add_argument('--v1',

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -40,6 +40,7 @@ def _get_parser():
     ## tf2tfliteV2 arguments
     tf2tfliteV2_group = parser.add_argument_group('converter arguments')
 
+    # TODO deprecate converter_version
     # converter version
     converter_version = tf2tfliteV2_group.add_mutually_exclusive_group()
     converter_version.add_argument('--v1',

--- a/compiler/one-cmds/onecc.template.cfg
+++ b/compiler/one-cmds/onecc.template.cfg
@@ -40,8 +40,6 @@ input_path=
 ; circle file
 output_path=
 # optional
-; v1 or v2
-converter_version=v2
 ; graph_def(default), saved_model or keras_model
 model_format=graph_def
 # optional but mandatory for model_format=graph_def
@@ -66,8 +64,6 @@ input_path=
 ; circle file
 output_path=
 # optional
-; v1 or v2
-converter_version=v2
 ; graph_def(default), saved_model or keras_model
 model_format=graph_def
 # optional but mandatory for model_format=graph_def

--- a/compiler/one-cmds/onelib/make_cmd.py
+++ b/compiler/one-cmds/onelib/make_cmd.py
@@ -37,13 +37,7 @@ def make_tf2tfliteV2_cmd(args, driver_path, input_path, output_path):
         cmd.append('--' + getattr(args, 'model_format'))
     else:
         cmd.append('--graph_def')  # default value
-    # converter version
-    if is_valid_attr(args, 'converter_version_cmd'):
-        cmd.append(getattr(args, 'converter_version_cmd'))
-    elif is_valid_attr(args, 'converter_version'):
-        cmd.append('--' + getattr(args, 'converter_version'))
-    else:
-        cmd.append('--v1')  # default value
+    # NOTE converter_version_cmd is removed as it is deprecated
     # input_path
     if is_valid_attr(args, 'input_path'):
         cmd.append('--input_path')

--- a/compiler/one-cmds/tests/one-import_002.cfg
+++ b/compiler/one-cmds/tests/one-import_002.cfg
@@ -13,4 +13,3 @@ output_path=inception_v3_cfg.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2

--- a/compiler/one-cmds/tests/onecc_001.cfg
+++ b/compiler/one-cmds/tests/onecc_001.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_001.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-optimize]
 input_path=inception_v3.onecc_001.circle

--- a/compiler/one-cmds/tests/onecc_002.cfg
+++ b/compiler/one-cmds/tests/onecc_002.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_002.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-optimize]
 input_path=inception_v3.onecc_002.circle

--- a/compiler/one-cmds/tests/onecc_003.cfg
+++ b/compiler/one-cmds/tests/onecc_003.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_003.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1
 
 [one-quantize]
 input_path=inception_v3.onecc_003.circle

--- a/compiler/one-cmds/tests/onecc_004.cfg
+++ b/compiler/one-cmds/tests/onecc_004.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_004.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1
 
 [one-codegen]
 backend=dummy

--- a/compiler/one-cmds/tests/onecc_006.cfg
+++ b/compiler/one-cmds/tests/onecc_006.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_006.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1
 
 [one-optimize]
 input_path=inception_v3.onecc_006.circle

--- a/compiler/one-cmds/tests/onecc_007.cfg
+++ b/compiler/one-cmds/tests/onecc_007.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_007.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1
 
 [one-optimize]
 input_path=inception_v3.onecc_007.circle

--- a/compiler/one-cmds/tests/onecc_010.cfg
+++ b/compiler/one-cmds/tests/onecc_010.cfg
@@ -13,5 +13,4 @@ output_path=inception_v3.alt.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1
 save_intermediate=True

--- a/compiler/one-cmds/tests/onecc_012.cfg
+++ b/compiler/one-cmds/tests/onecc_012.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_012.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1
 
 [one-quantize]
 input_path=inception_v3.onecc_012.circle

--- a/compiler/one-cmds/tests/onecc_013.cfg
+++ b/compiler/one-cmds/tests/onecc_013.cfg
@@ -4,4 +4,3 @@ output_path=inception_v3.onecc_13.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1

--- a/compiler/one-cmds/tests/onecc_014.cfg
+++ b/compiler/one-cmds/tests/onecc_014.cfg
@@ -4,4 +4,3 @@ output_path=inception_v3.onecc_014.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1

--- a/compiler/one-cmds/tests/onecc_024.cfg
+++ b/compiler/one-cmds/tests/onecc_024.cfg
@@ -14,7 +14,6 @@ output_path=inception_v3.onecc_024.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v1
 
 [one-optimize]
 input_path=inception_v3.onecc_024.circle

--- a/compiler/one-cmds/tests/onecc_025.cfg
+++ b/compiler/one-cmds/tests/onecc_025.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_025.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-optimize]
 input_path=inception_v3.onecc_025.circle

--- a/compiler/one-cmds/tests/onecc_028.workflow.json
+++ b/compiler/one-cmds/tests/onecc_028.workflow.json
@@ -15,8 +15,7 @@
                 "output_path": "inception_v3.onecc_028.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "OPTIMIZE": {

--- a/compiler/one-cmds/tests/onecc_029.workflow.json
+++ b/compiler/one-cmds/tests/onecc_029.workflow.json
@@ -14,8 +14,7 @@
                 "output_path": "inception_v3.onecc_029.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "QUANTIZE": {

--- a/compiler/one-cmds/tests/onecc_030.workflow.json
+++ b/compiler/one-cmds/tests/onecc_030.workflow.json
@@ -14,8 +14,7 @@
                 "output_path": "inception_v3.onecc_030.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "codegen": {

--- a/compiler/one-cmds/tests/onecc_035.workflow.json
+++ b/compiler/one-cmds/tests/onecc_035.workflow.json
@@ -14,7 +14,6 @@
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v1",
                 "save_intermediate": "True"
             }
         }

--- a/compiler/one-cmds/tests/onecc_037.workflow.json
+++ b/compiler/one-cmds/tests/onecc_037.workflow.json
@@ -14,8 +14,7 @@
                 "output_path": "inception_v3.onecc_037.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "OPTIMIZE": {

--- a/compiler/one-cmds/tests/onecc_038.workflow.json
+++ b/compiler/one-cmds/tests/onecc_038.workflow.json
@@ -14,8 +14,7 @@
                 "output_path": "inception_v3.onecc_038.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "QUANTIZE": {

--- a/compiler/one-cmds/tests/onecc_040.cfg
+++ b/compiler/one-cmds/tests/onecc_040.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_040.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-optimize]
 input_path=inception_v3.onecc_040.circle

--- a/compiler/one-cmds/tests/onecc_041.cfg
+++ b/compiler/one-cmds/tests/onecc_041.cfg
@@ -13,4 +13,3 @@ output_path=inception_v3_without_opt.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2

--- a/compiler/one-cmds/tests/onecc_041.workflow.json
+++ b/compiler/one-cmds/tests/onecc_041.workflow.json
@@ -45,8 +45,7 @@
                 "output_path": "inception_v3.onecc_041.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "OPTIMIZE": {

--- a/compiler/one-cmds/tests/onecc_059.cfg
+++ b/compiler/one-cmds/tests/onecc_059.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_059.circle #comment test
 input_arrays=input ; comment test
 input_shapes=1,299,299,3 ;comment test
 output_arrays=InceptionV3/Predictions/Reshape_1     ## test
-converter_version=v2       ## test
 # comment test
 [one-optimize]
 input_path=inception_v3.onecc_059.circle

--- a/compiler/one-cmds/tests/onecc_067.cfg
+++ b/compiler/one-cmds/tests/onecc_067.cfg
@@ -11,7 +11,6 @@ output_path=inception_v3.onecc_067.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-codegen]
 o=onecc_067.tvn

--- a/compiler/one-cmds/tests/onecc_068.cfg
+++ b/compiler/one-cmds/tests/onecc_068.cfg
@@ -11,7 +11,6 @@ output_path=inception_v3.onecc_068.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-codegen]
 output_path=onecc_068.tvn

--- a/compiler/one-cmds/tests/onecc_neg_002.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_002.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_neg_002.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-optimize]
 input_path=inception_v3.onecc_neg_002.circle

--- a/compiler/one-cmds/tests/onecc_neg_003.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_003.cfg
@@ -4,7 +4,6 @@ output_path=inception_v3.onecc_neg_003.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-optimize]
 input_path=inception_v3.onecc_neg_003.circle

--- a/compiler/one-cmds/tests/onecc_neg_004.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_004.cfg
@@ -13,7 +13,6 @@ output_path=inception_v3.onecc_neg_004.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2
 
 [one-optimize]
 input_path=inception_v3.onecc_neg_004.circle

--- a/compiler/one-cmds/tests/onecc_neg_005.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_005.cfg
@@ -13,4 +13,3 @@ output_path=inception_v3.alt.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2

--- a/compiler/one-cmds/tests/onecc_neg_018.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_018.workflow.json
@@ -16,8 +16,7 @@
                 "output_path": "inception_v3.onecc_neg_018.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         }
     }

--- a/compiler/one-cmds/tests/onecc_neg_019.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_019.workflow.json
@@ -13,8 +13,7 @@
                 "output_path": "inception_v3.onecc_neg_019.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         }
     }

--- a/compiler/one-cmds/tests/onecc_neg_020.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_020.workflow.json
@@ -13,8 +13,7 @@
                 "output_path": "inception_v3.onecc_neg_020.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         }
     }

--- a/compiler/one-cmds/tests/onecc_neg_021.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_021.workflow.json
@@ -17,8 +17,7 @@
                 "output_path": "inception_v3.onecc_neg_021.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         }
     },
@@ -36,8 +35,7 @@
                 "output_path": "inception_v3.onecc_neg_021.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         }
     }

--- a/compiler/one-cmds/tests/onecc_neg_022.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_022.cfg
@@ -13,4 +13,3 @@ output_path=inception_v3_without_opt.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-converter_version=v2

--- a/compiler/one-cmds/tests/onecc_neg_022.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_022.workflow.json
@@ -48,8 +48,7 @@
                 "output_path": "inception_v3.onecc_neg_022.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "OPTIMIZE": {

--- a/compiler/one-cmds/tests/onecc_neg_023.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_023.workflow.json
@@ -14,8 +14,7 @@
                 "output_path": "inception_v3.onecc_neg_023.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "OPTIMIZE": {

--- a/compiler/one-cmds/tests/onecc_neg_031.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_031.workflow.json
@@ -14,8 +14,7 @@
                 "output_path": "inception_v3.onecc_neg_031.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "codegen": {

--- a/compiler/one-cmds/tests/onecc_neg_036.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_036.workflow.json
@@ -14,8 +14,7 @@
                 "output_path": "inception_v3.onecc_neg_036.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
-                "output_arrays": "InceptionV3/Predictions/Reshape_1",
-                "converter_version": "v2"
+                "output_arrays": "InceptionV3/Predictions/Reshape_1"
             }
         },
         "profile": {


### PR DESCRIPTION
This will add deprecated comment to TF converter_version,
and remove the option from examples and test files.
