### PR TITLE
[locop] Fix an error when building with `gcc-15`

### DIFF
--- a/compiler/locop/include/locop/NodeSummary.h
+++ b/compiler/locop/include/locop/NodeSummary.h
@@ -17,6 +17,7 @@
 #ifndef __LOCO_NODE_SUMMARY_H__
 #define __LOCO_NODE_SUMMARY_H__
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>


### PR DESCRIPTION
This commit fixes an `'uint32_t' does not name a type` error emitted by `gcc-15` for the `NodeSummary.h` header file

this PR fix same issue as https://github.com/Samsung/ONE/pull/15967, but in different header file

```
In file included from (...)/compiler/locop/src/NodeSummary.cpp:17:
(...)/compiler/locop/include/locop/NodeSummary.h:41:3: error: 'uint32_t' does not name a type
   41 |   uint32_t count(void) const { return _args.size(); }
      |   ^~~~~~~~
(...)/compiler/locop/include/locop/NodeSummary.h:25:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```

ONE-DCO-1.0-Signed-off-by: Marcin Słowiński <m.slowinski2@samsung.com>