### PR TITLE
[infra/gbs] Customize build for profile

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -27,7 +27,11 @@ Source3016: XNNPACK.tar.gz
 
 %{!?build_type:     %define build_type      Release}
 %{!?trix_support:   %define trix_support    1}
+%if "%{?profile}" == "tv"
+%{!?odc_build:      %define odc_build       0}
+%else # "%{?profile}" == "tv"
 %{!?odc_build:      %define odc_build       1}
+%endif
 %{!?test_build:     %define test_build      0}
 %{!?extra_option:   %define extra_option    %{nil}}
 # Define nproc on gbs build option if you want to set number of build threads manually (ex. CI/CD infra)
@@ -41,10 +45,11 @@ Requires(postun): /sbin/ldconfig
 
 %if %{test_build} == 1
 BuildRequires:  pkgconfig(tensorflow2-lite)
+%if "%{?profile}" != "tv"
 BuildRequires:  hdf5-devel-static
 BuildRequires:  libaec-devel
 BuildRequires:  pkgconfig(zlib)
-BuildRequires:  pkgconfig(libjpeg)
+%endif
 BuildRequires:  gtest-devel
 %endif
 


### PR DESCRIPTION
This commit updates nnfw.spec file for gbs build
- Change default odc_build to disable when profile is "tv"
- Exclude hdf5-devel-static, libaec-devel, pkgconfig(zlib) for TV profile: unsupported packages

Additionally, it remove unused pkgconfig(libjpeg) dependency entirely

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>