### PR TITLE
[micro] Use 2 thread for arm target

### DIFF
--- a/onert-micro/CMakeLists.txt
+++ b/onert-micro/CMakeLists.txt
@@ -217,7 +217,7 @@ set(MICRO_ARM_BINARY "${MICRO_ARM_BUILD_DIR}/onert_micro/src/libonert_micro_dev.
 
 add_custom_command(
         OUTPUT "${MICRO_ARM_BINARY}"
-        COMMAND "${CMAKE_MAKE_PROGRAM}" onert_micro_dev -j ${CPU_COUNT}
+        COMMAND "${CMAKE_MAKE_PROGRAM}" onert_micro_dev -j2
         WORKING_DIRECTORY "${MICRO_ARM_BUILD_DIR}"
         DEPENDS onert_micro_arm_cmake ${OM_CIRCLE_SCHEMA}
         VERBATIM


### PR DESCRIPTION
- Use 2 thread to build arm target in order to avoid too much memory consumption

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>