### PR TITLE
[infra/onert] Remove temporary header installation steps

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -150,11 +150,6 @@ ifeq (,$(findstring android,$(TARGET_OS)))
 		$(OPTIONS_NNCC)
 	./nncc build -j$(NPROCS)
 	cmake --install $(NNCC_FOLDER) $(INSTALL_OPTIONS)
-# install angkor TensorIndex and oops InternalExn header (TODO: Remove this)
-	@mkdir -p ${OVERLAY_FOLDER}/include/nncc/core/ADT/tensor
-	@mkdir -p ${OVERLAY_FOLDER}/include/oops
-	@cp compiler/angkor/include/nncc/core/ADT/tensor/Index.h ${OVERLAY_FOLDER}/include/nncc/core/ADT/tensor
-	@cp compiler/oops/include/oops/InternalExn.h ${OVERLAY_FOLDER}/include/oops
 	@echo "Done prepare-nncc"
 endif
 

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -168,12 +168,6 @@ tar -xf %{SOURCE2001} -C ./externals
 	-DBUILD_WHITELIST="luci;foder;pepper-csv2vec;loco;locop;logo;logo-core;mio-circle;luci-compute;oops;hermes;hermes-std;angkor;pp;pepper-strcast;pepper-str"
 %{nncc_env} ./nncc build %{build_jobs}
 cmake --install %{nncc_workspace}
-
-# install angkor TensorIndex and oops InternalExn header (TODO: Remove this)
-mkdir -p %{overlay_path}/include/nncc/core/ADT/tensor
-mkdir -p %{overlay_path}/include/oops
-cp compiler/angkor/include/nncc/core/ADT/tensor/Index.h %{overlay_path}/include/nncc/core/ADT/tensor
-cp compiler/oops/include/oops/InternalExn.h %{overlay_path}/include/oops
 %endif # odc_build
 
 # runtime build


### PR DESCRIPTION
This commit removes the temporary installation of angkor TensorIndex and oops InternalExn headers from both Makefile.template and packaging/nnfw.spec.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>