### PR TITLE
[onert] Rename nnfw_set_signature_for_tensorinfo

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -202,9 +202,9 @@ NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE
 NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYPE type);
 
 /**
- * @brief     Set the entry signature to get entry's I/O tensorinfo before prepare
+ * @brief     Set the entry signature to configure entry's I/O before prepare
  *
- * User can call this function to select entry signature to get specific entry's I/O features
+ * User can call this function to select entry signature to configure specific entry's I/O features
  * for prepare phase. This function should be called after {@link nnfw_load_model_from_file}
  * and before {@link nnfw_prepare}.
  *
@@ -221,7 +221,7 @@ NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYP
  * @param[in] signature name of the entry signature
  * @return    @c NNFW_STATUS_NO_ERROR if successful
  */
-NNFW_STATUS nnfw_set_signature_for_tensorinfo(nnfw_session *session, const char *signature);
+NNFW_STATUS nnfw_configure_signature(nnfw_session *session, const char *signature);
 
 /**
  * @brief     Set the entry signature to run

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -245,10 +245,10 @@ NNFW_STATUS nnfw_set_workspace(nnfw_session *session, const char *dir)
   return session->set_workspace(dir);
 }
 
-NNFW_STATUS nnfw_set_signature_for_tensorinfo(nnfw_session *session, const char *signature)
+NNFW_STATUS nnfw_configure_signature(nnfw_session *session, const char *signature)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_signature_for_tensorinfo(signature);
+  return session->configure_signature(signature);
 }
 
 NNFW_STATUS nnfw_set_signature_run(nnfw_session *session, const char *signature)

--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -1009,15 +1009,14 @@ NNFW_STATUS nnfw_session::set_workspace(const char *dir)
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_signature_for_tensorinfo(const char *signature)
+NNFW_STATUS nnfw_session::configure_signature(const char *signature)
 {
   if (!signature)
     return NNFW_STATUS_UNEXPECTED_NULL;
 
   if (!isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::set_signature_for_tensorinfo : invalid state"
-              << std::endl;
+    std::cerr << "Error during nnfw_session::configure_signature : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1031,7 +1030,7 @@ NNFW_STATUS nnfw_session::set_signature_for_tensorinfo(const char *signature)
     }
   }
 
-  std::cerr << "Error during nnfw_session::set_signature_for_tensorinfo : cannot find signature \""
+  std::cerr << "Error during nnfw_session::configure_signature : cannot find signature \""
             << signature << "\"" << std::endl;
   return NNFW_STATUS_ERROR;
 }

--- a/runtime/onert/api/nnfw/src/nnfw_session.h
+++ b/runtime/onert/api/nnfw/src/nnfw_session.h
@@ -132,7 +132,7 @@ public:
 
   NNFW_STATUS set_workspace(const char *dir);
 
-  NNFW_STATUS set_signature_for_tensorinfo(const char *signature);
+  NNFW_STATUS configure_signature(const char *signature);
   NNFW_STATUS set_signature_run(const char *signature);
 
   static NNFW_STATUS deprecated(const char *msg);

--- a/runtime/tests/tools/onert_run/src/onert_run.cc
+++ b/runtime/tests/tools/onert_run/src/onert_run.cc
@@ -138,7 +138,7 @@ int main(const int argc, char **argv)
 
     const auto &signature = args.getSignature();
     if (signature != "")
-      NNPR_ENSURE_STATUS(nnfw_set_signature_for_tensorinfo(session, signature.c_str()));
+      NNPR_ENSURE_STATUS(nnfw_configure_signature(session, signature.c_str()));
 
     uint32_t num_inputs;
     uint32_t num_outputs;


### PR DESCRIPTION
This commit renames the API function nnfw_set_signature_for_tensorinfo to nnfw_configure_signature to reflect its purpose of configuring I/O features before prepare phase.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>