### PR TITLE
[onert] Refactor tensorinfo to be more pythonic and robust

### DIFF
--- a/runtime/onert/api/python/package/__init__.py
+++ b/runtime/onert/api/python/package/__init__.py
@@ -1,11 +1,12 @@
 # Define the public API of the onert package
-__all__ = ["infer", "tensorinfo", "experimental"]
+__all__ = ["dtype", "infer", "tensorinfo", "experimental"]
+
+# Import and expose tensorinfo and tensor data types
+from .native.libnnfw_api_pybind import dtype, tensorinfo
+from .native.libnnfw_api_pybind.dtypes import *
 
 # Import and expose the infer module's functionalities
 from . import infer
-
-# Import and expose tensorinfo
-from .common import tensorinfo
 
 # Import and expose the experimental module's functionalities
 from . import experimental

--- a/runtime/onert/api/python/package/common/basesession.py
+++ b/runtime/onert/api/python/package/common/basesession.py
@@ -6,10 +6,10 @@ from ..native.libnnfw_api_pybind.exception import OnertError
 
 
 def num_elems(tensor_info):
-    """Get the total number of elements in nnfw_tensorinfo.dims."""
+    """Get the total number of elements in tensorinfo.shape."""
     n = 1
-    for x in range(tensor_info.rank):
-        n *= tensor_info.dims[x]
+    for x in tensor_info.shape:
+        n *= x
     return n
 
 
@@ -131,13 +131,12 @@ class BaseSession:
                 input_array = np.zeros((num_elems(input_tensorinfo)),
                                        dtype=input_tensorinfo.dtype)
 
-            # Check if the shape of input_array matches the dims of input_tensorinfo
-            if input_array.shape != tuple(input_tensorinfo.dims):
+            # Check if the shape of input_array matches the input_tensorinfo
+            if input_array.shape != input_tensorinfo.shape:
                 # If not, set the input tensor info to match the input_array shape
                 try:
-                    input_tensorinfo.rank = len(input_array)
-                    input_tensorinfo.dims = list(input_array.shape)
-                    self.session.set_input_tensorinfo(i, input_tensorinfo)
+                    info = tensorinfo(input_tensorinfo.dtype, input_array)
+                    self.session.set_input_tensorinfo(i, info)
                 except Exception as e:
                     raise OnertError(f"Failed to set input tensor info #{i}: {e}") from e
 

--- a/runtime/onert/api/python/src/bindings/nnfw_tensorinfo_bindings.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_tensorinfo_bindings.cc
@@ -16,6 +16,9 @@
 
 #include "nnfw_tensorinfo_bindings.h"
 
+#include <cstdint>
+#include <vector>
+
 #include "nnfw_api_wrapper.h"
 
 namespace onert::api::python
@@ -23,18 +26,53 @@ namespace onert::api::python
 
 namespace py = pybind11;
 
-// Bind the `tensorinfo` class
+template <typename T> py::tuple shape_to_tuple(const T &shape)
+{
+  py::tuple t(shape.size());
+  for (size_t i = 0; i < shape.size(); i++)
+    t[i] = shape[i];
+  return t;
+}
+
+// Bind the `tensorinfo` class and related `dtype` class.
 void bind_tensorinfo(py::module_ &m)
 {
-  py::class_<tensorinfo>(m, "tensorinfo", "tensorinfo describes the type and shape of tensors",
+  py::class_<dtype>(m, "dtype", "Defines the type of the OneRT tensor.", py::module_local())
+    .def("__repr__", [](const dtype &dt) { return std::string("onert.") + dt.name; })
+    .def_readonly("dtype", &dtype::dtype, "A numpy data type.");
+
+  py::class_<tensorinfo>(m, "tensorinfo",
+                         "Immutable information about the type and shape of a tensor.",
                          py::module_local())
-    .def(py::init<>(), "The constructor of tensorinfo")
-    .def_readwrite("dtype", &tensorinfo::dtype, "The data type")
-    .def_readwrite("rank", &tensorinfo::rank, "The number of dimensions (rank)")
-    .def_property(
-      "dims", [](const tensorinfo &ti) { return get_dims(ti); },
-      [](tensorinfo &ti, const py::list &dims_list) { set_dims(ti, dims_list); },
-      "The dimension of tensor. Maximum rank is 6 (NNFW_MAX_RANK).");
+    .def(py::init<struct dtype, tensorinfo::SHAPE>(),
+         "Initialize new tensorinfo with dtype and shape.", py::arg("dtype"), py::arg("shape"))
+    .def_property_readonly("dtype", &tensorinfo::get_dtype, "The data type of the tensor.")
+    .def_property_readonly("rank", &tensorinfo::get_rank,
+                           "The rank of the tensor. The maximum supported rank is 6.")
+    .def_property_readonly(
+      "shape", [](const tensorinfo &ti) { return shape_to_tuple(ti.get_shape()); },
+      "The shape of the tensor.")
+    .def("__repr__", [](const tensorinfo &ti) {
+      auto dtype = py::repr(py::cast(ti.get_dtype())).cast<std::string>();
+      auto shape = py::repr(shape_to_tuple(ti.get_shape())).cast<std::string>();
+      return "<tensorinfo dtype=" + dtype + " shape=" + shape + ">";
+    });
+
+  static const dtype dtypes[] = {
+    get_dtype(NNFW_TYPE::NNFW_TYPE_TENSOR_FLOAT32),
+    get_dtype(NNFW_TYPE::NNFW_TYPE_TENSOR_INT32),
+    get_dtype(NNFW_TYPE::NNFW_TYPE_TENSOR_QUANT8_ASYMM),
+    get_dtype(NNFW_TYPE::NNFW_TYPE_TENSOR_UINT8),
+    get_dtype(NNFW_TYPE::NNFW_TYPE_TENSOR_BOOL),
+    get_dtype(NNFW_TYPE::NNFW_TYPE_TENSOR_INT64),
+    get_dtype(NNFW_TYPE::NNFW_TYPE_TENSOR_QUANT8_ASYMM_SIGNED),
+    get_dtype(NNFW_TYPE::NNFW_TYPE_TENSOR_QUANT16_SYMM_SIGNED),
+  };
+
+  // Export OneRT dtypes in a submodule
+  auto m_dtypes = m.def_submodule("dtypes", "OneRT tensor data types");
+  for (const auto &dt : dtypes)
+    m_dtypes.attr(dt.name) = dt;
 }
 
 void bind_nnfw_enums(py::module_ &m)

--- a/runtime/onert/sample/minimal-python/dynamic_shape_inference.py
+++ b/runtime/onert/sample/minimal-python/dynamic_shape_inference.py
@@ -15,12 +15,9 @@ def main(nnpackage_path, backends="cpu"):
     for i in range(10):
         dummy_inputs = []
         for info in input_infos:
-            # Retrieve the dimensions list from tensorinfo property.
-            dims = list(info.dims)
             # Replace -1 with a random value between 1 and 10
-            dims = [random.randint(1, 10) if d == -1 else d for d in dims]
-            # Build the shape tuple from tensorinfo dimensions.
-            shape = tuple(dims[:info.rank])
+            shape = [random.randint(1, 10) if d == -
+                     1 else d for d in info.shape]
             # Create a dummy numpy array filled with uniform random values in [0,1).
             dummy_inputs.append(
                 np.random.uniform(low=0.0, high=1.0, size=shape).astype(info.dtype))

--- a/runtime/onert/sample/minimal-python/experimental/src/train_step_with_dataset.py
+++ b/runtime/onert/sample/minimal-python/experimental/src/train_step_with_dataset.py
@@ -71,8 +71,8 @@ def train_steps(args):
     sess = session(args.nnpkg, args.backends)
 
     # Load data
-    input_shape = sess.input_tensorinfo(0).dims
-    label_shape = sess.output_tensorinfo(0).dims
+    input_shape = list(sess.input_tensorinfo(0).shape)
+    label_shape = list(sess.output_tensorinfo(0).shape)
 
     input_shape[0] = args.data_length
     label_shape[0] = args.data_length

--- a/runtime/onert/sample/minimal-python/experimental/src/train_with_dataset.py
+++ b/runtime/onert/sample/minimal-python/experimental/src/train_with_dataset.py
@@ -76,8 +76,8 @@ def train(args):
     sess = session(args.nnpkg, args.backends)
 
     # Load data
-    input_shape = sess.input_tensorinfo(0).dims
-    label_shape = sess.output_tensorinfo(0).dims
+    input_shape = list(sess.input_tensorinfo(0).shape)
+    label_shape = list(sess.output_tensorinfo(0).shape)
 
     input_shape[0] = args.data_length
     label_shape[0] = args.data_length

--- a/runtime/onert/sample/minimal-python/inference_benchmark.py
+++ b/runtime/onert/sample/minimal-python/inference_benchmark.py
@@ -2,7 +2,7 @@ import argparse
 import numpy as np
 import psutil
 import os
-from typing import List
+from typing import List, Optional
 from onert import infer, tensorinfo
 
 
@@ -38,14 +38,12 @@ def get_validated_input_tensorinfos(sess: infer.session,
             raise ValueError(
                 f"Rank mismatch for input {i}: expected rank {info.rank}, got {len(shape)}"
             )
-        info.dims = shape
-        info.rank = len(shape)
-        updated_infos.append(info)
+        updated_infos.append(tensorinfo(info.dtype, shape))
 
     return updated_infos
 
 
-def benchmark_inference(nnpackage_path: str, backends: str, input_shapes: List[List[int]],
+def benchmark_inference(nnpackage_path: str, backends: str, input_shapes: Optional[List[List[int]]],
                         repeat: int):
     mem_before_kb = get_memory_usage_mb() * 1024
 
@@ -58,8 +56,7 @@ def benchmark_inference(nnpackage_path: str, backends: str, input_shapes: List[L
     # Create dummy input arrays
     dummy_inputs = []
     for info in input_infos:
-        shape = tuple(info.dims[:info.rank])
-        dummy_inputs.append(np.random.rand(*shape).astype(info.dtype))
+        dummy_inputs.append(np.random.rand(*info.shape).astype(info.dtype))
 
     prepare = total_input = total_output = total_run = 0.0
 

--- a/runtime/onert/sample/minimal-python/minimal.py
+++ b/runtime/onert/sample/minimal-python/minimal.py
@@ -12,12 +12,8 @@ def main(nnpackage_path, backends="cpu"):
     input_infos = session.get_inputs_tensorinfo()
     dummy_inputs = []
     for info in input_infos:
-        # Retrieve the dimensions list from tensorinfo property.
-        dims = list(info.dims)
-        # Build the shape tuple from tensorinfo dimensions.
-        shape = tuple(dims[:info.rank])
         # Create a dummy numpy array filled with zeros.
-        dummy_inputs.append(np.zeros(shape, dtype=info.dtype))
+        dummy_inputs.append(np.zeros(info.shape, dtype=info.dtype))
 
     outputs = session.infer(dummy_inputs)
 


### PR DESCRIPTION
This commit refactors the `tensorinfo` structure to be easier to use on the Python side. Instead of exporting C dimension array which needs to be trimmed on the Python side, now it exports Python tuple with length equal to tensor rank. Also, the entire structure is designed to be immutable to improve the understanding of the API concept - altering the info structure will not change the tensor.

The new `tensorinfo` structure consists of a data type and the tensor shape. The data type is a dedicated type exposed by the native Python library. It provides a direct mapping between numpy data type and the internal NNFW data type. Additionally, it allows to expose all internal data types (quantized types) which was not possible with previous approach - there is no 1:1 mapping between C++ types and NNFW types.

New usage:

```python
>>> import onert
>>> onert.
onert.bool          onert.dtype(        onert.float32       onert.int32         onert.native        onert.qint8         onert.tensorinfo(
onert.common        onert.experimental  onert.infer         onert.int64         onert.qint16sym     onert.quint8        onert.uint8
>>> ti = onert.tensorinfo(onert.float32, [5, 7, 9, 2])
>>> ti
<tensorinfo dtype=onert.float32 shape=(5, 7, 9, 2)>
>>> ti.
ti.dtype  ti.rank   ti.shape
>>> ti.rank
4
>>> ti.shape = [3, 5, 2, 3]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: property of 'tensorinfo' object has no setter
>>> ti.dtype.dtype  # numpy dtype
dtype('float32')
>>>
```

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>