### PR TITLE
[loco] Fix an error when building with `gcc-15`

### DIFF
--- a/compiler/loco/include/loco/ADT/ObjectPool.h
+++ b/compiler/loco/include/loco/ADT/ObjectPool.h
@@ -18,6 +18,7 @@
 #define __LOCO_ADT_OBJECT_POOL_H__
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
This PR fixes an `'uint32_t' does not name a type` error emitted by `gcc-15` for the `ObjectPool.h` header file

when trying to build with gcc-15, it complains about missing header include:
```
In file included from (...)/compiler/loco/src/ADT/ObjectPool.cpp:17:
(...)/compiler/loco/include/loco/ADT/ObjectPool.h:38:3: error: 'uint32_t' does not name a type [-Wtemplate-body]
   38 |   uint32_t size(void) const { return _pool.size(); }
      |   ^~~~~~~~
(...)/compiler/loco/include/loco/ADT/ObjectPool.h:23:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   22 | #include <vector>
  +++ |+#include <cstdint>
   23 | 
(...)/compiler/loco/include/loco/ADT/ObjectPool.h:41:9: error: 'uint32_t' has not been declared [-Wtemplate-body]
   41 |   T *at(uint32_t n) const { return _pool.at(n).get(); }
      |         ^~~~~~~~
(...)/compiler/loco/include/loco/ADT/ObjectPool.h:41:9: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```

ONE-DCO-1.0-Signed-off-by: Marcin Słowiński <m.slowinski2@samsung.com>