### PR TITLE
[onert] Fix Python binding for tensorinfo

### DIFF
--- a/runtime/onert/api/python/include/nnfw_api_wrapper.h
+++ b/runtime/onert/api/python/include/nnfw_api_wrapper.h
@@ -17,6 +17,8 @@
 #ifndef __ONERT_API_PYTHON_NNFW_API_WRAPPER_H__
 #define __ONERT_API_PYTHON_NNFW_API_WRAPPER_H__
 
+#include <string>
+
 #include "nnfw.h"
 #include "nnfw_experimental.h"
 #include "nnfw_internal.h"
@@ -48,7 +50,7 @@ namespace py = pybind11;
 struct tensorinfo
 {
   /** The data type */
-  const char *dtype;
+  std::string dtype;
   /** The number of dimensions (rank) */
   int32_t rank;
   /**

--- a/runtime/onert/api/python/src/wrapper/nnfw_api_wrapper.cc
+++ b/runtime/onert/api/python/src/wrapper/nnfw_api_wrapper.cc
@@ -156,7 +156,7 @@ void NNFW_SESSION::close_session()
 void NNFW_SESSION::set_input_tensorinfo(uint32_t index, const tensorinfo *tensor_info)
 {
   nnfw_tensorinfo ti;
-  ti.dtype = getType(tensor_info->dtype);
+  ti.dtype = getType(tensor_info->dtype.c_str());
   ti.rank = tensor_info->rank;
   for (int i = 0; i < NNFW_MAX_RANK; i++)
   {


### PR DESCRIPTION
This commits fixes the tensorinfo binding, so it will be possible to set the data type value in the Python code. The tensorinfo refactoring https://github.com/Samsung/ONE/pull/16199 might take some time, so at least make current implementation functional.

Previous behavior:

```python
>>> import onert
>>> ti = onert.tensorinfo()
>>> ti.dtype = 'int32'
>>> ti.dtype
''
```

Behavior after the fix:

```python
>>> import onert
>>> ti = onert.tensorinfo()
>>> ti.dtype = 'int32'
>>> ti.dtype
'int32'
```

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>