### PR TITLE
[infra] Add patch to build TensorFlow without Ruy

### DIFF
--- a/infra/cmake/packages/TensorFlowSource-2.19.0/TensorFlowSource.patch
+++ b/infra/cmake/packages/TensorFlowSource-2.19.0/TensorFlowSource.patch
@@ -1,0 +1,13 @@
+diff --git a/tensorflow/lite/kernels/internal/reference/fully_connected.h b/tensorflow/lite/kernels/internal/reference/fully_connected.h
+index ba51cbcfe3e..d9d4e6ec5f7 100644
+--- a/tensorflow/lite/kernels/internal/reference/fully_connected.h
++++ b/tensorflow/lite/kernels/internal/reference/fully_connected.h
+@@ -17,7 +17,7 @@ limitations under the License.
+
+ #include <algorithm>
+
+-#include "ruy/profiler/instrumentation.h"  // from @ruy
++// #include "ruy/profiler/instrumentation.h"  // from @ruy
+ #include "tensorflow/lite/kernels/internal/common.h"
+ #include "tensorflow/lite/kernels/internal/cppmath.h"
+ #include "tensorflow/lite/kernels/internal/quantization_util.h"

--- a/infra/cmake/packages/TensorFlowSource-2.19.0/TensorFlowSourceConfig.cmake
+++ b/infra/cmake/packages/TensorFlowSource-2.19.0/TensorFlowSourceConfig.cmake
@@ -10,7 +10,12 @@ function(_TensorFlowSource_import)
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(TENSORFLOW_2_19_0_URL ${EXTERNAL_DOWNLOAD_SERVER}/tensorflow/tensorflow/archive/v2.19.0.tar.gz)
 
-  ExternalSource_Download(TENSORFLOW DIRNAME TENSORFLOW-2.19.0 ${TENSORFLOW_2_19_0_URL})
+  # Apply patch to build luci-compute without Ruy - comment out header include which is not using now
+  ExternalSource_Download(TENSORFLOW
+    DIRNAME TENSORFLOW-2.19.0
+    PATCH ${CMAKE_CURRENT_LIST_DIR}/TensorFlowSource.patch
+    ${TENSORFLOW_2_19_0_URL}
+  )
 
   set(TensorFlowSource_DIR ${TENSORFLOW_SOURCE_DIR} PARENT_SCOPE)
   set(TensorFlowSource_FOUND TRUE PARENT_SCOPE)


### PR DESCRIPTION
This commit adds TensorFlowSource.patch and update TensorFlowSourceConfig.cmake to apply the patch during download.
The patch comments out an unused header include to enable building luci-compute without the Ruy library dependency.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #16061