### PR TITLE
[onert-micro] Fixing the ReduceMaxTest.Float_4D_2axis_P

### DIFF
--- a/onert-micro/onert-micro/include/pal/mcu/PALReduceCommon.h
+++ b/onert-micro/onert-micro/include/pal/mcu/PALReduceCommon.h
@@ -133,7 +133,7 @@ bool Reducer<T, ReduceFn>::ResolveAxis()
   if (_input.IsScalar())
     return 0;
 
-  for (size_t i = 0; i < _axes.DimsCount(); ++i)
+  for (size_t i = 0; i < _axes.ElementsCount(); ++i)
   {
     int current = _axes.Data().At(i);
 

--- a/onert-micro/onert-micro/src/execute/kernels/tests/ReduceMax.test.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/tests/ReduceMax.test.cpp
@@ -40,14 +40,13 @@ TEST_F(ReduceMaxTest, Float_P)
   EXPECT_THAT(output_data_vector, test_data_kernel.get_output_data_by_index(0));
 }
 
-// TODO: enable this test
-// TEST_F(ReduceMaxTest, Float_4D_2axis_P)
-// {
-//   onert_micro::test_model::TestDataFloatReduceMax4D_2axis test_data_kernel;
-//   std::vector<float> output_data_vector =
-//     onert_micro::execute::testing::checkKernel<float>(1, &test_data_kernel);
-//   EXPECT_THAT(output_data_vector, test_data_kernel.get_output_data_by_index(0));
-// }
+TEST_F(ReduceMaxTest, Float_4D_2axis_P)
+{
+  onert_micro::test_model::TestDataFloatReduceMax4D_2axis test_data_kernel;
+  std::vector<float> output_data_vector =
+    onert_micro::execute::testing::checkKernel<float>(1, &test_data_kernel);
+  EXPECT_THAT(output_data_vector, test_data_kernel.get_output_data_by_index(0));
+}
 
 TEST_F(ReduceMaxTest, Float_3D_P)
 {


### PR DESCRIPTION
This commit fixes `ResolveAxis` function and enable the Float_4D_2axis_P test for ReduceMax kernel

ONE-DCO-1.0-Signed-off-by:  Evgenii Maltsev <e.maltsev@samsung.com>