### PR TITLE
[infra] Install ccache to docker images

### DIFF
--- a/infra/docker/focal/Dockerfile
+++ b/infra/docker/focal/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:20.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qqy install tzdata
 
 # Build tool
-RUN apt-get update && apt-get -qqy install build-essential cmake scons git lcov g++-arm-linux-gnueabihf g++-aarch64-linux-gnu pkg-config
+RUN apt-get update && apt-get -qqy install build-essential cmake scons git lcov g++-arm-linux-gnueabihf g++-aarch64-linux-gnu pkg-config ccache
 
 # Debian build tool
 RUN apt-get update && apt-get -qqy install fakeroot devscripts debhelper python3-all dh-python
@@ -35,6 +35,9 @@ RUN apt-get update && \
     apt-get -qqy install doxygen graphviz wget zip unzip python3 python3-pip python3-venv python3-dev hdf5-tools curl
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install numpy flatbuffers
+
+# Setup ccache max size: 1.5GB
+RUN ccache -M 1536MB
 
 # Install libtsan_preinit.o manually (workaround for missing package in focal)
 WORKDIR /root/tmp

--- a/infra/docker/jammy/Dockerfile
+++ b/infra/docker/jammy/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:jammy
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qqy install tzdata
 
 # Build tool
-RUN apt-get update && apt-get -qqy install build-essential cmake scons git lcov g++-arm-linux-gnueabihf g++-aarch64-linux-gnu pkg-config
+RUN apt-get update && apt-get -qqy install build-essential cmake scons git lcov g++-arm-linux-gnueabihf g++-aarch64-linux-gnu pkg-config ccache
 
 # Debian build tool
 RUN apt-get update && apt-get -qqy install fakeroot devscripts debhelper python3-all dh-python
@@ -35,6 +35,9 @@ RUN apt-get update && \
     apt-get -qqy install doxygen graphviz wget zip unzip python3 python3-pip python3-venv python3-dev hdf5-tools curl
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install numpy flatbuffers
+
+# Setup ccache max size: 1.5GB
+RUN ccache -M 1536MB
 
 # Setup user to match host user, and give superuser permissions
 ARG USER_ID=1000

--- a/infra/docker/noble/Dockerfile
+++ b/infra/docker/noble/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:noble
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qqy install tzdata
 
 # Build tool
-RUN apt-get update && apt-get -qqy install build-essential cmake scons git lcov g++-arm-linux-gnueabihf g++-aarch64-linux-gnu pkg-config
+RUN apt-get update && apt-get -qqy install build-essential cmake scons git lcov g++-arm-linux-gnueabihf g++-aarch64-linux-gnu pkg-config ccache
 
 # Debian build tool
 RUN apt-get update && apt-get -qqy install fakeroot devscripts debhelper python3-all dh-python
@@ -30,6 +30,9 @@ RUN apt-get update && apt-get -qqy install libboost-all-dev libgflags-dev libgoo
 RUN apt-get update && \
     apt-get -qqy install doxygen graphviz wget zip unzip python3 python3-pip python3-venv python3-dev hdf5-tools curl
 RUN python3 -m pip install numpy flatbuffers --break-system-packages
+
+# Setup ccache max size: 1.5GB
+RUN ccache -M 1536MB
 
 # Setup user ubuntu: give superuser permissions without password
 RUN apt-get update && apt-get -qqy install sudo


### PR DESCRIPTION
This commit installs ccache package and configure 1.5GB cache size in Docker images to improve build performance.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #16223 