### PR TITLE
[infra/compiler] Add ccache support for faster compilation

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -90,6 +90,13 @@ nnas_include(IdentifyPlatform)
 # Configuration flags
 include("cmake/CfgOptionFlags.cmake")
 
+# CCache support
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM AND ENABLE_CCACHE)
+  set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+endif(CCACHE_PROGRAM AND ENABLE_CCACHE)
+
 nnas_find_package(GTest QUIET)
 
 option(ENABLE_TEST "Build Tests using Google Test" ${GTest_FOUND})

--- a/infra/nncc/cmake/CfgOptionFlags.cmake
+++ b/infra/nncc/cmake/CfgOptionFlags.cmake
@@ -57,3 +57,6 @@ option(NNCC_LIBRARY_NO_PIC "Disable PIC option for libraries" OFF)
 # Enable exclusion of a module in compiler with exclude.me file
 # This option is ignored when BUILD_WHITELIST is given
 option(ENABLE_EXCLUDE_ME "Exclude compiler module with exclude.me" ON)
+
+# Enable ccache for faster compilation
+option(ENABLE_CCACHE "Enable ccache for faster compilation" ON)


### PR DESCRIPTION
This commit adds ccache integration to improve build times by caching compilation artifacts.
- Add ENABLE_CCACHE option in CfgOptionFlags.cmake (default ON)
- Configure CMAKE_C_COMPILER_LAUNCHER and CMAKE_CXX_COMPILER_LAUNCHER when ccache is available and enabled

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #16223