### PR TITLE
[onert] Refactor custom kernel builder handling

### DIFF
--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -40,8 +40,6 @@ struct ContextData
   std::vector<onert::ir::OperationIndex> op_order;
   /* Operands that are defined by other backends */
   util::Set<ir::OperandIndex> external_operands;
-  /* Custom kernel builder */
-  std::shared_ptr<custom::IKernelBuilder> custom_kernel_builder;
   /* Is linear executor or not */
   bool is_linear_executor;
 };

--- a/runtime/onert/core/include/backend/train/TrainableBackendContext.h
+++ b/runtime/onert/core/include/backend/train/TrainableBackendContext.h
@@ -40,8 +40,6 @@ struct TrainableContextData
   std::vector<onert::ir::OperationIndex> op_order;
   /* Operands that are defined by other backends */
   util::Set<ir::OperandIndex> external_operands;
-  /* Custom kernel builder */
-  std::shared_ptr<custom::IKernelBuilder> custom_kernel_builder;
   /* Is linear executor or not */
   bool is_linear_executor;
   /* Optimizer information */

--- a/runtime/onert/core/src/backend/builtin/Backend.h
+++ b/runtime/onert/core/src/backend/builtin/Backend.h
@@ -66,8 +66,7 @@ public:
     context->tensor_registry = tr;
     context->tensor_builder = tb;
     context->kernel_gen = std::make_shared<KernelGenerator>(
-      *context->graph(), tb->dynamicTensorManager(), tr, context->data().custom_kernel_builder,
-      context->external_context());
+      *context->graph(), tb->dynamicTensorManager(), tr, context->external_context());
     return context;
   }
 

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -28,11 +28,10 @@ namespace onert::backend::builtin
 
 KernelGenerator::KernelGenerator(const ir::Graph &graph, DynamicTensorManager *dyn_tensor_manager,
                                  const std::shared_ptr<TensorRegistry> &tensor_reg,
-                                 const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                                  const std::shared_ptr<ExternalContext> &external_context)
   : basic::KernelGeneratorBase{graph}, _dyn_tensor_manager{dyn_tensor_manager},
     _tensor_reg{tensor_reg}, _tensor_registries{}, _executors{nullptr}, _model_index{},
-    _kernel_builder{kernel_builder}, _external_context{external_context}
+    _external_context{external_context}
 {
   // DO NOTHING
 }
@@ -82,7 +81,7 @@ void KernelGenerator::visit(const ir::operation::Custom &node)
   params.userdata = node.userdata().data;
   params.userdata_size = node.userdata().size;
 
-  auto fn = _kernel_builder->buildKernel(node.id(), std::move(params));
+  auto fn = _custom_kernel_builder->buildKernel(node.id(), std::move(params));
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.h
@@ -35,7 +35,6 @@ class KernelGenerator : public basic::KernelGeneratorBase
 public:
   KernelGenerator(const ir::Graph &graph, DynamicTensorManager *dyn_tensor_manager,
                   const std::shared_ptr<TensorRegistry> &tensor_reg,
-                  const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                   const std::shared_ptr<ExternalContext> &external_context);
 
   void setTensorRegistries(const compiler::TensorRegistries &tensor_registries)
@@ -49,6 +48,11 @@ public:
   }
 
   void setModelIndex(const ir::ModelIndex &index) { _model_index = index; }
+
+  void setCustomKernelBuilder(const std::shared_ptr<custom::IKernelBuilder> &custom_kernel_builder)
+  {
+    _custom_kernel_builder = custom_kernel_builder;
+  }
 
   std::unique_ptr<exec::FunctionSequence> generate(ir::OperationIndex ind) override;
 
@@ -69,7 +73,7 @@ private:
   compiler::TensorRegistries _tensor_registries;
   exec::IExecutors *_executors;
   ir::ModelIndex _model_index;
-  std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
+  std::shared_ptr<backend::custom::IKernelBuilder> _custom_kernel_builder;
   const std::shared_ptr<ExternalContext> _external_context;
 };
 

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -65,10 +65,10 @@ private:
 private:
   static void prepareMigrantTensors(compiler::ILoweredGraph &lowered_graph,
                                     const backend::BackendContexts &backend_contexts);
-  static void prepareBuiltinBackend(const TensorRegistries &tensor_regs,
-                                    const std::shared_ptr<exec::IExecutors> &executors,
-                                    const backend::BackendContexts &backend_contexts,
-                                    const ir::ModelIndex &index);
+  static void prepareBuiltinBackend(
+    const TensorRegistries &tensor_regs, const std::shared_ptr<exec::IExecutors> &executors,
+    const backend::BackendContexts &backend_contexts, const ir::ModelIndex &index,
+    const std::shared_ptr<backend::custom::IKernelBuilder> &custom_kernel_builder);
   static std::deque<std::pair<const backend::Backend *, backend::BackendContext *>>
   orderBackendContext(const backend::BackendContexts &backend_contexts);
 


### PR DESCRIPTION
This commit removes custom_kernel_builder from ContextData and TrainableContextData structures becuase custom_kernel_builder is used on builtin backend only. 
Instead of passing it through the ContextData, add a setCustomKernelBuilder method to builtin KernelGenerator.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>