### PR TITLE
[onert] Fix the errors when building with `gcc-15`

### DIFF
--- a/runtime/onert/core/include/backend/basic/Allocator.h
+++ b/runtime/onert/core/include/backend/basic/Allocator.h
@@ -22,6 +22,7 @@
 #ifndef __ONERT_BACKEND_BASIC_ALLOCATOR_H__
 #define __ONERT_BACKEND_BASIC_ALLOCATOR_H__
 
+#include <cstdint>
 #include <memory>
 
 namespace onert::backend::basic

--- a/runtime/onert/core/include/util/Set.h
+++ b/runtime/onert/core/include/util/Set.h
@@ -24,6 +24,7 @@
 #define __ONERT_UTIL_SET_H__
 
 #include <cassert>
+#include <cstdint>
 #include <unordered_set>
 
 namespace onert::util


### PR DESCRIPTION
This commit fixes an `'uint32_t' does not name a type` errors emitted by `gcc-15` for the `Allocator.h` and `Set.h` header files

this PR fix same issue as https://github.com/Samsung/ONE/pull/15967, but in different header files

```
(...)/runtime/onert/core/include/backend/basic/Allocator.h:42:3: error: 'uint8_t' does not name a type
   42 |   uint8_t *base() const { return _base.get(); }
      |   ^~~~~~~
(...)/runtime/onert/core/include/backend/basic/Allocator.h:27:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'


(...)/runtime/onert/core/include/util/Set.h:81:3: error: 'uint32_t' does not name a type [-Wtemplate-body]
   81 |   uint32_t size() const { return static_cast<uint32_t>(_set.size()); }
      |   ^~~~~~~~
(...)/runtime/onert/core/include/util/Set.h:29:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```

ONE-DCO-1.0-Signed-off-by: Marcin Słowiński <m.slowinski2@samsung.com>