### PR TITLE
[tflchef/reverse] Prohibit constant as graph I/O

### DIFF
--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -318,6 +318,18 @@ template <typename T> void ModelChef::cook_operands(const T &graph)
     // Create Buffer if filler is specified
     if (operand.has_filler())
     {
+      // prohibit constant as graph input/output
+      for (auto it = input_names.begin(); it != input_names.end(); ++it)
+      {
+        if (*it == operand.name())
+          throw std::runtime_error{"Constant '" + *it + "' cannot be graph I/O"};
+      }
+      for (auto it = output_names.begin(); it != output_names.end(); ++it)
+      {
+        if (*it == operand.name())
+          throw std::runtime_error{"Constant '" + *it + "' cannot be graph I/O"};
+      }
+
       const auto &filler = operand.filler();
 
       assert(filler.has_tag());


### PR DESCRIPTION
This will revise to prohibit constant as beging graph I/O.
