### PR TITLE
[onert] Support input/output layout/type configuration for signature graph

### DIFF
--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -18,7 +18,7 @@
 #define __ONERT_COMPILER_COMPILER_OPTIONS_H_
 
 #include "ir/OpCode.h"
-#include "ir/Index.h"
+#include "ir/NNPkg.h"
 #include "ir/Layout.h"
 #include "ir/TypeInfo.h"
 
@@ -65,10 +65,10 @@ struct CompilerOptions
 
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
-  std::unordered_map<ir::IOIndex, ir::Layout> input_layout;
-  std::unordered_map<ir::IOIndex, ir::Layout> output_layout;
-  std::unordered_map<ir::IOIndex, ir::TypeInfo> input_type;
-  std::unordered_map<ir::IOIndex, ir::TypeInfo> output_type;
+  std::unordered_map<ir::IODesc, ir::Layout> input_layout;
+  std::unordered_map<ir::IODesc, ir::Layout> output_layout;
+  std::unordered_map<ir::IODesc, ir::TypeInfo> input_type;
+  std::unordered_map<ir::IODesc, ir::TypeInfo> output_type;
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   int graph_dump_level; //< Graph dump level, values between 0 and 2 are valid

--- a/runtime/onert/core/src/compiler/Compiler.h
+++ b/runtime/onert/core/src/compiler/Compiler.h
@@ -56,7 +56,7 @@ public:
   std::unique_ptr<CompilerArtifact> compile(void);
 
 private:
-  CompilerOptions optionForSingleModel(const ir::ModelIndex &model_index);
+  void updateOptionForMultiModel();
 
 private:
   std::unique_ptr<ir::NNPkg> _nnpkg;

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.cc
@@ -34,28 +34,32 @@ void PermutationIOPass::run()
 
   for (auto i = ir::IOIndex{0}; i < ir::IOIndex{_graph.getInputs().size()}; i++)
   {
-    if (_options.input_layout.count(i) == 0 && _options.input_type.count(i) == 0)
+    const auto &iodesc = ir::IODesc{_model_index, _subg_index, i};
+    if (_options.input_layout.count(iodesc) == 0 && _options.input_type.count(iodesc) == 0)
       continue;
 
     const auto index = _graph.getInputs().at(i);
-    const auto &type = _options.input_type.count(i) > 0 ? _options.input_type.at(i)
-                                                        : _graph.operands().at(index).typeInfo();
+    const auto &type = _options.input_type.count(iodesc) > 0
+                         ? _options.input_type.at(iodesc)
+                         : _graph.operands().at(index).typeInfo();
     const auto layout =
-      _options.input_layout.count(i) > 0 ? _options.input_layout.at(i) : ir::Layout::NHWC;
+      _options.input_layout.count(iodesc) > 0 ? _options.input_layout.at(iodesc) : ir::Layout::NHWC;
 
     insertInputPermute(index, type, layout);
   }
 
   for (auto i = ir::IOIndex{0}; i < ir::IOIndex{_graph.getOutputs().size()}; i++)
   {
-    if (_options.output_layout.count(i) == 0 && _options.output_type.count(i) == 0)
+    const auto &iodesc = ir::IODesc{_model_index, _subg_index, i};
+    if (_options.output_layout.count(iodesc) == 0 && _options.output_type.count(iodesc) == 0)
       continue;
 
     const auto index = _graph.getOutputs().at(i);
-    const auto &type = _options.output_type.count(i) > 0 ? _options.output_type.at(i)
-                                                         : _graph.operands().at(index).typeInfo();
-    const auto layout =
-      _options.output_layout.count(i) > 0 ? _options.output_layout.at(i) : ir::Layout::NHWC;
+    const auto &type = _options.output_type.count(iodesc) > 0
+                         ? _options.output_type.at(iodesc)
+                         : _graph.operands().at(index).typeInfo();
+    const auto layout = _options.output_layout.count(iodesc) > 0 ? _options.output_layout.at(iodesc)
+                                                                 : ir::Layout::NHWC;
 
     insertOutputPermute(index, type, layout);
   }

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.h
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.h
@@ -43,8 +43,9 @@ class PermutationIOPass : public Pass
 {
 
 public:
-  PermutationIOPass(ir::Graph &graph, const CompilerOptions &options)
-    : Pass(graph), _options(options)
+  PermutationIOPass(ir::Graph &graph, const CompilerOptions &options,
+                    const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index)
+    : Pass(graph), _options(options), _model_index(model_index), _subg_index(subg_index)
   {
   }
 
@@ -60,6 +61,8 @@ private:
 
 private:
   const compiler::CompilerOptions &_options;
+  const ir::ModelIndex _model_index;
+  const ir::SubgraphIndex _subg_index;
 };
 
 } // namespace pass

--- a/runtime/onert/core/src/compiler/pass/PermutationIOPass.test.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationIOPass.test.cc
@@ -41,9 +41,11 @@ TEST(PermutationIOPass, type)
 
   // Set input/output type to float32
   CompilerOptions options;
-  options.input_type.insert_or_assign(IOIndex{0}, actual_type);
-  options.output_type.insert_or_assign(IOIndex{0}, actual_type);
-  PermutationIOPass{graph, options}.run();
+  options.input_type.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                      actual_type);
+  options.output_type.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                       actual_type);
+  PermutationIOPass{graph, options, ModelIndex{0}, SubgraphIndex{0}}.run();
 
   // Check input/output type is changed to float32
   ASSERT_TRUE(graph.getInputs().at(0) != in);
@@ -84,9 +86,11 @@ TEST(PermutationIOPass, neg_type_skip)
 
   // Set input/output type but same
   CompilerOptions options;
-  options.input_type.insert_or_assign(IOIndex{0}, actual_type);
-  options.output_type.insert_or_assign(IOIndex{0}, actual_type);
-  PermutationIOPass{graph, options}.run();
+  options.input_type.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                      actual_type);
+  options.output_type.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                       actual_type);
+  PermutationIOPass{graph, options, ModelIndex{0}, SubgraphIndex{0}}.run();
 
   // Check input/output is same
   ASSERT_TRUE(graph.getInputs().at(0) == in);
@@ -117,9 +121,11 @@ TEST(PermutationIOPass, layout)
   // Set input/output layout to NCHW
   CompilerOptions options;
   Layout actual_type = Layout::NCHW;
-  options.input_layout.insert_or_assign(IOIndex{0}, actual_type);
-  options.output_layout.insert_or_assign(IOIndex{0}, actual_type);
-  PermutationIOPass{graph, options}.run();
+  options.input_layout.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                        actual_type);
+  options.output_layout.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                         actual_type);
+  PermutationIOPass{graph, options, ModelIndex{0}, SubgraphIndex{0}}.run();
 
   // Check input/output shape is changed to NCHW
   Shape actual_shape{1, 1, 2, 2};
@@ -161,9 +167,11 @@ TEST(PermutationIOPass, neg_layout_skip)
   // Set input/output layout to NHWC (same)
   CompilerOptions options;
   Layout actual_type = Layout::NHWC;
-  options.input_layout.insert_or_assign(IOIndex{0}, actual_type);
-  options.output_layout.insert_or_assign(IOIndex{0}, actual_type);
-  PermutationIOPass{graph, options}.run();
+  options.input_layout.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                        actual_type);
+  options.output_layout.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                         actual_type);
+  PermutationIOPass{graph, options, ModelIndex{0}, SubgraphIndex{0}}.run();
 
   // Check input/output shape is changed to NCHW
   Shape actual_shape{1, 2, 2, 1};

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -290,9 +290,12 @@ public:
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, graph);
     coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-    coptions->input_type.insert_or_assign(IOIndex{0}, TypeInfo(DataType::FLOAT32));
-    coptions->input_type.insert_or_assign(IOIndex{1}, TypeInfo(DataType::FLOAT32));
-    coptions->output_type.insert_or_assign(IOIndex{0}, TypeInfo(DataType::FLOAT32));
+    coptions->input_type.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                          TypeInfo(DataType::FLOAT32));
+    coptions->input_type.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{1}},
+                                          TypeInfo(DataType::FLOAT32));
+    coptions->output_type.insert_or_assign(IODesc{ModelIndex{0}, SubgraphIndex{0}, IOIndex{0}},
+                                           TypeInfo(DataType::FLOAT32));
     auto compiler = onert::compiler::CompilerFactory::get().create(std::make_unique<NNPkg>(model),
                                                                    coptions.get());
     artifact = compiler->compile();
@@ -892,11 +895,11 @@ TEST(ExecInstance, multi_model_dequant_input_quant_output)
   int32_t zero_point = 128;
 
   mockup.coptions->input_type.insert_or_assign(
-    input1, TypeInfo(DataType::QUANT_UINT8_ASYMM, scale, zero_point));
+    mockup.nnpkg->input(input1), TypeInfo(DataType::QUANT_UINT8_ASYMM, scale, zero_point));
   mockup.coptions->input_type.insert_or_assign(
-    input2, TypeInfo(DataType::QUANT_UINT8_ASYMM, scale, zero_point));
+    mockup.nnpkg->input(input2), TypeInfo(DataType::QUANT_UINT8_ASYMM, scale, zero_point));
   mockup.coptions->output_type.insert_or_assign(
-    output, TypeInfo(DataType::QUANT_UINT8_ASYMM, scale, zero_point));
+    mockup.nnpkg->output(output), TypeInfo(DataType::QUANT_UINT8_ASYMM, scale, zero_point));
   mockup.compile();
   auto executors = mockup.artifact->_executors;
 


### PR DESCRIPTION
This commit updates input/output layout and type setting functions to properly handle model signatures. 
This commit changes CompilerOption's I/O layout/type field to use IODesc instead of plain IOIndex.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #15369