### PR TITLE
[infra/gbs] Update GBS config with latest and reference repos

### DIFF
--- a/runtime/infra/gbs/gbs.conf
+++ b/runtime/infra/gbs/gbs.conf
@@ -5,44 +5,35 @@ profile = profile.tizen
 [profile.tizen]
 repos = repo.base, repo.unified
 
-[profile.tizen_7]
-repos = repo.base_7, repo.unified_7
-
 [profile.tizen_8]
 repos = repo.base_8, repo.unified_8
 
 [profile.tizen_9]
 repos = repo.base_9, repo.unified_9
 
-[profile.tizen_x]
-repos = repo.base_x, repo.unified_x
+[profile.tizen_latest]
+repos = repo.base_latest, repo.unified_latest
 
-[repo.unified]
+[repo.unified_latest]
 url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/latest/repos/standard/packages/
 
-[repo.base]
+[repo.base_latest]
 url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/latest/repos/standard/packages/
 
-[repo.unified_7]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Unified/latest/repos/standard/packages/
+[repo.unified]
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/reference/repos/standard/packages/
 
-[repo.base_7]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Base/latest/repos/standard/packages/
+[repo.base]
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/reference/repos/standard/packages/
 
 [repo.unified_8]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Unified/latest/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Unified/reference/repos/standard/packages/
 
 [repo.base_8]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Base/latest/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Base/reference/repos/standard/packages/
 
 [repo.unified_9]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-9.0/Tizen-9.0-Unified/latest/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-9.0/Tizen-9.0-Unified/reference/repos/standard/packages/
 
 [repo.base_9]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-9.0/Tizen-9.0-Base/latest/repos/standard/packages/
-
-[repo.unified_x]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified-X/latest/repos/standard/packages/
-
-[repo.base_x]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base-X/latest/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-9.0/Tizen-9.0-Base/reference/repos/standard/packages/


### PR DESCRIPTION
- Remove deprecated tizen_x profiles
- Remove tizen_7 profiles
- Add new tizen_latest profile pointing to latest repositories
- Change repository URLs from "latest" to "reference" for stable builds

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>