### PR TITLE
[onert] Fix MockTensor constructor syntax

### DIFF
--- a/runtime/onert/core/src/exec/feature/MockTensor.test.h
+++ b/runtime/onert/core/src/exec/feature/MockTensor.test.h
@@ -20,7 +20,7 @@
 template <typename T> class MockTensor : public onert::backend::ITensor
 {
 public:
-  MockTensor<T>(onert::ir::Shape &shape, T *buf, onert::ir::Layout layout)
+  MockTensor(onert::ir::Shape &shape, T *buf, onert::ir::Layout layout)
     : _buf(reinterpret_cast<uint8_t *>(buf)), _shape(shape), _layout(layout)
   {
   }


### PR DESCRIPTION
This commit removes template parameter from MockTensor constructor name to follow correct C++ syntax for constructors of class templates.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Resolve build error on gbs build by `template-id-cdtor` 