### PR TITLE
[onert] Add Attention operator in circle_schema.fbs

### DIFF
--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -37,6 +37,7 @@
 //              ROPE op is added. MXFP4, MXINT8 types are added.
 //              MXQuantization is added.
 // Version 0.10: Base up to TensorFlow Lite v2.20.0 schema. RUN_MODEL op is added.
+//               ATTENTION op is added.
 
 namespace circle;
 
@@ -317,6 +318,7 @@ table Tensor {
 // set of acceptable options.
 // LINT.IfChange
 enum BuiltinOperator : int32 {
+  ATTENTION = -9,
   RUN_MODEL = -8,
   ROPE = -7,
   RMS_NORM = -6,
@@ -673,6 +675,7 @@ union BuiltinOptions {
   BitcastOptions,
   BitwiseXorOptions,
   RightShiftOptions,
+  AttentionOptions = 247,
   RunModelOptions = 248,
   RoPEOptions = 249,
   RmsNormOptions = 250,
@@ -1586,6 +1589,9 @@ table RunModelOptions {
   // Entry subgraph signature.
   // Empty means default entry subgraph (ex. 0th on circle & tflite)
   signature:string;
+}
+
+table AttentionOptions {
 }
 
 // An OperatorCode can be an enum value (BuiltinOperator) if the operator is a

--- a/runtime/libs/circle-schema/circle_schema.fbs
+++ b/runtime/libs/circle-schema/circle_schema.fbs
@@ -37,6 +37,7 @@
 //              ROPE op is added. MXFP4, MXINT8 types are added.
 //              MXQuantization is added.
 // Version 0.10: Base up to TensorFlow Lite v2.20.0 schema. RUN_MODEL op is added.
+//               ATTENTION op is added.
 
 namespace circle;
 
@@ -317,6 +318,7 @@ table Tensor {
 // set of acceptable options.
 // LINT.IfChange
 enum BuiltinOperator : int32 {
+  ATTENTION = -9,
   RUN_MODEL = -8,
   ROPE = -7,
   RMS_NORM = -6,
@@ -673,6 +675,7 @@ union BuiltinOptions {
   BitcastOptions,
   BitwiseXorOptions,
   RightShiftOptions,
+  AttentionOptions = 247,
   RunModelOptions = 248,
   RoPEOptions = 249,
   RmsNormOptions = 250,
@@ -1586,6 +1589,9 @@ table RunModelOptions {
   // Entry subgraph signature.
   // Empty means default entry subgraph (ex. 0th on circle & tflite)
   signature:string;
+}
+
+table AttentionOptions {
 }
 
 // An OperatorCode can be an enum value (BuiltinOperator) if the operator is a


### PR DESCRIPTION
It introduces Attention operator in circle_schema.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

With #16055 and #16056, I confirmed attention op works using GGMA. GGMA generates the exactly same sequence of tokens that HuggingFace transformer (python) generated.