### PR TITLE
[onert/test] Replace C-style arrays with std::vector

### DIFF
--- a/runtime/tests/nnfw_api/src/RegressionTests.test.cc
+++ b/runtime/tests/nnfw_api/src/RegressionTests.test.cc
@@ -114,13 +114,13 @@ TEST_F(RegressionTest, github_11748)
     ASSERT_EQ(t_input.rank, t_new_input.rank);
     ASSERT_EQ(t_input.dims[0], new_dim);
 
-    uint8_t input_buf[new_dim * sizeof(float)];
+    std::vector<uint8_t> input_buf(new_dim * sizeof(float));
     NNFW_ENSURE_SUCCESS(
-      nnfw_set_input(session, 0, t_input.dtype, &input_buf, new_dim * sizeof(float)));
+      nnfw_set_input(session, 0, t_input.dtype, input_buf.data(), new_dim * sizeof(float)));
 
-    uint8_t output_buf[new_dim * sizeof(float)];
+    std::vector<uint8_t> output_buf(new_dim * sizeof(float));
     NNFW_ENSURE_SUCCESS(
-      nnfw_set_output(session, 0, t_output.dtype, &output_buf, new_dim * sizeof(float)));
+      nnfw_set_output(session, 0, t_output.dtype, output_buf.data(), new_dim * sizeof(float)));
 
     NNFW_ENSURE_SUCCESS(nnfw_run(session));
 
@@ -134,9 +134,9 @@ TEST_F(RegressionTest, github_11748)
     // seems weird calling but anyway nnstreamer people case calls this again.
     // Anyways, runtime should work
     NNFW_ENSURE_SUCCESS(
-      nnfw_set_input(session, 0, t_input.dtype, &input_buf, new_dim * sizeof(float)));
+      nnfw_set_input(session, 0, t_input.dtype, input_buf.data(), new_dim * sizeof(float)));
     NNFW_ENSURE_SUCCESS(
-      nnfw_set_output(session, 0, t_output.dtype, &output_buf, new_dim * sizeof(float)));
+      nnfw_set_output(session, 0, t_output.dtype, output_buf.data(), new_dim * sizeof(float)));
     NNFW_ENSURE_SUCCESS(nnfw_run(session));
   }
 

--- a/runtime/tests/tools/tflite_run/src/tensor_loader.cc
+++ b/runtime/tests/tools/tflite_run/src/tensor_loader.cc
@@ -41,8 +41,9 @@ void TensorLoader::loadDumpedTensors(const std::string &filename)
   uint32_t num_tensors = 0;
   file.read(reinterpret_cast<char *>(&num_tensors), sizeof(num_tensors));
 
-  int tensor_indices_raw[num_tensors];
-  file.read(reinterpret_cast<char *>(tensor_indices_raw), sizeof(tensor_indices_raw));
+  std::vector<int> tensor_indices_raw(num_tensors);
+  file.read(reinterpret_cast<char *>(tensor_indices_raw.data()),
+            tensor_indices_raw.size() * sizeof(int));
 
   _raw_data = std::unique_ptr<float[]>(new float[file_size]);
   file.read(reinterpret_cast<char *>(_raw_data.get()), file_size);
@@ -52,8 +53,8 @@ void TensorLoader::loadDumpedTensors(const std::string &filename)
     loadInputTensorsFromRawData() + loadOutputTensorsFromRawData();
 
   // The file size and total output tensor size must match
-  assert(file_size ==
-         sizeof(num_tensors) + sizeof(tensor_indices_raw) + read_bytes * sizeof(float));
+  assert(file_size == sizeof(num_tensors) + tensor_indices_raw.size() * sizeof(int) +
+                        read_bytes * sizeof(float));
 }
 
 void TensorLoader::loadRawInputTensors(const std::string &filename)


### PR DESCRIPTION
This commit changes variable length raw arrays to std::vector in RegressionTests.test.cc and tensor_loader.cc to prevent potential stack overflow and improve memory safety.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>