### PR TITLE
[infra/onert] Update Android NDK configuration for cross-compilation

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -51,9 +51,12 @@ else
 	endif
 endif
 
+# Workaround to use NDK_DIR
+# TODO remove NDK_DIR
 ifeq ($(TARGET_OS),android)
-	OPTIONS+= -DNDK_DIR=$(NDK_DIR)
-	OPTIONS_NNCC+= -DNDK_DIR=$(NDK_DIR)
+ifneq ($(NDK_DIR),)
+	OPTIONS+= -DCMAKE_ANDROID_NDK=$(NDK_DIR)
+endif
 endif
 
 ifneq ($(ANDROID_BUILD_TOOLS_DIR),)

--- a/docs/howto/how-to-cross-build-runtime-for-android.md
+++ b/docs/howto/how-to-cross-build-runtime-for-android.md
@@ -30,19 +30,29 @@ $ docker build -t nnfw/one-devtools:android-sdk -f infra/docker/android-sdk/Dock
 ### Build and install the runtime
 
 Some tools/libs are still not supported and those are not built by default - mostly due to dependency on HDF5 library.
-Please refer to `infra/nnfw/cmake/options/options_aarch64-android.cmake` for details.
 
 Different from cross build for linux,
 
-- `NDK_DIR` is required
+- Wrapper toolchain file for Android NDK: `runtime/infra/cmake/buildtool/cross/toolchain_aarch64-android.cmake`
+- `ANDROID_NDK` environment variable or `CMAKE_ANDROID_NDK` cmake variable is required
 
-If you are using docker image `nnfw/one-devtools:android-sdk`, you don't need to specify `NDK_DIR` because it is already set in the image.
+If you are using docker image `nnfw/one-devtools:android-sdk`, you don't need to specify above variable because environment variable is already set in the image.
 
 Here is an example of using Makefile.
 
 ```bash
 TARGET_OS=android \
 CROSS_BUILD=1 \
-NDK_DIR=/path/android-sdk/ndk/{ndk-version}/ \
+ANDROID_NDK=/path/android-sdk/ndk/{ndk-version}/ \
 make -f Makefile.template install
+```
+
+Otherwise, you can use command
+```
+$ source .venv/bin/activate
+(.venv)$ ./nnfw configure \
+  -DCMAKE_TOOLCHAIN_FILE=infra/cmake/buildtool/cross/toolchain_aarch64-android.cmake \
+  -DCMAKE_ANDROID_NDK=/path/android-sdk/ndk/{ndk-version}
+(.venv)$ ./nnfw build
+(.venv)$ ./nnfw install --prefix build/onert/out
 ```

--- a/infra/docker/android-sdk/Dockerfile
+++ b/infra/docker/android-sdk/Dockerfile
@@ -73,7 +73,7 @@ RUN ${ANDROID_HOME}/cmdline-tools/${CMDTOOLS_VERSION}/bin/sdkmanager --sdk_root=
 RUN ${ANDROID_HOME}/cmdline-tools/${CMDTOOLS_VERSION}/bin/sdkmanager --sdk_root=${ANDROID_HOME} "platform-tools"
 
 # Env variable for android build (ndk, gradle)
-ENV NDK_DIR=${ANDROID_HOME}/ndk/${NDK_VERSION}
+ENV ANDROID_NDK=${ANDROID_HOME}/ndk/${NDK_VERSION}
 ENV GRADLE_HOME=/opt/android-tools/gradle
 ENV PATH=${PATH}:${GRADLE_HOME}/bin:${ANDROID_HOME}/cmdline-tools/${CMDTOOLS_VERSION}/bin:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 

--- a/runtime/infra/cmake/buildtool/cross/toolchain_aarch64-android.cmake
+++ b/runtime/infra/cmake/buildtool/cross/toolchain_aarch64-android.cmake
@@ -1,14 +1,26 @@
-# A workaround for accessing to NDK_DIR. This works since Env Vars are always accessible
-# while cache variables are not
-if (NDK_DIR)
-    set(ENV{_NDK_DIR} "${NDK_DIR}")
-else (NDK_DIR)
-    set(NDK_DIR "$ENV{_NDK_DIR}")
-endif (NDK_DIR)
+# This toolchain file is used to help setting variables for Android cross compilation.
+# It is a wrapper of android.toolchain.cmake provided by NDK.
+# This file requires only CMAKE_ANDROID_NDK or ANDROID_NDK environment variable.
 
-if(NOT DEFINED NDK_DIR)
-  message(FATAL_ERROR "NDK_DIR should be specified via cmake argument")
-endif(NOT DEFINED NDK_DIR)
+# If you want to use android NDK's toolchain file directly without this file,
+# please follow CMake's android cross build guide
+# https://cmake.org/cmake/help/v3.18/manual/cmake-toolchains.7.html#cross-compiling-for-android
+# https://developer.android.com/studio/projects/configure-cmake#call-cmake-cli
+
+# Use android sdk environment variable ANDROID_NDK to find the toolchain
+# Otherwise, use cmake android cross build guide's CMAKE_ANDROID_NDK variable
+if (DEFINED ENV{ANDROID_NDK})
+  set(CMAKE_ANDROID_NDK $ENV{ANDROID_NDK})
+elseif (CMAKE_ANDROID_NDK)
+  # A workaround for accessing NDK path
+  # This helps to work on try_compile since Env Vars are always accessible
+  # while cache variables are not
+  set(ENV{ANDROID_NDK} ${CMAKE_ANDROID_NDK})
+endif ()
+
+if (NOT EXISTS ${CMAKE_ANDROID_NDK})
+  message(FATAL_ERROR "CMAKE_ANDROID_NDK does not exist: ${CMAKE_ANDROID_NDK}")
+endif (NOT EXISTS ${CMAKE_ANDROID_NDK})
 
 set(ANDROID_ABI arm64-v8a)
 set(ANDROID_API_LEVEL 29)
@@ -20,7 +32,7 @@ set(ANDROID_STL c++_shared)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE NEVER)
 
 # Use the toolchain file that NDK provides
-include(${NDK_DIR}/build/cmake/android.toolchain.cmake)
+include(${CMAKE_ANDROID_NDK}/build/cmake/android.toolchain.cmake)
 
 find_library(ANDROID_STL_LIB c++_shared PATHS /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE})
 


### PR DESCRIPTION
This commit is transition from custom NDK_DIR to standard CMAKE_ANDROID_NDK or ANDROID_NDK variable for Android builds. 
It updates Makefile.template, documentation, docker environment variables, and toolchain configuration.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>