### PR TITLE
[onert] Remove custom kernel builder from backends

### DIFF
--- a/runtime/onert/backend/cpu/Backend.h
+++ b/runtime/onert/backend/cpu/Backend.h
@@ -38,15 +38,14 @@ public:
 
   std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto custom_kernel_builder = data.custom_kernel_builder;
     auto &graph = *data.graph;
     auto context = std::make_unique<BackendContext>(this, std::move(data));
     auto tr = std::make_shared<basic::TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr, findSharedMemoryOperandIndexes(graph));
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, custom_kernel_builder,
-                                                            context->external_context());
+    context->kernel_gen =
+      std::make_shared<KernelGenerator>(graph, tb, tr, context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -226,14 +226,12 @@ ops::ReduceType convertReduceType(ir::operation::Reduce::ReduceType reduce_type_
 }
 } // namespace
 
-KernelGenerator::KernelGenerator(
-  const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
-  const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
-  const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
-  const std::shared_ptr<ExternalContext> &external_context)
+KernelGenerator::KernelGenerator(const ir::Graph &graph,
+                                 const std::shared_ptr<TensorBuilder> &tensor_builder,
+                                 const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
+                                 const std::shared_ptr<ExternalContext> &external_context)
   : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
-    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _kernel_builder(kernel_builder),
-    _external_context(external_context)
+    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _external_context(external_context)
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -22,7 +22,6 @@
 #include "backend/basic/TensorRegistry.h"
 #include "Tensor.h"
 
-#include <backend/CustomKernelBuilder.h>
 #include <backend/basic/KernelGeneratorBase.h>
 #include <ir/Operands.h>
 #include <ir/Operations.h>
@@ -35,7 +34,6 @@ class KernelGenerator : public basic::KernelGeneratorBase
 public:
   KernelGenerator(const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
                   const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
-                  const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                   const std::shared_ptr<ExternalContext> &external_context);
 
   std::unique_ptr<exec::FunctionSequence> generate(ir::OperationIndex op_ind) override;
@@ -99,7 +97,6 @@ private:
   const ir::Operations &_operations_ctx;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<basic::TensorRegistry> _tensor_reg;
-  std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
   const std::shared_ptr<ExternalContext> _external_context;
 };
 

--- a/runtime/onert/backend/ruy/Backend.h
+++ b/runtime/onert/backend/ruy/Backend.h
@@ -37,15 +37,14 @@ public:
 
   std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto custom_kernel_builder = data.custom_kernel_builder;
     auto &graph = *data.graph;
     auto context = std::make_unique<BackendContext>(this, std::move(data));
     auto tr = std::make_shared<basic::TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, custom_kernel_builder,
-                                                            context->external_context());
+    context->kernel_gen =
+      std::make_shared<KernelGenerator>(graph, tb, tr, context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/ruy/KernelGenerator.cc
+++ b/runtime/onert/backend/ruy/KernelGenerator.cc
@@ -62,14 +62,12 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   return ret;
 }
 
-KernelGenerator::KernelGenerator(
-  const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
-  const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
-  const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
-  const std::shared_ptr<ExternalContext> &external_context)
+KernelGenerator::KernelGenerator(const ir::Graph &graph,
+                                 const std::shared_ptr<TensorBuilder> &tensor_builder,
+                                 const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
+                                 const std::shared_ptr<ExternalContext> &external_context)
   : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
-    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _kernel_builder(kernel_builder),
-    _external_context(external_context)
+    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _external_context(external_context)
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/ruy/KernelGenerator.h
+++ b/runtime/onert/backend/ruy/KernelGenerator.h
@@ -22,7 +22,6 @@
 #include "backend/basic/TensorRegistry.h"
 #include "Tensor.h"
 
-#include <backend/CustomKernelBuilder.h>
 #include <backend/basic/KernelGeneratorBase.h>
 #include <ir/Operands.h>
 #include <ir/Operations.h>
@@ -35,7 +34,6 @@ class KernelGenerator : public basic::KernelGeneratorBase
 public:
   KernelGenerator(const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
                   const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
-                  const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                   const std::shared_ptr<ExternalContext> &external_context);
 
   std::unique_ptr<exec::FunctionSequence> generate(ir::OperationIndex ind) override;
@@ -49,7 +47,6 @@ private:
   const ir::Operations &_operations_ctx;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<basic::TensorRegistry> _tensor_reg;
-  std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
   const std::shared_ptr<ExternalContext> _external_context;
 };
 


### PR DESCRIPTION
This commit removes the custom kernel builder functionality from both the CPU and Ruy backends.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

For https://github.com/Samsung/ONE/pull/15989#discussion_r2318352101