### PR TITLE
[infra] Check patch in stamp content for external sources

### DIFF
--- a/infra/cmake/modules/ExternalSourceTools.cmake
+++ b/infra/cmake/modules/ExternalSourceTools.cmake
@@ -36,8 +36,13 @@ function(ExternalSource_Download PREFIX)
     file(MAKE_DIRECTORY "${CACHE_DIR}")
   endif(NOT EXISTS "${CACHE_DIR}")
 
-  # Compare URL in STAMP file and the given URL
-  Stamp_Check(URL_CHECK "${STAMP_PATH}" "${URL}")
+  # Compare content in STAMP file and the given URL and patch file
+  set(STAMP_CONTENT "${URL}")
+  if(ARG_PATCH)
+    file(MD5 ${ARG_PATCH} PATCH_MD5)
+    set(STAMP_CONTENT "${URL} ${ARG_PATCH} ${PATCH_MD5}")
+  endif(ARG_PATCH)
+  Stamp_Check(URL_CHECK "${STAMP_PATH}" "${STAMP_CONTENT}")
 
   if(NOT EXISTS "${OUT_DIR}" OR NOT URL_CHECK)
     file(REMOVE "${STAMP_PATH}")
@@ -141,7 +146,7 @@ function(ExternalSource_Download PREFIX)
     endif(ARG_PATCH)
 
     file(REMOVE_RECURSE "${TMP_DIR}")
-    file(WRITE "${STAMP_PATH}" "${URL}")
+    file(WRITE "${STAMP_PATH}" "${STAMP_CONTENT}")
     message(STATUS "Cleanup ${PREFIX} - done")
   endif()
 


### PR DESCRIPTION
This commit updates ExternalSource_Download to include patch file information in the stamp content alongside the URL. This ensures that when a patch file changes, the external source is properly re-downloaded and re-patched, even if the URL remains the same.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>