### PR TITLE
[onert/test] Apply strict build to runtime lib unittest

### DIFF
--- a/runtime/libs/misc/CMakeLists.txt
+++ b/runtime/libs/misc/CMakeLists.txt
@@ -15,7 +15,7 @@ endif(NOT ENABLE_TEST)
 
 add_executable(nnfw_lib_misc_test ${TESTS})
 target_link_libraries(nnfw_lib_misc_test PRIVATE nnfw_lib_misc)
-target_link_libraries(nnfw_lib_misc_test PRIVATE nnfw_coverage)
+target_link_libraries(nnfw_lib_misc_test PRIVATE nnfw_common nnfw_coverage)
 target_link_libraries(nnfw_lib_misc_test PUBLIC gtest gtest_main ${LIB_PTHREAD})
 
 add_test(nnfw_lib_misc_test nnfw_lib_misc_test)

--- a/runtime/libs/misc/src/tensor/IndexIterator.test.cpp
+++ b/runtime/libs/misc/src/tensor/IndexIterator.test.cpp
@@ -56,6 +56,6 @@ TEST(MiscIndexIteratorTest, neg_zero_rank_shape)
   // It is expected not to throw any exception, do nothing
   const Shape shape{};
 
-  ASSERT_NO_THROW(iterate(shape) << ([](const Index &index) {}));
+  ASSERT_NO_THROW(iterate(shape) << ([](const Index &) {}));
   SUCCEED();
 }

--- a/runtime/libs/ndarray/CMakeLists.txt
+++ b/runtime/libs/ndarray/CMakeLists.txt
@@ -19,7 +19,7 @@ endif(NOT ENABLE_TEST)
 
 add_executable(ndarray_test src/Array.test.cpp src/ContiguousSpan.test.cpp)
 target_link_libraries(ndarray_test PRIVATE ndarray)
-target_link_libraries(ndarray_test PRIVATE nnfw_coverage)
+target_link_libraries(ndarray_test PRIVATE nnfw_common nnfw_coverage)
 target_link_libraries(ndarray_test PUBLIC gtest gtest_main ${LIB_PTHREAD})
 
 add_test(ndarray_test ndarray_test)


### PR DESCRIPTION
This commit applies strict build to runtime lib unittests.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>