### PR TITLE
[tflchef/tests] Remove graph I/O for constants

### DIFF
--- a/compiler/tflchef/tests/no_shape/test.recipe
+++ b/compiler/tflchef/tests/no_shape/test.recipe
@@ -38,6 +38,4 @@ operation {
   output: "ofm"
 }
 input: "indices"
-input: "on_value"
-input: "off_value"
 output: "ofm"

--- a/compiler/tflchef/tests/readme/test.recipe
+++ b/compiler/tflchef/tests/readme/test.recipe
@@ -40,5 +40,4 @@ operation {
   output: "ofm"
 }
 input: "ifm"
-input: "ker"
 output: "ofm"

--- a/compiler/tflchef/tests/short_int_datatype/test.recipe
+++ b/compiler/tflchef/tests/short_int_datatype/test.recipe
@@ -40,5 +40,4 @@ operation {
   output: "ofm"
 }
 input: "ifm"
-input: "ker"
 output: "ofm"


### PR DESCRIPTION
This will revise test recipes not to be graph I/O for constants.
