### PR TITLE
[exo] Add angkor dependency

### DIFF
--- a/compiler/exo/CMakeLists.txt
+++ b/compiler/exo/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(exo PRIVATE locop)
 target_link_libraries(exo PRIVATE hermes_std)
 target_link_libraries(exo PRIVATE logo)
 target_link_libraries(exo PRIVATE oops)
+target_link_libraries(exo PRIVATE angkor)
 install(TARGETS exo DESTINATION lib)
 
 # Let's apply nncc common compile options

--- a/compiler/exo/requires.cmake
+++ b/compiler/exo/requires.cmake
@@ -1,3 +1,4 @@
+require("angkor")
 require("loco")
 require("locoex-customop")
 require("logo")

--- a/compiler/exo/src/Pass/FoldTransposeOfConstPass.cpp
+++ b/compiler/exo/src/Pass/FoldTransposeOfConstPass.cpp
@@ -115,8 +115,8 @@ void fold_transpose_of_const(locoex::TFLTranspose *transpose)
 
   for (; e.valid(); e.advance())
   {
-    loco::TensorIndex index_new = e.current();
-    loco::TensorIndex index_orig;
+    nncc::core::ADT::tensor::Index index_new = e.current();
+    nncc::core::ADT::tensor::Index index_orig;
 
     // Set original index from matching new index
     index_orig.resize(rank);


### PR DESCRIPTION
This commit adds angkor library dependency to exo and fixes removed alias loco::TensorIndex with nncc::core::ADT::tensor::Index.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>