### PR TITLE
[oops] Install oops header files for dependent libraries

### DIFF
--- a/compiler/oops/CMakeLists.txt
+++ b/compiler/oops/CMakeLists.txt
@@ -3,6 +3,11 @@ target_include_directories(oops INTERFACE include)
 target_link_libraries(oops INTERFACE pepper_str)
 target_link_libraries(oops INTERFACE nncc_coverage)
 
+# oops is used by many other libraries' public header files,
+# so its header should be installed to ensure their completeness
+install(DIRECTORY include/ DESTINATION include
+        FILES_MATCHING PATTERN "*.h")
+
 if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)


### PR DESCRIPTION
This commit adds install command to copy header files. 
This ensures that other installed libraries that depend on oops can access its public headers, maintaining completeness of their public interfaces.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>