### PR TITLE
[onert] Keep training related bindings in a dedicated submodule

### DIFF
--- a/runtime/onert/api/python/package/experimental/train/__init__.py
+++ b/runtime/onert/api/python/package/experimental/train/__init__.py
@@ -1,5 +1,5 @@
 from .session import TrainSession as session
-from onert.native.libnnfw_api_pybind import traininfo
+from onert.native.libnnfw_api_pybind.train import traininfo
 from .dataloader import DataLoader
 from . import optimizer
 from . import losses

--- a/runtime/onert/api/python/package/experimental/train/losses/__init__.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/__init__.py
@@ -1,5 +1,5 @@
 from .cce import CategoricalCrossentropy
 from .mse import MeanSquaredError
-from onert.native.libnnfw_api_pybind import lossinfo
+from onert.native.libnnfw_api_pybind.train import lossinfo
 
-__all__ = ["CategoricalCrossentropy", "MeanSquaredError", "lossinfo", "loss"]
+__all__ = ["CategoricalCrossentropy", "MeanSquaredError", "lossinfo"]

--- a/runtime/onert/api/python/package/experimental/train/losses/cce.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/cce.py
@@ -1,5 +1,4 @@
 from typing import Literal
-import numpy as np
 from .loss import LossFunction
 
 

--- a/runtime/onert/api/python/package/experimental/train/losses/loss.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/loss.py
@@ -1,5 +1,5 @@
 from typing import Literal, Dict
-from onert.native.libnnfw_api_pybind import loss_reduction
+from onert.native.libnnfw_api_pybind.train import loss_reduction
 
 
 class LossFunction:

--- a/runtime/onert/api/python/package/experimental/train/losses/mse.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/mse.py
@@ -1,5 +1,4 @@
 from typing import Literal
-import numpy as np
 from .loss import LossFunction
 
 

--- a/runtime/onert/api/python/package/experimental/train/losses/registry.py
+++ b/runtime/onert/api/python/package/experimental/train/losses/registry.py
@@ -2,7 +2,7 @@ from typing import Type, Dict
 from .loss import LossFunction
 from .cce import CategoricalCrossentropy
 from .mse import MeanSquaredError
-from onert.native.libnnfw_api_pybind import loss as loss_type
+from onert.native.libnnfw_api_pybind.train import loss as loss_type
 
 
 class LossRegistry:

--- a/runtime/onert/api/python/package/experimental/train/optimizer/__init__.py
+++ b/runtime/onert/api/python/package/experimental/train/optimizer/__init__.py
@@ -1,5 +1,5 @@
 from .sgd import SGD
 from .adam import Adam
-from onert.native.libnnfw_api_pybind import trainable_ops
+from onert.native.libnnfw_api_pybind.train import trainable_ops
 
 __all__ = ["SGD", "Adam", "trainable_ops"]

--- a/runtime/onert/api/python/package/experimental/train/optimizer/adam.py
+++ b/runtime/onert/api/python/package/experimental/train/optimizer/adam.py
@@ -1,4 +1,3 @@
-from typing import Literal
 from .optimizer import Optimizer
 
 

--- a/runtime/onert/api/python/package/experimental/train/optimizer/optimizer.py
+++ b/runtime/onert/api/python/package/experimental/train/optimizer/optimizer.py
@@ -1,4 +1,4 @@
-from onert.native.libnnfw_api_pybind import trainable_ops
+from onert.native.libnnfw_api_pybind.train import trainable_ops
 
 
 class Optimizer:

--- a/runtime/onert/api/python/package/experimental/train/optimizer/registry.py
+++ b/runtime/onert/api/python/package/experimental/train/optimizer/registry.py
@@ -2,7 +2,7 @@ from typing import Type, Dict
 from .optimizer import Optimizer
 from .adam import Adam
 from .sgd import SGD
-from onert.native.libnnfw_api_pybind import optimizer as optimizer_type
+from onert.native.libnnfw_api_pybind.train import optimizer as optimizer_type
 
 
 class OptimizerRegistry:

--- a/runtime/onert/api/python/package/experimental/train/session.py
+++ b/runtime/onert/api/python/package/experimental/train/session.py
@@ -3,7 +3,7 @@ import numpy as np
 from typing import Any, List, Tuple, Dict, Union, Optional
 
 from onert.native import libnnfw_api_pybind
-from onert.native.libnnfw_api_pybind import traininfo
+from onert.native.libnnfw_api_pybind.train import traininfo
 from onert.common.basesession import BaseSession
 from .dataloader import DataLoader
 from .losses.loss import LossFunction

--- a/runtime/onert/api/python/src/bindings/nnfw_api_wrapper_pybind.cc
+++ b/runtime/onert/api/python/src/bindings/nnfw_api_wrapper_pybind.cc
@@ -51,14 +51,9 @@ PYBIND11_MODULE(libnnfw_api_pybind, m)
   // Bind enums
   bind_nnfw_enums(m);
 
-  m.doc() = "NNFW Python Bindings for Training";
-
-  // Bind training enums
-  bind_nnfw_train_enums(m);
-
-  // Bind training nnfw_loss_info
-  bind_nnfw_loss_info(m);
-
-  // Bind_train_info
-  bind_nnfw_train_info(m);
+  // Keep training related bindings in a dedicated submodule
+  auto train = m.def_submodule("train", "NNFW Python Bindings for Training");
+  bind_nnfw_train_enums(train);
+  bind_nnfw_loss_info(train);
+  bind_nnfw_train_info(train);
 }


### PR DESCRIPTION
This commit moves training related bindings into the "train" submodule. It looks like that was the original intention - there is a dedicated doc string for such module, but instead it overwrites doc string in the main native module.

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>