### PR TITLE
[infra] Support HDF5 build on CMake 4

### DIFF
--- a/infra/cmake/packages/HDF5Config.cmake
+++ b/infra/cmake/packages/HDF5Config.cmake
@@ -35,7 +35,8 @@ function(_HDF5_build)
                                  "-DHDF5_BUILD_EXAMPLES:BOOL=OFF"
                                  "-DHDF5_BUILD_TOOLS:BOOL=ON"
                                  "-DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF"
-                                 "-DHDF5_ENABLE_Z_LIB_SUPPORT:BOOL=OFF")
+                                 "-DHDF5_ENABLE_Z_LIB_SUPPORT:BOOL=OFF"
+                                 "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
 endfunction(_HDF5_build)
 


### PR DESCRIPTION
This commit adds CMAKE_POLICY_VERSION_MINIMUM=3.5 to HDF5 build configuration to avoid policy related errors with CMake versions 4.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>