### PR TITLE
Draft: [onert] Apply cast-align build option

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -112,16 +112,11 @@ if(${ENABLE_COVERAGE} AND NOT ${ENABLE_TEST})
   message(FATAL_ERROR "Test should be enabled to measure test coverage")
 endif(${ENABLE_COVERAGE} AND NOT ${ENABLE_TEST})
 
+# TODO Apply -Wshadow option
 add_library(nnfw_common INTERFACE)
 if(ENABLE_STRICT_BUILD)
-  target_compile_options(nnfw_common INTERFACE -Werror -Wall -Wextra)
+  target_compile_options(nnfw_common INTERFACE -Werror -Wall -Wextra -Wcast-align)
 endif(ENABLE_STRICT_BUILD)
-
-macro(nnfw_strict_build TARGET)
-  if(ENABLE_STRICT_BUILD)
-    target_compile_options(${TARGET} PRIVATE -Werror -Wall -Wextra)
-  endif(ENABLE_STRICT_BUILD)
-endmacro(nnfw_strict_build)
 
 # TODO Replace using default build option setting in cmake/buildtool/config/config_linux.cmake
 #      to link nnfw_coverage on each module which want to check coverage


### PR DESCRIPTION
This commit adds strict build option "-Wcast-align". 
It includes removing unused nnfw_strict_build macro.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>