### PR TITLE
[infra/gbs] Disable on-device compiler

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -27,11 +27,7 @@ Source3016: XNNPACK.tar.gz
 
 %{!?build_type:     %define build_type      Release}
 %{!?trix_support:   %define trix_support    1}
-%if "%{?profile}" == "tv"
 %{!?odc_build:      %define odc_build       0}
-%else # "%{?profile}" == "tv"
-%{!?odc_build:      %define odc_build       1}
-%endif
 %{!?test_build:     %define test_build      0}
 %{!?extra_option:   %define extra_option    %{nil}}
 # Define nproc on gbs build option if you want to set number of build threads manually (ex. CI/CD infra)


### PR DESCRIPTION
This commit disables on-device compiler build on tizen gbs build as default. 
It's not simple to matching external library source version. (ex. used for luci-compute)

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>