### PR TITLE
[loco] Remove external dependencies for TensorIndex

### DIFF
--- a/compiler/loco/CMakeLists.txt
+++ b/compiler/loco/CMakeLists.txt
@@ -4,8 +4,6 @@ list(REMOVE_ITEM SOURCES ${TESTS})
 
 add_library(loco SHARED ${SOURCES})
 target_include_directories(loco PUBLIC include)
-# TODO Remove dependencies on angkor library
-target_link_libraries(loco PUBLIC angkor)
 # Let's apply nncc common compile options
 #
 # NOTE This will enable strict compilation (warnings as error).

--- a/compiler/loco/include/loco/IR/TensorIndex.h
+++ b/compiler/loco/include/loco/IR/TensorIndex.h
@@ -17,13 +17,31 @@
 #ifndef __LOCO_IR_TENSOR_INDEX_H__
 #define __LOCO_IR_TENSOR_INDEX_H__
 
-#include <nncc/core/ADT/tensor/Index.h>
+#include <cstdint>
+#include <initializer_list>
+#include <vector>
 
 namespace loco
 {
 
-// TODO Remove dependencies on angkor
-using TensorIndex = nncc::core::ADT::tensor::Index;
+class TensorIndex
+{
+public:
+  TensorIndex();
+
+public:
+  uint32_t rank(void) const;
+
+public:
+  TensorIndex &resize(uint32_t size);
+
+public:
+  uint32_t &at(uint32_t axis);
+  uint32_t at(uint32_t axis) const;
+
+private:
+  std::vector<uint32_t> _indices;
+};
 
 } // namespace loco
 

--- a/compiler/loco/src/IR/TensorIndex.cpp
+++ b/compiler/loco/src/IR/TensorIndex.cpp
@@ -16,4 +16,23 @@
 
 #include "loco/IR/TensorIndex.h"
 
-// NOTE This file validates "TensorIndex.h". Please DO NOT remove this file.
+#include <stdexcept>
+
+namespace loco
+{
+
+TensorIndex::TensorIndex() = default;
+
+uint32_t TensorIndex::rank(void) const { return _indices.size(); }
+
+TensorIndex &TensorIndex::resize(uint32_t size)
+{
+  _indices.resize(size);
+  return *this;
+}
+
+uint32_t &TensorIndex::at(uint32_t axis) { return _indices.at(axis); }
+
+uint32_t TensorIndex::at(uint32_t axis) const { return _indices.at(axis); }
+
+} // namespace loco


### PR DESCRIPTION
This commit replaces TensorIndex type alias with implementation to remove dependencies on angkor library.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>