### PR TITLE
[onert] Return ValidatorBase false

### DIFF
--- a/runtime/onert/core/include/backend/ValidatorBase.h
+++ b/runtime/onert/core/include/backend/ValidatorBase.h
@@ -40,10 +40,8 @@ public:
 protected:
   using OperationVisitor::visit;
 
-  // TODO: Fix to return false on ValidatorBase when all backends are ready
-  //       Derived classes should override only supported operations, and return true
 #define OP(InternalName) \
-  void visit(const ir::operation::InternalName &) override { _supported = true; }
+  void visit(const ir::operation::InternalName &) override { _supported = false; }
 #include "ir/Operations.lst"
 #undef OP
 


### PR DESCRIPTION
This commit change the default validator behavior to return false for operations instead of true. This ensures proper validation when backends are not ready to handle specific operations.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>