### PR TITLE
[onert] Change Custom OP backend to builtin

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -623,33 +623,6 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   _return_fn = std::move(fn);
 }
 
-void KernelGenerator::visit(const ir::operation::Custom &node)
-{
-  auto fill_op_info = [&](const ir::OperandIndexSequence &opSeq,
-                          std::vector<custom::TypeInfo> &types,
-                          std::vector<IPortableTensor *> &tensors) {
-    for (const auto &idx : opSeq)
-    {
-      const auto &operand = _ctx.at(idx);
-      types.emplace_back(custom::TypeInfo{operand.shape(), operand.typeInfo().type()});
-      auto in_tensor = _tensor_reg->getPortableTensor(idx);
-      tensors.emplace_back(in_tensor);
-    }
-  };
-
-  backend::custom::CustomKernelConfigParams params{};
-
-  fill_op_info(node.getInputs(), params.input_types, params.input_tensors);
-  fill_op_info(node.getOutputs(), params.output_types, params.output_tensors);
-
-  params.userdata = node.userdata().data;
-  params.userdata_size = node.userdata().size;
-
-  auto fn = _kernel_builder->buildKernel(node.id(), std::move(params));
-
-  _return_fn = std::move(fn);
-}
-
 void KernelGenerator::visit(const ir::operation::ElementwiseActivation &node)
 {
   const auto output_index{node.getOutputs().at(0)};

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -49,7 +49,6 @@ public:
   void visit(const ir::operation::Comparison &) override;
   void visit(const ir::operation::Concat &) override;
   void visit(const ir::operation::Conv2D &) override;
-  void visit(const ir::operation::Custom &node) override;
   void visit(const ir::operation::DepthToSpace &) override;
   void visit(const ir::operation::DepthwiseConv2D &) override;
   void visit(const ir::operation::DynamicUpdateSlice &) override;

--- a/runtime/onert/core/src/backend/builtin/Backend.h
+++ b/runtime/onert/core/src/backend/builtin/Backend.h
@@ -66,7 +66,8 @@ public:
     context->tensor_registry = tr;
     context->tensor_builder = tb;
     context->kernel_gen = std::make_shared<KernelGenerator>(
-      *context->graph(), tb->dynamicTensorManager(), tr, context->external_context());
+      *context->graph(), tb->dynamicTensorManager(), tr, context->data().custom_kernel_builder,
+      context->external_context());
     return context;
   }
 

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -28,10 +28,11 @@ namespace onert::backend::builtin
 
 KernelGenerator::KernelGenerator(const ir::Graph &graph, DynamicTensorManager *dyn_tensor_manager,
                                  const std::shared_ptr<TensorRegistry> &tensor_reg,
+                                 const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                                  const std::shared_ptr<ExternalContext> &external_context)
   : basic::KernelGeneratorBase{graph}, _dyn_tensor_manager{dyn_tensor_manager},
     _tensor_reg{tensor_reg}, _tensor_registries{}, _executors{nullptr}, _model_index{},
-    _external_context{external_context}
+    _kernel_builder{kernel_builder}, _external_context{external_context}
 {
   // DO NOTHING
 }
@@ -57,6 +58,33 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   ret->append(std::move(_return_fn));
 
   return ret;
+}
+
+void KernelGenerator::visit(const ir::operation::Custom &node)
+{
+  auto fill_op_info = [&](const ir::OperandIndexSequence &opSeq,
+                          std::vector<custom::TypeInfo> &types,
+                          std::vector<IPortableTensor *> &tensors) {
+    for (const auto &idx : opSeq)
+    {
+      const auto &operand = _graph.operands().at(idx);
+      types.emplace_back(custom::TypeInfo{operand.shape(), operand.typeInfo().type()});
+      auto in_tensor = _tensor_reg->getPortableTensor(idx);
+      tensors.emplace_back(in_tensor);
+    }
+  };
+
+  backend::custom::CustomKernelConfigParams params{};
+
+  fill_op_info(node.getInputs(), params.input_types, params.input_tensors);
+  fill_op_info(node.getOutputs(), params.output_types, params.output_tensors);
+
+  params.userdata = node.userdata().data;
+  params.userdata_size = node.userdata().size;
+
+  auto fn = _kernel_builder->buildKernel(node.id(), std::move(params));
+
+  _return_fn = std::move(fn);
 }
 
 void KernelGenerator::visit(const ir::operation::Call &node)

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.h
@@ -23,6 +23,7 @@
 #include "../../compiler/TensorRegistries.h"
 
 #include "backend/basic/KernelGeneratorBase.h"
+#include "backend/CustomKernelBuilder.h"
 #include "exec/IExecutors.h"
 #include "ir/Graph.h"
 
@@ -34,6 +35,7 @@ class KernelGenerator : public basic::KernelGeneratorBase
 public:
   KernelGenerator(const ir::Graph &graph, DynamicTensorManager *dyn_tensor_manager,
                   const std::shared_ptr<TensorRegistry> &tensor_reg,
+                  const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                   const std::shared_ptr<ExternalContext> &external_context);
 
   void setTensorRegistries(const compiler::TensorRegistries &tensor_registries)
@@ -51,6 +53,7 @@ public:
   std::unique_ptr<exec::FunctionSequence> generate(ir::OperationIndex ind) override;
 
 private:
+  void visit(const ir::operation::Custom &) override;
   void visit(const ir::operation::Call &) override;
   void visit(const ir::operation::If &) override;
   void visit(const ir::operation::Permute &) override;
@@ -66,6 +69,7 @@ private:
   compiler::TensorRegistries _tensor_registries;
   exec::IExecutors *_executors;
   ir::ModelIndex _model_index;
+  std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
   const std::shared_ptr<ExternalContext> _external_context;
 };
 

--- a/runtime/onert/core/src/compiler/CompilerOptions.cc
+++ b/runtime/onert/core/src/compiler/CompilerOptions.cc
@@ -110,12 +110,15 @@ std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig()
 
 void CompilerOptions::forceInternalOptions()
 {
-  // Set control flow backend for control flow operators
+  // Set builtin backend for control flow operators
   auto &builtin_id = backend::builtin::Config::ID;
   manual_scheduler_options.opcode_to_backend[ir::OpCode::If] = builtin_id;
   manual_scheduler_options.opcode_to_backend[ir::OpCode::While] = builtin_id;
   manual_scheduler_options.opcode_to_backend[ir::OpCode::Call] = builtin_id;
   manual_scheduler_options.opcode_to_backend[ir::OpCode::Permute] = builtin_id;
+
+  // Set builtin backend for custom operator
+  manual_scheduler_options.opcode_to_backend[ir::OpCode::Custom] = builtin_id;
 
   // FIXME This is a workaround for bcq operations, should remove it
   manual_scheduler_options.opcode_to_backend[ir::OpCode::BCQFullyConnected] = "bcq";

--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -66,8 +66,6 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
   {
     op_type_map.emplace(op_code, BackendManager::get().get(backend_name));
   }
-  // By default, Custom uses cpu backend
-  op_type_map[ir::OpCode::Custom] = BackendManager::get().get("cpu");
 
   graph.operations().iterate([&](const ir::OperationIndex &index, const ir::IOperation &operation) {
     auto itr = op_type_map.find(operation.opcode());


### PR DESCRIPTION
This commit changes custom operator backend from CPU to builtin backend to remove backend dependency with handling custom operator.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>