### PR TITLE
[circle-verify] Use mio-circle

### DIFF
--- a/compiler/circle-verify/CMakeLists.txt
+++ b/compiler/circle-verify/CMakeLists.txt
@@ -1,14 +1,14 @@
-if(NOT TARGET mio_circle08)
-  message(STATUS "Skip circle-verify: mio_circle08 not found")
+if(NOT TARGET mio_circle)
+  message(STATUS "Skip circle-verify: mio_circle not found")
   return()
-endif(NOT TARGET mio_circle08)
+endif(NOT TARGET mio_circle)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 add_executable(circle-verify ${SOURCES})
 target_include_directories(circle-verify PRIVATE src)
 target_link_libraries(circle-verify arser)
-target_link_libraries(circle-verify mio_circle08)
+target_link_libraries(circle-verify mio_circle)
 target_link_libraries(circle-verify safemain)
 target_link_libraries(circle-verify cwrap)
 target_link_libraries(circle-verify foder)

--- a/compiler/circle-verify/requires.cmake
+++ b/compiler/circle-verify/requires.cmake
@@ -1,5 +1,5 @@
 require("arser")
-require("mio-circle08")
+require("mio-circle")
 require("safemain")
 require("cwrap")
 require("foder")


### PR DESCRIPTION
This will revise to use mio-circle, without version number.
