### PR TITLE
[locomotiv] Add conversion utilities for tensor index types

### DIFF
--- a/compiler/locomotiv/src/ConvertIndex.cpp
+++ b/compiler/locomotiv/src/ConvertIndex.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "loco/IR/TensorIndex.h"
+
+#include <nncc/core/ADT/tensor/Index.h>
+
+namespace locomotiv
+{
+
+nncc::core::ADT::tensor::Index as_nncc_index(const loco::TensorIndex &index)
+{
+  nncc::core::ADT::tensor::Index nncc_index;
+  nncc_index.resize(index.rank());
+  for (uint32_t axis = 0; axis < index.rank(); ++axis)
+    nncc_index.at(axis) = index.at(axis);
+
+  return nncc_index;
+}
+
+loco::TensorIndex as_loco_index(const nncc::core::ADT::tensor::Index &index)
+{
+  loco::TensorIndex loco_index;
+  loco_index.resize(index.rank());
+  for (uint32_t axis = 0; axis < index.rank(); ++axis)
+    loco_index.at(axis) = index.at(axis);
+
+  return loco_index;
+}
+
+} // namespace locomotiv

--- a/compiler/locomotiv/src/ConvertIndex.h
+++ b/compiler/locomotiv/src/ConvertIndex.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "loco/IR/TensorIndex.h"
+
+#include <nncc/core/ADT/tensor/Index.h>
+
+namespace locomotiv
+{
+
+// convert TensorIndex to nncc::core::ADT::tensor::Index
+nncc::core::ADT::tensor::Index as_nncc_index(const loco::TensorIndex &index);
+
+// convert nncc::core::ADT::tensor::Index to TensorIndex
+loco::TensorIndex as_loco_index(const nncc::core::ADT::tensor::Index &index);
+
+} // namespace locomotiv

--- a/compiler/locomotiv/src/ConvertIndex.test.cpp
+++ b/compiler/locomotiv/src/ConvertIndex.test.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConvertIndex.h"
+
+#include <gtest/gtest.h>
+
+TEST(ConvertIndexTest, as_nncc_index_rank_0)
+{
+  loco::TensorIndex loco_idx;
+  ASSERT_EQ(loco_idx.rank(), 0);
+
+  auto nncc_idx = locomotiv::as_nncc_index(loco_idx);
+
+  ASSERT_EQ(nncc_idx.rank(), 0);
+}
+
+TEST(ConvertIndexTest, as_nncc_index_rank_1)
+{
+  loco::TensorIndex loco_idx;
+  loco_idx.resize(1);
+  loco_idx.at(0) = 5;
+
+  auto nncc_idx = locomotiv::as_nncc_index(loco_idx);
+
+  ASSERT_EQ(nncc_idx.rank(), 1);
+  ASSERT_EQ(nncc_idx.at(0), 5);
+}
+
+TEST(ConvertIndexTest, as_nncc_index_rank_4)
+{
+  loco::TensorIndex loco_idx;
+  loco_idx.resize(4);
+  loco_idx.at(0) = 1;
+  loco_idx.at(1) = 2;
+  loco_idx.at(2) = 3;
+  loco_idx.at(3) = 4;
+
+  auto nncc_idx = locomotiv::as_nncc_index(loco_idx);
+
+  ASSERT_EQ(nncc_idx.rank(), 4);
+  ASSERT_EQ(nncc_idx.at(0), 1);
+  ASSERT_EQ(nncc_idx.at(1), 2);
+  ASSERT_EQ(nncc_idx.at(2), 3);
+  ASSERT_EQ(nncc_idx.at(3), 4);
+}
+
+TEST(ConvertIndexTest, as_loco_index_rank_0)
+{
+  nncc::core::ADT::tensor::Index nncc_idx;
+  ASSERT_EQ(nncc_idx.rank(), 0);
+
+  auto loco_idx = locomotiv::as_loco_index(nncc_idx);
+
+  ASSERT_EQ(loco_idx.rank(), 0);
+}
+
+TEST(ConvertIndexTest, as_loco_index_rank_1)
+{
+  nncc::core::ADT::tensor::Index nncc_idx;
+  nncc_idx.resize(1);
+  nncc_idx.at(0) = 10;
+
+  auto loco_idx = locomotiv::as_loco_index(nncc_idx);
+
+  ASSERT_EQ(loco_idx.rank(), 1);
+  ASSERT_EQ(loco_idx.at(0), 10);
+}
+
+TEST(ConvertIndexTest, as_loco_index_rank_4)
+{
+  nncc::core::ADT::tensor::Index nncc_idx;
+  nncc_idx.resize(4);
+  nncc_idx.at(0) = 4;
+  nncc_idx.at(1) = 3;
+  nncc_idx.at(2) = 2;
+  nncc_idx.at(3) = 1;
+
+  auto loco_idx = locomotiv::as_loco_index(nncc_idx);
+
+  ASSERT_EQ(loco_idx.rank(), 4);
+  ASSERT_EQ(loco_idx.at(0), 4);
+  ASSERT_EQ(loco_idx.at(1), 3);
+  ASSERT_EQ(loco_idx.at(2), 2);
+  ASSERT_EQ(loco_idx.at(3), 1);
+}
+
+TEST(ConvertIndexTest, roundtrip_loco_to_nncc_to_loco)
+{
+  loco::TensorIndex original_loco_idx;
+  original_loco_idx.resize(3);
+  original_loco_idx.at(0) = 100;
+  original_loco_idx.at(1) = 200;
+  original_loco_idx.at(2) = 300;
+
+  auto nncc_idx = locomotiv::as_nncc_index(original_loco_idx);
+  auto converted_loco_idx = locomotiv::as_loco_index(nncc_idx);
+
+  ASSERT_EQ(converted_loco_idx.rank(), original_loco_idx.rank());
+  for (uint32_t i = 0; i < original_loco_idx.rank(); ++i)
+  {
+    ASSERT_EQ(converted_loco_idx.at(i), original_loco_idx.at(i));
+  }
+}
+
+TEST(ConvertIndexTest, roundtrip_nncc_to_loco_to_nncc)
+{
+  nncc::core::ADT::tensor::Index original_nncc_idx;
+  original_nncc_idx.resize(2);
+  original_nncc_idx.at(0) = 50;
+  original_nncc_idx.at(1) = 60;
+
+  auto loco_idx = locomotiv::as_loco_index(original_nncc_idx);
+  auto converted_nncc_idx = locomotiv::as_nncc_index(loco_idx);
+
+  ASSERT_EQ(converted_nncc_idx.rank(), original_nncc_idx.rank());
+  for (uint32_t i = 0; i < original_nncc_idx.rank(); ++i)
+  {
+    ASSERT_EQ(converted_nncc_idx.at(i), original_nncc_idx.at(i));
+  }
+}

--- a/compiler/locomotiv/src/Node/DepthwiseFilterEncode.cpp
+++ b/compiler/locomotiv/src/Node/DepthwiseFilterEncode.cpp
@@ -16,6 +16,7 @@
 
 #include "NodeExecution.h"
 
+#include "ConvertIndex.h"
 #include "NodeDataImpl.h"
 #include "NodeDomain.h"
 #include "Validation.h"
@@ -71,7 +72,7 @@ std::unique_ptr<locomotiv::NodeData> dw_filter_encode(const loco::DepthwiseFilte
     index.channel() = e.current().at(2);
     index.nth() = e.current().at(3);
 
-    node_buf.at(e.current()) = input_buf->at(encoder->value(index));
+    node_buf.at(e.current()) = input_buf->at(locomotiv::as_nncc_index(encoder->value(index)));
   }
 
   return locomotiv::make_data(node_buf);

--- a/compiler/locomotiv/src/Node/FeatureDecode.cpp
+++ b/compiler/locomotiv/src/Node/FeatureDecode.cpp
@@ -16,6 +16,7 @@
 
 #include "NodeExecution.h"
 
+#include "ConvertIndex.h"
 #include "NodeDataImpl.h"
 #include "NodeDomain.h"
 #include "Validation.h"
@@ -60,7 +61,7 @@ std::unique_ptr<locomotiv::NodeData> feature_decode(const loco::FeatureDecode *n
   // Copy buffer in an order arranged by decoder
   for (IndexEnumerator e{node_buf.shape()}; e.valid(); e.advance())
   {
-    loco::FeatureIndex feature_index = decoder->value(e.current());
+    loco::FeatureIndex feature_index = decoder->value(locomotiv::as_loco_index(e.current()));
     Index buf_index({feature_index.batch(), feature_index.row(), feature_index.column(),
                      feature_index.channel()});
 

--- a/compiler/locomotiv/src/Node/FeatureEncode.cpp
+++ b/compiler/locomotiv/src/Node/FeatureEncode.cpp
@@ -16,6 +16,7 @@
 
 #include "NodeExecution.h"
 
+#include "ConvertIndex.h"
 #include "NodeDataImpl.h"
 #include "NodeDomain.h"
 #include "Validation.h"
@@ -66,7 +67,7 @@ std::unique_ptr<locomotiv::NodeData> feature_encode(const loco::FeatureEncode *n
     index.column() = e.current().at(2);
     index.channel() = e.current().at(3);
 
-    node_buf.at(e.current()) = input_buf->at(encoder->value(index));
+    node_buf.at(e.current()) = input_buf->at(locomotiv::as_nncc_index(encoder->value(index)));
   }
 
   return locomotiv::make_data(node_buf);

--- a/compiler/locomotiv/src/Node/FilterEncode.cpp
+++ b/compiler/locomotiv/src/Node/FilterEncode.cpp
@@ -16,6 +16,7 @@
 
 #include "NodeExecution.h"
 
+#include "ConvertIndex.h"
 #include "NodeDataImpl.h"
 #include "NodeDomain.h"
 #include "Validation.h"
@@ -66,7 +67,7 @@ std::unique_ptr<locomotiv::NodeData> filter_encode(const loco::FilterEncode *nod
     index.column() = e.current().at(2);
     index.channel() = e.current().at(3);
 
-    node_buf.at(e.current()) = input_buf->at(encoder->value(index));
+    node_buf.at(e.current()) = input_buf->at(locomotiv::as_nncc_index(encoder->value(index)));
   }
 
   return locomotiv::make_data(node_buf);

--- a/compiler/locomotiv/src/Node/MatrixDecode.cpp
+++ b/compiler/locomotiv/src/Node/MatrixDecode.cpp
@@ -16,6 +16,7 @@
 
 #include "NodeExecution.h"
 
+#include "ConvertIndex.h"
 #include "NodeDataImpl.h"
 #include "NodeDomain.h"
 #include "Validation.h"
@@ -57,7 +58,7 @@ std::unique_ptr<locomotiv::NodeData> matrix_decode(const loco::MatrixDecode *nod
   // Copy buffer in an order arranged by decoder
   for (IndexEnumerator e{node_buf.shape()}; e.valid(); e.advance())
   {
-    loco::MatrixIndex matrix_index = decoder->value(e.current());
+    loco::MatrixIndex matrix_index = decoder->value(locomotiv::as_loco_index(e.current()));
     Index buf_index({matrix_index.row(), matrix_index.column()});
 
     node_buf.at(e.current()) = input_buf->at(buf_index);

--- a/compiler/locomotiv/src/Node/MatrixEncode.cpp
+++ b/compiler/locomotiv/src/Node/MatrixEncode.cpp
@@ -16,6 +16,7 @@
 
 #include "NodeExecution.h"
 
+#include "ConvertIndex.h"
 #include "NodeDataImpl.h"
 #include "NodeDomain.h"
 #include "Validation.h"
@@ -63,7 +64,7 @@ std::unique_ptr<locomotiv::NodeData> matrix_encode(const loco::MatrixEncode *nod
     index.row() = e.current().at(0);
     index.column() = e.current().at(1);
 
-    node_buf.at(e.current()) = input_buf->at(encoder->value(index));
+    node_buf.at(e.current()) = input_buf->at(locomotiv::as_nncc_index(encoder->value(index)));
   }
 
   return locomotiv::make_data(node_buf);


### PR DESCRIPTION
This commit Introduces functions to convert between loco::TensorIndex and nncc::core::ADT::tensor::Index types. Conversion is implicitly handled because loco::TensorIndex is alias of nncc::core::ADT::tensor::Index, but explicit conversion functions are added to remove alias.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #16124