### PR TITLE
[github] Adjust runners for circle-mlir and onecc

### DIFF
--- a/.github/workflows/run-circle-mlir-build.yml
+++ b/.github/workflows/run-circle-mlir-build.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.run_matrix) }}
 
-    runs-on: ubuntu-latest
+    runs-on: one-x64-linux
 
     container:
       image: nnfw/circle-mlir-build:${{ matrix.ubuntu_code }}

--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   prepare:
     if: github.repository_owner == 'Samsung'
-    runs-on: one-x64-linux
+    runs-on: ubuntu-latest
     outputs:
       run_matrix: ${{ steps.set-matrix.outputs.run_matrix }}
     steps:


### PR DESCRIPTION
This will adjust runners for circle-mlir and onecc
- run prepare on ubuntu-latest, by github
- run test on one-x64-linux, by us
