### PR TITLE
[infra/onert] Add glibc-static installation for flatc build

### DIFF
--- a/.github/workflows/pub-onert-pypi.yml
+++ b/.github/workflows/pub-onert-pypi.yml
@@ -56,6 +56,11 @@ jobs:
           source ./venv/bin/activate
           pip3 install -U setuptools wheel
 
+      # For flatc build
+      - name: Install glibc-static
+        run: |
+          yum install -y glibc-static
+
       - name: Build
         run: |
           source ./venv/bin/activate


### PR DESCRIPTION
This commit Installs glibc-static package in the PyPI publishing workflow to enable successful compilation of the FlatBuffers compiler (flatc). 
This resolves build dependencies required for the flatc build process.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>