### PR TITLE
[onert] Add backend operation validation

### DIFF
--- a/runtime/onert/core/include/backend/Backend.h
+++ b/runtime/onert/core/include/backend/Backend.h
@@ -22,6 +22,7 @@
 #include "ir/Graph.h"
 #include "backend/IConfig.h"
 #include "backend/BackendContext.h"
+#include "backend/ValidatorBase.h"
 
 namespace onert::backend
 {
@@ -38,6 +39,11 @@ public:
   virtual std::shared_ptr<onert::backend::IConfig> config() const = 0;
 
   virtual std::unique_ptr<BackendContext> newContext(ContextData &&) const = 0;
+
+  virtual std::unique_ptr<ValidatorBase> validator(const ir::Graph &graph) const
+  {
+    return std::make_unique<ValidatorBase>(graph);
+  }
 };
 
 } // namespace onert::backend

--- a/runtime/onert/core/include/backend/ValidatorBase.h
+++ b/runtime/onert/core/include/backend/ValidatorBase.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_VALIDATOR_BASE_H__
+#define __ONERT_BACKEND_VALIDATOR_BASE_H__
+
+#include "ir/Graph.h"
+#include "ir/OperationVisitor.h"
+
+namespace onert::backend
+{
+
+class ValidatorBase : public ir::OperationVisitor
+{
+public:
+  virtual ~ValidatorBase() = default;
+  ValidatorBase() = delete;
+  ValidatorBase(const ir::Graph &graph) : _graph(graph), _supported(false) {}
+
+public:
+  virtual bool supported(const ir::IOperation &op) final
+  {
+    op.accept(*this);
+    return _supported;
+  }
+
+protected:
+  using OperationVisitor::visit;
+
+  // TODO: Fix to return false on ValidatorBase when all backends are ready
+  //       Derived classes should override only supported operations, and return true
+#define OP(InternalName) \
+  void visit(const ir::operation::InternalName &) override { _supported = true; }
+#include "ir/Operations.lst"
+#undef OP
+
+protected:
+  const ir::Graph &_graph;
+  bool _supported;
+};
+
+} // namespace onert::backend
+
+#endif // __ONERT_BACKEND_VALIDATOR_BASE_H__

--- a/runtime/onert/core/include/compiler/BackendResolver.h
+++ b/runtime/onert/core/include/compiler/BackendResolver.h
@@ -39,6 +39,11 @@ public:
     _gen_map[index] = backend;
   }
 
+  bool hasBackend(const ir::OperationIndex &index) const
+  {
+    return _gen_map.find(index) != _gen_map.end();
+  }
+
   void
   iterate(const std::function<void(const ir::OperationIndex &, const backend::Backend &)> &fn) const
   {

--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -38,27 +38,27 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
   const auto &manual_options = _options.manual_scheduler_options;
   auto backend_resolver = std::make_unique<compiler::BackendResolver>();
 
-  // This fallback will be used in case that `backend_for_all` is unavailable
-  auto fallback = [&]() -> const backend::Backend * {
-    for (auto &&backend_id : _options.backend_list)
-    {
-      auto backend = resolveBackend(backend_id);
-      if (backend)
-        return backend;
-    }
-    return nullptr;
-  }();
-  if (fallback == nullptr)
+  // This fallback order will be used in case that manual backend mapping is unavailable
+  std::vector<const backend::Backend *> backend_order;
+  for (auto &&backend_id : _options.backend_list)
+  {
+    auto backend = resolveBackend(backend_id);
+    if (backend)
+      backend_order.push_back(backend);
+  }
+  if (backend_order.size() == 0)
     throw std::runtime_error{"No loaded backends available."};
 
   // 1. Backend for All operations
-  const backend::Backend *backend_all = resolveBackend(manual_options.backend_for_all, fallback);
-  VERBOSE(ManualScheduler) << "Default backend for all ops: " << backend_all->config()->id()
-                           << std::endl;
-
-  graph.operations().iterate([&](const ir::OperationIndex &index, const ir::IOperation &) {
-    backend_resolver->setBackend(index, backend_all);
-  });
+  const backend::Backend *backend_all = resolveBackend(manual_options.backend_for_all);
+  if (backend_all)
+  {
+    VERBOSE(ManualScheduler) << "Default backend for all ops: " << backend_all->config()->id()
+                             << std::endl;
+    graph.operations().iterate([&](const ir::OperationIndex &index, const ir::IOperation &) {
+      backend_resolver->setBackend(index, backend_all);
+    });
+  }
 
   // 2. Backend per operation type
   std::unordered_map<ir::OpCode, backend::Backend *> op_type_map;
@@ -75,7 +75,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
     }
   });
 
-  // 3. Backend per operation
+  // 3. Backend per operation index
   for (const auto &[key, val] : manual_options.index_to_backend)
   {
     try
@@ -89,6 +89,44 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
                                << " -> \"" << val << "\"" << std::endl;
     }
   }
+
+  // 4. Fallback - backend priority order
+  std::unordered_map<const backend::Backend *, std::unique_ptr<backend::ValidatorBase>> validators;
+  for (auto &&backend : backend_order)
+  {
+    // Skip train backend because it's not supporting validator
+    // TODO: Remove this condition when train backend supports validator
+    if (backend->config()->id() == "train")
+      continue;
+
+    validators.emplace(backend, backend->validator(graph));
+  }
+
+  graph.operations().iterate([&](const ir::OperationIndex &index, const ir::IOperation &op) {
+    if (!backend_resolver->hasBackend(index))
+    {
+      for (auto backend : backend_order)
+      {
+        // Use train backend if existed
+        // On training mode, we should use train backend only for all operations
+        // TODO: Remove this condition when train backend supports validator
+        if (backend->config()->id() == "train")
+        {
+          backend_resolver->setBackend(index, backend);
+          break;
+        }
+
+        if (validators[backend]->supported(op))
+        {
+          backend_resolver->setBackend(index, backend);
+          break;
+        }
+      }
+      if (!backend_resolver->hasBackend(index))
+        throw std::runtime_error{"No backend found for operation @" +
+                                 std::to_string(index.value())};
+    }
+  });
 
   // Dump final assignment
   WHEN_LOG_ENABLED(backend_resolver->iterate(


### PR DESCRIPTION
This commit adds ValidatorBase class to provide operation validation capabilities for backends. 
The validator uses visitor to check if operations are supported by specific backends. 
And it updates Backend interface to include validator() method and enhance BackendResolver with hasBackend() utility. 
It refactors ManualScheduler to use ordered backend fallback list for better backend selection logic.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #16177
Draft: #16178