### PR TITLE
[infra/onert] Add ccache support for faster compilation

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -98,6 +98,13 @@ include("${CMAKE_CURRENT_LIST_DIR}/infra/cmake/CfgOptionFlags.cmake")
 #      because compile flag setting can be decided using option (ex. ENABLE_COVERAGE)
 include("${CMAKE_CURRENT_LIST_DIR}/infra/cmake/ApplyCompileFlags.cmake")
 
+# CCache support
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM AND ENABLE_CCACHE)
+  set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+endif(CCACHE_PROGRAM AND ENABLE_CCACHE)
+
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 

--- a/runtime/infra/cmake/CfgOptionFlags.cmake
+++ b/runtime/infra/cmake/CfgOptionFlags.cmake
@@ -13,6 +13,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/options/options_${TARGET_PLATFORM}.cmake" OPT
 option(ENABLE_STRICT_BUILD "Treat warning as error" ON)
 option(ENABLE_COVERAGE "Build for coverage test" OFF)
 option(ASAN_BUILD "Address Sanitizer build" OFF)
+option(ENABLE_CCACHE "Enable ccache for faster compilation" ON)
 
 #
 # Default build configuration for runtime


### PR DESCRIPTION
This commit adds ccache integration to improve build times by caching compilation artifacts.
- Add ENABLE_CCACHE option in CfgOptionFlags.cmake (default ON)
- Configure CMAKE_C_COMPILER_LAUNCHER and CMAKE_CXX_COMPILER_LAUNCHER when ccache is available and enabled

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>