### PR TITLE
[infra/onert] Fix nnfw_find_package

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -56,7 +56,7 @@ macro(nnfw_include PREFIX)
   include("${ONERT_PROJECT_SOURCE_DIR}/infra/cmake/modules/${PREFIX}.cmake")
 endmacro(nnfw_include)
 
-# Runtime 'find_package()' wrapper to find in cmake/packages folder
+# Runtime 'find_package()' wrapper to find in infra/cmake/packages folder
 #
 # Example:
 #  nnfw_find_package(Eigen): Load settings from 'EigenConfig.cmake' file
@@ -64,7 +64,8 @@ endmacro(nnfw_include)
 #  nnfw_find_package(Eigen QUIET): Load settings silently, without warnings
 #  nnfw_find_package(Eigen REQUIRED): Load settings but stop with error when failed
 macro(nnfw_find_package PREFIX)
-  find_package(${PREFIX} CONFIG NO_DEFAULT_PATH
+  find_package(${PREFIX} CONFIG
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH
     PATHS ${ONERT_PROJECT_SOURCE_DIR}/infra/cmake/packages
     ${ARGN}
   )

--- a/runtime/infra/cmake/buildtool/cross/toolchain_aarch64-android.cmake
+++ b/runtime/infra/cmake/buildtool/cross/toolchain_aarch64-android.cmake
@@ -27,10 +27,6 @@ set(ANDROID_API_LEVEL 29)
 set(ANDROID_PLATFORM android-${ANDROID_API_LEVEL})
 set(ANDROID_STL c++_shared)
 
-# Find package in the host. `nnfw_find_package` won't work without this
-# Others (library, path) will follow android.toolchain.cmake settings
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE NEVER)
-
 # Use the toolchain file that NDK provides
 include(${CMAKE_ANDROID_NDK}/build/cmake/android.toolchain.cmake)
 


### PR DESCRIPTION
This commit removes workaround to find package in android build
- Add NO_CMAKE_FIND_ROOT_PATH to nnfw_find_package macro to force finding packages in host path
- Remove CMAKE_FIND_ROOT_PATH_MODE_PACKAGE setting from Android toolchain

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>