### PR TITLE
[infra/onert] Update CPUINFO library build options

### DIFF
--- a/runtime/infra/cmake/packages/CpuInfoConfig.cmake
+++ b/runtime/infra/cmake/packages/CpuInfoConfig.cmake
@@ -19,13 +19,16 @@ function(_CpuInfo_Build)
   # Set build option
   # - Static (position independent)
   # - No logging
-  # - Library only (CPUINFO_RUNTIME_TYPE is not used)
+  # - Disable tools, tests and benchmarks
   set(CPUINFO_LIBRARY_TYPE "static" CACHE STRING "")
+  set(CPUINFO_RUNTIME_TYPE "static" CACHE STRING "")
   set(CPUINFO_LOG_LEVEL "none" CACHE STRING "")
+  set(CPUINFO_LOG_TO_STDIO OFF  CACHE BOOL "")
   set(CPUINFO_BUILD_TOOLS OFF CACHE BOOL "")
-  set(CPUINFO_BUILD_BENCHMARKS OFF CACHE BOOL "")
   set(CPUINFO_BUILD_UNIT_TESTS OFF CACHE BOOL "")
   set(CPUINFO_BUILD_MOCK_TESTS OFF CACHE BOOL "")
+  set(CPUINFO_BUILD_BENCHMARKS OFF CACHE BOOL "")
+  set(CPUINFO_BUILD_PKG_CONFIG OFF CACHE BOOL "")
   add_extdirectory("${CpuInfoSource_DIR}" cpuinfo EXCLUDE_FROM_ALL)
   set_target_properties(cpuinfo PROPERTIES POSITION_INDEPENDENT_CODE ON)
   set(CpuInfoSource_DIR ${CpuInfoSource_DIR} PARENT_SCOPE)


### PR DESCRIPTION
This commit updates CpuInfoConfig.cmake
- Explicitly set CPUINFO_RUNTIME_TYPE to static
- Disable logging to stdio
- Ensure tools, tests, benchmarks, and pkg_config are disabled

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>