### PR TITLE
[infra/gbs] Remove source tar files usage

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -53,6 +53,8 @@ BuildRequires:  libaec-devel
 BuildRequires:  pkgconfig(zlib)
 %endif
 BuildRequires:  gtest-devel
+BuildRequires:  python3
+BuildRequires:  python3-numpy
 %endif
 
 %if %{trix_support} == 1
@@ -157,23 +159,12 @@ If you want to use test package, you should install runtime package which is bui
 %setup -q
 cp %{SOURCE1} .
 mkdir ./runtime/externals
-tar -xf %{SOURCE1001} -C ./runtime/tests/nnapi/src/
-tar -xf %{SOURCE3001} -C ./runtime/externals
+
+# For compute library
 tar -xf %{SOURCE3002} -C ./runtime/externals
-tar -xf %{SOURCE3003} -C ./runtime/externals
-tar -xf %{SOURCE3004} -C ./runtime/externals
-tar -xf %{SOURCE3005} -C ./runtime/externals
-tar -xf %{SOURCE3006} -C ./runtime/externals
-tar -xf %{SOURCE3007} -C ./runtime/externals
-tar -xf %{SOURCE3008} -C ./runtime/externals
-tar -xf %{SOURCE3009} -C ./runtime/externals
-tar -xf %{SOURCE3010} -C ./runtime/externals
-tar -xf %{SOURCE3011} -C ./runtime/externals
 tar -xf %{SOURCE3012} -C ./runtime/externals
 tar -xf %{SOURCE3013} -C ./runtime/externals
 tar -xf %{SOURCE3014} -C ./runtime/externals
-tar -xf %{SOURCE3015} -C ./runtime/externals
-tar -xf %{SOURCE3016} -C ./runtime/externals
 
 %if %{odc_build} == 1
 mkdir ./externals

--- a/runtime/infra/cmake/options/options_aarch64-tizen.cmake
+++ b/runtime/infra/cmake/options/options_aarch64-tizen.cmake
@@ -5,7 +5,6 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)

--- a/runtime/infra/cmake/options/options_armv7hl-tizen.cmake
+++ b/runtime/infra/cmake/options/options_armv7hl-tizen.cmake
@@ -5,7 +5,6 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)

--- a/runtime/infra/cmake/options/options_armv7l-tizen.cmake
+++ b/runtime/infra/cmake/options/options_armv7l-tizen.cmake
@@ -5,7 +5,6 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)

--- a/runtime/infra/cmake/options/options_i686-tizen.cmake
+++ b/runtime/infra/cmake/options/options_i686-tizen.cmake
@@ -4,7 +4,6 @@
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)

--- a/runtime/infra/cmake/options/options_riscv64-tizen.cmake
+++ b/runtime/infra/cmake/options/options_riscv64-tizen.cmake
@@ -4,7 +4,6 @@
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)

--- a/runtime/infra/cmake/options/options_x86_64-tizen.cmake
+++ b/runtime/infra/cmake/options/options_x86_64-tizen.cmake
@@ -4,7 +4,6 @@
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 
-option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)


### PR DESCRIPTION
This commit removes external libraries and generated code tar files usage
- Add python3 and python3-numpy as build requirements
- Remove external source extractions for unused TFLite build

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>