### PR TITLE
[onert] Apply strict build to compute unittests

### DIFF
--- a/runtime/compute/cker/CMakeLists.txt
+++ b/runtime/compute/cker/CMakeLists.txt
@@ -36,7 +36,7 @@ file(GLOB_RECURSE TESTS "src/*.test.cc")
 add_executable(${TEST_CKER} ${TESTS})
 
 target_link_libraries(${TEST_CKER} nnfw_lib_cker)
-target_link_libraries(${TEST_CKER} nnfw_coverage)
+target_link_libraries(${TEST_CKER} nnfw_common nnfw_coverage)
 target_link_libraries(${TEST_CKER} gtest gtest_main ${LIB_PTHREAD})
 
 add_test(${TEST_CKER} ${TEST_CKER})

--- a/runtime/compute/cker/src/DepthwiseConv.test.cc
+++ b/runtime/compute/cker/src/DepthwiseConv.test.cc
@@ -75,7 +75,7 @@ public:
                       const nnfw::cker::Shape &input_shape, const T *input_data,
                       const nnfw::cker::Shape &filter_shape, const T *filter_data,
                       const nnfw::cker::Shape &bias_shape, const T *bias_data,
-                      const nnfw::cker::Shape &output_shape, const T *expected)
+                      const nnfw::cker::Shape &output_shape, const T *)
   {
     std::vector<T> output(output_shape.FlatSize());
     EXPECT_ANY_THROW(

--- a/runtime/compute/cker/src/Range.test.cc
+++ b/runtime/compute/cker/src/Range.test.cc
@@ -28,7 +28,7 @@ TEST(CKer_Operation, Range)
     std::vector<int> actual(10);
     nnfw::cker::Range<int>(&start, &limit, &delta, actual.data());
 
-    for (int i = 0; i < actual.size(); i++)
+    for (size_t i = 0; i < actual.size(); i++)
       ASSERT_EQ(actual[i], i);
   }
 
@@ -40,7 +40,7 @@ TEST(CKer_Operation, Range)
     std::vector<int> actual(expected.size());
     nnfw::cker::Range<int>(&start, &limit, &delta, actual.data());
 
-    for (int i = 0; i < actual.size(); i++)
+    for (size_t i = 0; i < actual.size(); i++)
       ASSERT_EQ(actual[i], expected[i]);
   }
 
@@ -52,7 +52,7 @@ TEST(CKer_Operation, Range)
     std::vector<float> actual(expected.size());
     nnfw::cker::Range<float>(&start, &limit, &delta, actual.data());
 
-    for (int i = 0; i < actual.size(); i++)
+    for (size_t i = 0; i < actual.size(); i++)
       ASSERT_FLOAT_EQ(actual[i], expected[i]);
   }
 }

--- a/runtime/compute/cker/src/StridedSlice.test.cc
+++ b/runtime/compute/cker/src/StridedSlice.test.cc
@@ -56,7 +56,7 @@ TEST(CKer_Operation, StridedSlice5D)
 
 TEST(CKer_Operation, neg_StridedSliceNotSupportedDims)
 {
-  nnfw::cker::StridedSliceParams op_params{};
+  [[maybe_unused]] nnfw::cker::StridedSliceParams op_params{};
   op_params.start_indices_count = 5;
   op_params.stop_indices_count = 5;
   op_params.strides_count = 5;

--- a/runtime/compute/cker/src/train/Adam.test.cc
+++ b/runtime/compute/cker/src/train/Adam.test.cc
@@ -72,7 +72,7 @@ private:
 
     const T alpha = _learning_rate * std::sqrt(static_cast<T>(1) - beta2_power) /
                     (static_cast<T>(1) - beta1_power);
-    for (int i = 0; i < _expected.size(); ++i)
+    for (size_t i = 0; i < _expected.size(); ++i)
     {
       T m = _m.at(i);
       T v = _v.at(i);

--- a/runtime/compute/cker/src/train/AveragePool.test.cc
+++ b/runtime/compute/cker/src/train/AveragePool.test.cc
@@ -44,8 +44,8 @@ public:
   void verifyForward(const std::vector<T> input, const std::vector<T> expected_output,
                      bool expect_eq = true)
   {
-    assert(input.size() == _in_shape.FlatSize());
-    assert(expected_output.size() == _out_shape.FlatSize());
+    assert(input.size() == static_cast<size_t>(_in_shape.FlatSize()));
+    assert(expected_output.size() == static_cast<size_t>(_out_shape.FlatSize()));
 
     std::vector<T> cacluated_output(_out_shape.FlatSize());
     nnfw::cker::AveragePool<float>(_op_params, _in_shape, input.data(), _out_shape,
@@ -60,8 +60,8 @@ public:
   void verifyBackward(const std::vector<T> incoming_data, const std::vector<T> expected_grad_data,
                       bool expect_eq = true)
   {
-    assert(incoming_data.size() == _out_shape.FlatSize());
-    assert(expected_grad_data.size() == _in_shape.FlatSize());
+    assert(incoming_data.size() == static_cast<size_t>(_out_shape.FlatSize()));
+    assert(expected_grad_data.size() == static_cast<size_t>(_in_shape.FlatSize()));
 
     std::vector<T> calcuated_grad(_in_shape.FlatSize());
     nnfw::cker::train::AveragePool2DGrad(_op_params, _out_shape, incoming_data.data(), _in_shape,

--- a/runtime/compute/cker/src/train/Loss.test.cc
+++ b/runtime/compute/cker/src/train/Loss.test.cc
@@ -37,8 +37,6 @@ public:
     assert(y_pred.size() == y_true.size());
 
     std::vector<T> output(_out_shape.FlatSize());
-    const int N = _in_shape.Dims(0);
-    const int D = _in_shape.FlatSize() / N;
 
     nnfw::cker::train::CategoricalCrossEntropy(_in_shape, y_pred.data(), _in_shape, y_true.data(),
                                                _out_shape, output.data());
@@ -46,20 +44,18 @@ public:
     // Don't be panic when it fails after kernel implementation or input is changed.
     // CrossEntropy formula can be calculated slightly differently depending on the environment
     // because it involes calculations such as log or exp.
-    for (int i = 0; i < output.size(); ++i)
+    for (size_t i = 0; i < output.size(); ++i)
     {
       EXPECT_NEAR(output[i], expected[i], 1e-4f);
     }
   }
 
   void throwForward(const std::vector<T> &y_pred, const std::vector<T> &y_true,
-                    const std::vector<T> &expected)
+                    const std::vector<T> &)
   {
     assert(y_pred.size() == y_true.size());
 
     std::vector<T> output(_out_shape.FlatSize());
-    const int N = _in_shape.Dims(0);
-    const int D = _in_shape.FlatSize() / N;
 
     EXPECT_ANY_THROW(nnfw::cker::train::CategoricalCrossEntropy(
       _in_shape, y_pred.data(), _in_shape, y_true.data(), _out_shape, output.data()));
@@ -72,8 +68,6 @@ public:
     assert(y_pred.size() == y_true.size());
 
     std::vector<T> output(_in_shape.FlatSize());
-    const int N = _in_shape.Dims(0);
-    const int D = _in_shape.FlatSize() / N;
 
     nnfw::cker::train::CategoricalCrossEntropyGrad(
       _in_shape, y_pred.data(), _in_shape, y_true.data(), _out_shape, output.data(), reduction);
@@ -81,7 +75,7 @@ public:
     // Don't be panic when it fails after kernel implementation or input is changed.
     // CrossEntropy Gradient formula can be calculated slightly differently depending on the
     // environment because it involes calculations such as log or exp.
-    for (int i = 0; i < output.size(); ++i)
+    for (size_t i = 0; i < output.size(); ++i)
     {
       EXPECT_NEAR(output[i], expected[i], 1e-4f);
     }
@@ -102,33 +96,31 @@ public:
                                                          y_true.data(), _out_shape, loss_out.data(),
                                                          _in_shape, grad.data(), reduction);
 
-    for (int i = 0; i < loss_out.size(); ++i)
+    for (size_t i = 0; i < loss_out.size(); ++i)
     {
       EXPECT_NEAR(loss_out[i], expected_loss_out[i], 1e-4f);
     }
 
-    for (int i = 0; i < grad.size(); ++i)
+    for (size_t i = 0; i < grad.size(); ++i)
     {
       EXPECT_NEAR(grad[i], expected_grad[i], 1e-4f);
     }
   }
 
   void throwBackward(const std::vector<T> &y_pred, const std::vector<T> &y_true,
-                     const std::vector<T> &expected, nnfw::cker::train::LossReductionType reduction)
+                     const std::vector<T> &, nnfw::cker::train::LossReductionType reduction)
   {
     assert(y_pred.size() == y_true.size());
 
     std::vector<T> output(_out_shape.FlatSize());
-    const int N = _in_shape.Dims(0);
-    const int D = _in_shape.FlatSize() / N;
 
     EXPECT_ANY_THROW(nnfw::cker::train::CategoricalCrossEntropyGrad(
       _in_shape, y_pred.data(), _in_shape, y_true.data(), _out_shape, output.data(), reduction));
   }
 
   void throwBackwardWithLogits(const std::vector<T> &logits, const std::vector<T> &y_true,
-                               const std::vector<T> &expected_loss_out,
-                               const std::vector<T> &expected_grad,
+                               const std::vector<T> &,
+                               [[maybe_unused]] const std::vector<T> &expected_grad,
                                nnfw::cker::train::LossReductionType reduction)
   {
     assert(logits.size() == y_true.size());
@@ -186,7 +178,7 @@ TEST(CKer_Operation, LossMSE)
     nnfw::cker::train::MSE(nnfw::cker::Shape{2, 3}, y_pred.data(), nnfw::cker::Shape{2, 3},
                            y_true.data(), nnfw::cker::Shape{2}, output.data());
 
-    for (int i = 0; i < output.size(); ++i)
+    for (size_t i = 0; i < output.size(); ++i)
     {
       EXPECT_FLOAT_EQ(output[i], expected[i]);
     }
@@ -204,7 +196,7 @@ TEST(CKer_Operation, LossMSE)
     nnfw::cker::train::MSE(nnfw::cker::Shape{2, 3, 4}, y_pred.data(), nnfw::cker::Shape{2, 3, 4},
                            y_true.data(), nnfw::cker::Shape{2}, output.data());
 
-    for (int i = 0; i < output.size(); ++i)
+    for (size_t i = 0; i < output.size(); ++i)
     {
       EXPECT_FLOAT_EQ(output[i], expected[i]);
     }
@@ -223,7 +215,7 @@ TEST(CKer_Operation, neg_LossMSE)
     nnfw::cker::train::MSE(nnfw::cker::Shape{2, 5}, y_pred.data(), nnfw::cker::Shape{2, 5},
                            y_true.data(), nnfw::cker::Shape{2}, output.data());
 
-    for (int i = 0; i < output.size(); ++i)
+    for (size_t i = 0; i < output.size(); ++i)
     {
       EXPECT_NE(output[i], expected[i]);
     }

--- a/runtime/compute/cker/src/train/MaxPool.test.cc
+++ b/runtime/compute/cker/src/train/MaxPool.test.cc
@@ -47,8 +47,8 @@ public:
   void verifyForward(const std::vector<T> input, const std::vector<T> expected_output,
                      bool expect_eq = true)
   {
-    assert(input.size() == _in_shape.FlatSize());
-    assert(expected_output.size() == _out_shape.FlatSize());
+    assert(input.size() == static_cast<size_t>(_in_shape.FlatSize()));
+    assert(expected_output.size() == static_cast<size_t>(_out_shape.FlatSize()));
 
     std::vector<T> cacluated_output(_out_shape.FlatSize());
     nnfw::cker::train::MaxPool2D(_op_params, _in_shape, input.data(), _out_shape,
@@ -63,8 +63,8 @@ public:
   void verifyBackward(const std::vector<T> incoming_data, const std::vector<T> expected_grad_data,
                       bool expect_eq = true)
   {
-    assert(incoming_data.size() == _out_shape.FlatSize());
-    assert(expected_grad_data.size() == _in_shape.FlatSize());
+    assert(incoming_data.size() == static_cast<size_t>(_out_shape.FlatSize()));
+    assert(expected_grad_data.size() == static_cast<size_t>(_in_shape.FlatSize()));
 
     std::vector<T> calcuated_grad(_in_shape.FlatSize());
     nnfw::cker::train::MaxPool2DGrad(_out_shape, incoming_data.data(), _arg_max_index.data(),

--- a/runtime/compute/cker/src/train/Pad.test.cc
+++ b/runtime/compute/cker/src/train/Pad.test.cc
@@ -46,8 +46,8 @@ public:
   void verifyForward(const std::vector<T> input, const std::vector<T> expected_output,
                      bool expect_eq = true)
   {
-    assert(input.size() == _in_shape.FlatSize());
-    assert(expected_output.size() == _out_shape.FlatSize());
+    assert(input.size() == static_cast<size_t>(_in_shape.FlatSize()));
+    assert(expected_output.size() == static_cast<size_t>(_out_shape.FlatSize()));
 
     std::vector<T> cacluated_output(_out_shape.FlatSize());
     nnfw::cker::Pad(_op_params.data, _op_params.rank, _in_shape, input.data(), _out_shape,
@@ -62,8 +62,8 @@ public:
   void verifyBackward(const std::vector<T> backward_output,
                       const std::vector<T> expected_backward_input, bool expect_eq = true)
   {
-    assert(backward_output.size() == _out_shape.FlatSize());
-    assert(expected_backward_input.size() == _in_shape.FlatSize());
+    assert(backward_output.size() == static_cast<size_t>(_out_shape.FlatSize()));
+    assert(expected_backward_input.size() == static_cast<size_t>(_in_shape.FlatSize()));
 
     std::vector<T> backward_input(_in_shape.FlatSize());
     nnfw::cker::train::Depad(_op_params.data, _op_params.rank, _out_shape, backward_output.data(),

--- a/runtime/compute/cker/src/train/ReduceMean.test.cc
+++ b/runtime/compute/cker/src/train/ReduceMean.test.cc
@@ -39,8 +39,8 @@ public:
   void verifyForward(const std::vector<T> &input, const std::vector<T> &expected,
                      bool expect_eq = true)
   {
-    assert(input.size() == _in_shape.FlatSize());
-    assert(expected.size() == _out_shape.FlatSize());
+    assert(input.size() == static_cast<size_t>(_in_shape.FlatSize()));
+    assert(expected.size() == static_cast<size_t>(_out_shape.FlatSize()));
 
     std::vector<T> output(_out_shape.FlatSize());
 
@@ -69,7 +69,7 @@ public:
     if (expect_eq)
     {
       // consider the floating point error
-      for (int i = 0; i < grad.size(); ++i)
+      for (size_t i = 0; i < grad.size(); ++i)
       {
         EXPECT_NEAR(grad[i], expected[i], 1e-3f);
       }

--- a/runtime/compute/cker/src/train/SGD.test.cc
+++ b/runtime/compute/cker/src/train/SGD.test.cc
@@ -55,7 +55,7 @@ private:
   {
     assert(_expected.size() == _gradient.size());
 
-    for (int i = 0; i < _expected.size(); ++i)
+    for (size_t i = 0; i < _expected.size(); ++i)
     {
       T g = _gradient.at(i);
       T &var = _expected.at(i);


### PR DESCRIPTION
This commit applies strict build to comput library unittests.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>