### PR TITLE
[infra/gbs] Enable  on-device compiler again

### DIFF
--- a/.github/workflows/run-onert-gbs-build.yml
+++ b/.github/workflows/run-onert-gbs-build.yml
@@ -78,4 +78,4 @@ jobs:
 
       - name: Build
         run: |
-          gbs -c runtime/infra/gbs/gbs.conf build -A ${{ matrix.arch }} --profile ${{ matrix.profile }} --buildroot .gbs
+          gbs -c runtime/infra/gbs/gbs.conf build -A ${{ matrix.arch }} --profile ${{ matrix.profile }} --buildroot .gbs --define 'odc_build 0'

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -28,7 +28,11 @@ Source4001: EXTERNALS_FOR_ODC.tar.gz
 
 %{!?build_type:     %define build_type      Release}
 %{!?trix_support:   %define trix_support    1}
+%if "%{?profile}" == "tv"
 %{!?odc_build:      %define odc_build       0}
+%else # "%{?profile}" == "tv"
+%{!?odc_build:      %define odc_build       1}
+%endif
 %{!?test_build:     %define test_build      0}
 %{!?extra_option:   %define extra_option    %{nil}}
 # Define nproc on gbs build option if you want to set number of build threads manually (ex. CI/CD infra)


### PR DESCRIPTION
This commit enables on-device compiler again on normal profiles. 
It also updates gbs build workflow to explicitly set odc_build to 0 to reduce build time on PR check.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>