### PR TITLE
[onert] Add validator for backends

### DIFF
--- a/runtime/onert/backend/acl_cl/Backend.h
+++ b/runtime/onert/backend/acl_cl/Backend.h
@@ -27,6 +27,7 @@
 #include "TensorManager.h"
 #include "Optimizer.h"
 #include "AclTensorRegistry.h"
+#include "Validator.h"
 
 namespace onert::backend::acl_cl
 {
@@ -54,6 +55,11 @@ public:
     context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr);
     context->optimizer = std::make_shared<Optimizer>(context.get());
     return context;
+  }
+
+  std::unique_ptr<ValidatorBase> validator(const ir::Graph &graph) const override
+  {
+    return std::make_unique<Validator>(graph);
   }
 
 private:

--- a/runtime/onert/backend/acl_cl/Validator.h
+++ b/runtime/onert/backend/acl_cl/Validator.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_ACL_CL_VALIDATOR_H__
+#define __ONERT_BACKEND_ACL_CL_VALIDATOR_H__
+
+#include <backend/ValidatorBase.h>
+
+namespace onert::backend::acl_cl
+{
+
+// TODO Validate inputs, outputs, and parameters of each operation
+class Validator : public backend::ValidatorBase
+{
+public:
+  virtual ~Validator() = default;
+  Validator(const ir::Graph &graph) : backend::ValidatorBase(graph) {}
+
+private:
+#define OP(InternalName) \
+  void visit(const ir::operation::InternalName &) override { _supported = true; }
+#include "Operation.lst"
+#undef OP
+};
+
+} // namespace onert::backend::acl_cl
+
+#endif // __ONERT_BACKEND_ACL_CL_VALIDATOR_H__

--- a/runtime/onert/backend/acl_neon/Backend.h
+++ b/runtime/onert/backend/acl_neon/Backend.h
@@ -27,6 +27,7 @@
 #include "KernelGenerator.h"
 #include "TensorManager.h"
 #include "Optimizer.h"
+#include "Validator.h"
 
 namespace onert::backend::acl_neon
 {
@@ -54,6 +55,11 @@ public:
     context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr);
     context->optimizer = std::make_shared<Optimizer>(context.get());
     return context;
+  }
+
+  std::unique_ptr<ValidatorBase> validator(const ir::Graph &graph) const override
+  {
+    return std::make_unique<Validator>(graph);
   }
 
 private:

--- a/runtime/onert/backend/acl_neon/Validator.h
+++ b/runtime/onert/backend/acl_neon/Validator.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_ACL_NEON_VALIDATOR_H__
+#define __ONERT_BACKEND_ACL_NEON_VALIDATOR_H__
+
+#include <backend/ValidatorBase.h>
+
+namespace onert::backend::acl_neon
+{
+
+// TODO Validate inputs, outputs, and parameters of each operation
+class Validator : public backend::ValidatorBase
+{
+public:
+  virtual ~Validator() = default;
+  Validator(const ir::Graph &graph) : backend::ValidatorBase(graph) {}
+
+private:
+#define OP(InternalName) \
+  void visit(const ir::operation::InternalName &) override { _supported = true; }
+#include "Operation.lst"
+#undef OP
+};
+
+} // namespace onert::backend::acl_neon
+
+#endif // __ONERT_BACKEND_ACL_NEON_VALIDATOR_H__

--- a/runtime/onert/backend/cpu/Backend.h
+++ b/runtime/onert/backend/cpu/Backend.h
@@ -21,6 +21,7 @@
 #include "Config.h"
 #include "KernelGenerator.h"
 #include "SharedMemoryOperands.h"
+#include "Validator.h"
 
 #include <backend/Backend.h>
 
@@ -47,6 +48,11 @@ public:
     context->kernel_gen =
       std::make_shared<KernelGenerator>(graph, tb, tr, context->external_context());
     return context;
+  }
+
+  std::unique_ptr<ValidatorBase> validator(const ir::Graph &graph) const override
+  {
+    return std::make_unique<Validator>(graph);
   }
 
 private:

--- a/runtime/onert/backend/cpu/Validator.h
+++ b/runtime/onert/backend/cpu/Validator.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CPU_VALIDATOR_H__
+#define __ONERT_BACKEND_CPU_VALIDATOR_H__
+
+#include <backend/ValidatorBase.h>
+
+namespace onert::backend::cpu
+{
+
+// TODO Validate inputs, outputs, and parameters of each operation
+class Validator : public backend::ValidatorBase
+{
+public:
+  virtual ~Validator() = default;
+  Validator(const ir::Graph &graph) : backend::ValidatorBase(graph) {}
+
+private:
+#define OP(InternalName) \
+  void visit(const ir::operation::InternalName &) override { _supported = true; }
+#include "Operation.lst"
+#undef OP
+};
+
+} // namespace onert::backend::cpu
+
+#endif // __ONERT_BACKEND_CPU_VALIDATOR_H__

--- a/runtime/onert/backend/ruy/Backend.h
+++ b/runtime/onert/backend/ruy/Backend.h
@@ -20,6 +20,7 @@
 #include "BackendContext.h"
 #include "Config.h"
 #include "KernelGenerator.h"
+#include "Validator.h"
 
 #include <backend/Backend.h>
 
@@ -46,6 +47,11 @@ public:
     context->kernel_gen =
       std::make_shared<KernelGenerator>(graph, tb, tr, context->external_context());
     return context;
+  }
+
+  std::unique_ptr<ValidatorBase> validator(const ir::Graph &graph) const override
+  {
+    return std::make_unique<Validator>(graph);
   }
 
 private:

--- a/runtime/onert/backend/ruy/Validator.h
+++ b/runtime/onert/backend/ruy/Validator.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_RUY_VALIDATOR_H__
+#define __ONERT_BACKEND_RUY_VALIDATOR_H__
+
+#include <backend/ValidatorBase.h>
+
+namespace onert::backend::ruy
+{
+
+// TODO Validate inputs, outputs, and parameters of each operation
+class Validator : public backend::ValidatorBase
+{
+public:
+  virtual ~Validator() = default;
+  Validator(const ir::Graph &graph) : backend::ValidatorBase(graph) {}
+
+private:
+#define OP(InternalName) \
+  void visit(const ir::operation::InternalName &) override { _supported = true; }
+#include "Operation.lst"
+#undef OP
+};
+
+} // namespace onert::backend::ruy
+
+#endif // __ONERT_BACKEND_RUY_VALIDATOR_H__

--- a/runtime/onert/backend/trix/Backend.h
+++ b/runtime/onert/backend/trix/Backend.h
@@ -20,6 +20,7 @@
 #include "BackendContext.h"
 #include "Config.h"
 #include "KernelGenerator.h"
+#include "Validator.h"
 
 #include <backend/Backend.h>
 
@@ -45,6 +46,11 @@ public:
     context->tensor_builder = tb;
     context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, context->dev_context());
     return context;
+  }
+
+  std::unique_ptr<ValidatorBase> validator(const ir::Graph &graph) const override
+  {
+    return std::make_unique<Validator>(graph);
   }
 
 private:

--- a/runtime/onert/backend/trix/Validator.h
+++ b/runtime/onert/backend/trix/Validator.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_TRIX_VALIDATOR_H__
+#define __ONERT_BACKEND_TRIX_VALIDATOR_H__
+
+#include <backend/ValidatorBase.h>
+
+namespace onert::backend::trix
+{
+
+// TODO Validate inputs, outputs, and parameters of each operation
+class Validator : public backend::ValidatorBase
+{
+public:
+  virtual ~Validator() = default;
+  Validator(const ir::Graph &graph) : backend::ValidatorBase(graph) {}
+
+private:
+  void visit(const ir::operation::Bulk &) override { _supported = true; }
+};
+
+} // namespace onert::backend::trix
+
+#endif // __ONERT_BACKEND_TRIX_VALIDATOR_H__


### PR DESCRIPTION
This commit adds Validator class to validate operations in CPU, ACL-CL/NEON, ruy backend. 
The validator uses the operation list macro.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/16177
Draft: https://github.com/Samsung/ONE/pull/16178