### PR TITLE
[onert] Refactor ruy backend to use operation list

### DIFF
--- a/runtime/onert/backend/ruy/CMakeLists.txt
+++ b/runtime/onert/backend/ruy/CMakeLists.txt
@@ -2,7 +2,12 @@ set(LIB_ONERT_BACKEND_RUY onert_backend_ruy)
 
 nnfw_find_package(Ruy REQUIRED)
 
-file(GLOB_RECURSE SOURCES "*.cc")
+file(GLOB SOURCES "*.cc")
+list(APPEND SOURCES ops/OperationUtils.cc)
+macro(OP NAME)
+  list(APPEND SOURCES ops/${NAME}Layer.cc)
+endmacro(OP)
+include(Operation.lst)
 
 add_library(${LIB_ONERT_BACKEND_RUY} SHARED ${SOURCES})
 

--- a/runtime/onert/backend/ruy/KernelGenerator.cc
+++ b/runtime/onert/backend/ruy/KernelGenerator.cc
@@ -16,7 +16,7 @@
 
 #include "KernelGenerator.h"
 
-#include "ops/ConvolutionLayer.h"
+#include "ops/Conv2DLayer.h"
 #include "ops/FullyConnectedLayer.h"
 
 #include <backend/Backend.h>

--- a/runtime/onert/backend/ruy/KernelGenerator.h
+++ b/runtime/onert/backend/ruy/KernelGenerator.h
@@ -39,8 +39,9 @@ public:
   std::unique_ptr<exec::FunctionSequence> generate(ir::OperationIndex ind) override;
 
 private:
-  void visit(const ir::operation::Conv2D &) override;
-  void visit(const ir::operation::FullyConnected &) override;
+#define OP(InternalName) void visit(const ir::operation::InternalName &) override;
+#include "Operation.lst"
+#undef OP
 
 private:
   const ir::Operands &_ctx;

--- a/runtime/onert/backend/ruy/Operation.lst
+++ b/runtime/onert/backend/ruy/Operation.lst
@@ -1,0 +1,2 @@
+OP(Conv2D)
+OP(FullyConnected)

--- a/runtime/onert/backend/ruy/ops/Conv2DLayer.cc
+++ b/runtime/onert/backend/ruy/ops/Conv2DLayer.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "ConvolutionLayer.h"
+#include "Conv2DLayer.h"
 
 #include "../Tensor.h"
 #include "ir/Padding.h"

--- a/runtime/onert/backend/ruy/ops/Conv2DLayer.h
+++ b/runtime/onert/backend/ruy/ops/Conv2DLayer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_RUY_OPS_CONVOLUTIONLAYER_H__
-#define __ONERT_BACKEND_RUY_OPS_CONVOLUTIONLAYER_H__
+#ifndef __ONERT_BACKEND_RUY_OPS_CONV2D_LAYER_H__
+#define __ONERT_BACKEND_RUY_OPS_CONV2D_LAYER_H__
 
 #include <backend/IPortableTensor.h>
 #include "../ExternalContext.h"
@@ -78,4 +78,4 @@ private:
 
 } // namespace onert::backend::ruy::ops
 
-#endif // __ONERT_BACKEND_RUY_OPS_CONVOLUTIONLAYER_H__
+#endif // __ONERT_BACKEND_RUY_OPS_CONV2D_LAYER_H__


### PR DESCRIPTION
This commit refactors the ruy backend to use operation list in CMakeLists.txt and KernelGenerator header. 
It is same with CPU backend.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

CPU backend: https://github.com/Samsung/ONE/pull/16202