### PR TITLE
[infra/onert] Upgrade flatbuffers for host to v24.3.25

### DIFF
--- a/runtime/infra/buildtool/CMakeLists.txt
+++ b/runtime/infra/buildtool/CMakeLists.txt
@@ -31,25 +31,16 @@ else()
   envoption(EXTERNAL_SERVER_PASSWORD "")
 endif()
 
-set(FLATBUFFERS_URL https://github.com/google/flatbuffers/archive/v23.5.26.tar.gz)
+set(FLATBUFFERS_URL https://github.com/google/flatbuffers/archive/v24.3.25.tar.gz)
 
-# Download and build Flatbuffers 23.5.26
+# Download and build Flatbuffers 24.3.25
 include(ExternalProject)
-ExternalProject_Add(flatbuffers-23.5.26
+ExternalProject_Add(flatbuffers-24.3.25
   URL ${FLATBUFFERS_URL}
   PREFIX  ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers
-  SOURCE_DIR  ${ONERT_EXTERNALS_DIR}/FLATBUFFERS-23.5.26
+  SOURCE_DIR  ${ONERT_EXTERNALS_DIR}/FLATBUFFERS-HOST-24.3.25
   STAMP_DIR ${ONERT_EXTERNALS_DIR}/external-stamp
   INSTALL_DIR ${BUILDTOOL_PATH}
   CMAKE_ARGS  -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${BUILDTOOL_PATH}
               -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF
 )
-
-# Sync with traditional external download tool - stamp
-# TODO Migrate external download tool
-nnfw_include(StampTools)
-set(STAMP_PATH "${ONERT_EXTERNALS_DIR}/FLATBUFFERS-23.5.26.stamp")
-Stamp_Check(URL_CHECK "${STAMP_PATH}" "${FLATBUFFERS_URL}")
-if(NOT URL_CHECK)
-  file(WRITE "${STAMP_PATH}" "${FLATBUFFERS_URL}")
-endif(NOT URL_CHECK)


### PR DESCRIPTION
This commit updates Flatbuffers for host buildtool to version 24.3.25. And it removes legacy stamp synchronization because source download path is divided with source for target flatbuffers.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>