### PR TITLE
[loco] Fix an error when building with `gcc-15`

### DIFF
--- a/compiler/loco/include/loco/IR/Node.h
+++ b/compiler/loco/include/loco/IR/Node.h
@@ -26,6 +26,7 @@
 #include "loco/IR/CastHelpers.h"
 
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <set>
 


### PR DESCRIPTION
This commit fixes an `'uint32_t' does not name a type` error emitted by `gcc-15` for the `Node.h` header file

this PR fix same issue as https://github.com/Samsung/ONE/pull/15967, but in different header file
```
In file included from (...)/compiler/loco/include/loco/IR/Algorithm.h:20,
                 from (...)/compiler/loco/src/IR/Algorithm.cpp:17:
(...)/compiler/loco/include/loco/IR/Node.h:89:11: error: 'uint32_t' does not name a type
   89 |   virtual uint32_t opnum(void) const = 0;
      |           ^~~~~~~~
(...)/compiler/loco/include/loco/IR/Node.h:31:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```


ONE-DCO-1.0-Signed-off-by: Marcin Słowiński <m.slowinski2@samsung.com>