### PR TITLE
[onert] Remove unused tensorinfo function from common module

### DIFF
--- a/runtime/onert/api/python/package/__init__.py
+++ b/runtime/onert/api/python/package/__init__.py
@@ -5,7 +5,7 @@ __all__ = ["infer", "tensorinfo", "experimental"]
 from . import infer
 
 # Import and expose tensorinfo
-from .common import tensorinfo as tensorinfo
+from .common import tensorinfo
 
 # Import and expose the experimental module's functionalities
 from . import experimental

--- a/runtime/onert/api/python/package/common/basesession.py
+++ b/runtime/onert/api/python/package/common/basesession.py
@@ -1,7 +1,7 @@
 from typing import List
 import numpy as np
 
-from ..native.libnnfw_api_pybind import infer, tensorinfo
+from ..native.libnnfw_api_pybind import tensorinfo
 from ..native.libnnfw_api_pybind.exception import OnertError
 
 
@@ -176,18 +176,3 @@ class BaseSession:
                 raise OnertError(f"Failed to get output #{i}: {e}") from e
 
             self.outputs.append(output_array)
-
-
-def tensorinfo():
-    """
-    Shortcut to create a fresh tensorinfo instance.
-    Raises:
-        OnertError: If the C-API call fails.
-    """
-
-    try:
-        return infer.nnfw_tensorinfo()
-    except OnertError:
-        raise
-    except Exception as e:
-        raise OnertError(f"Failed to create tensorinfo: {e}") from e

--- a/runtime/onert/sample/minimal-python/inference_benchmark.py
+++ b/runtime/onert/sample/minimal-python/inference_benchmark.py
@@ -3,9 +3,7 @@ import numpy as np
 import psutil
 import os
 from typing import List
-from onert import infer
-# TODO: Import tensorinfo from onert
-from onert.native.libnnfw_api_pybind import tensorinfo
+from onert import infer, tensorinfo
 
 
 def get_memory_usage_mb() -> float:


### PR DESCRIPTION
This commit removes unused and broken tensorinfo() function from the common Python module.

```python
>>> import onert
>>> onert.tensorinfo()
Traceback (most recent call last):
  File ".../onert/common/basesession.py", line 189, in tensorinfo
    return infer.nnfw_tensorinfo()
           ^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'onert.native.libnnfw_api_pybind.infer' has no attribute 'nnfw_tensorinfo'
```

Removing this function allows to properly use the native tensorinfo structure from the onert top level module.

```python
>>> import onert
>>> onert.tensorinfo()
<onert.native.libnnfw_api_pybind.tensorinfo object at 0x7601fe0916f0>
```

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>