### PR TITLE
[res/tflite] Remove graph I/O for constants

### DIFF
--- a/res/TensorFlowLiteRecipes/DepthwiseConv2D_U8_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/DepthwiseConv2D_U8_001/test.recipe
@@ -57,5 +57,4 @@ operation {
   output: "ofm"
 }
 input: "ifm"
-input: "ker"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/GatherNd_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/GatherNd_000/test.recipe
@@ -22,5 +22,4 @@ operation {
   output: "ofm"
 }
 input: "param"
-input: "indices"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/GatherNd_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/GatherNd_001/test.recipe
@@ -27,5 +27,4 @@ operation {
   output: "ofm"
 }
 input: "param"
-input: "indices"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/OneHot_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/OneHot_003/test.recipe
@@ -38,6 +38,4 @@ operation {
   output: "ofm"
 }
 input: "indices"
-input: "on_value"
-input: "off_value"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/ReverseSequence_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/ReverseSequence_000/test.recipe
@@ -28,5 +28,4 @@ operation {
   output: "ofm"
 }
 input: "ifm"
-input: "seq_lengths"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/ReverseV2_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/ReverseV2_000/test.recipe
@@ -26,5 +26,4 @@ operation {
   output: "ofm"
 }
 input: "ifm"
-input: "axis"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/ScatterNd_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/ScatterNd_000/test.recipe
@@ -35,6 +35,5 @@ operation {
   input: "shape"
   output: "ofm"
 }
-input: "indices"
 input: "updates"
 output: "ofm"


### PR DESCRIPTION
This will revise tflite recipes not to be graph I/O for constants.
