### PR TITLE
Draft: [infra] Remove buildtool preparation and use system flatbuffers

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -100,12 +100,11 @@ export NNCC_WORKSPACE=$(NNCC_FOLDER)
 ###
 ### Default target
 ###
-all: prepare-buildtool prepare-nncc configure build install
+all: prepare-nncc configure build install
 
 ###
 ### Command (build step)
 ###
-prepare-buildtool: prepare_buildtool_internal
 
 prepare-nncc: prepare_nncc_internal
 
@@ -119,7 +118,7 @@ install: install_all_internal
 ### Command (public)
 ###
 # Don't install arm compute
-create-package: prepare-buildtool prepare-nncc configure build install_except_acl runtime_tar_internal
+create-package: prepare-nncc configure build install_except_acl runtime_tar_internal
 
 create-aclpack: configure acl_tar_internal
 
@@ -138,13 +137,9 @@ distclean:
 ###
 ### Command (internal)
 ###
-prepare_buildtool_internal:
-	cmake -S runtime/infra/buildtool -B $(BUILDTOOL_WORKSPACE)/obj -DBUILDTOOL_PATH=$(BUILDTOOL_PATH)
-	cmake --build $(BUILDTOOL_WORKSPACE)/obj/ -j$(NPROCS)
-
 prepare_nncc_internal:
 ifeq (,$(findstring android,$(TARGET_OS)))
-	EXTERNAL_FLATC=$(BUILDTOOL_PATH)/bin/flatc ./nncc configure -DBUILD_GTEST=OFF -DENABLE_TEST=OFF -DEXTERNALS_BUILD_THREADS=$(NPROCS) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+	./nncc configure -DBUILD_GTEST=OFF -DENABLE_TEST=OFF -DEXTERNALS_BUILD_THREADS=$(NPROCS) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DCMAKE_INSTALL_PREFIX=$(OVERLAY_FOLDER) \
 		-DBUILD_WHITELIST="luci;foder;pepper-csv2vec;loco;locop;logo;logo-core;mio-circle;luci-compute;oops;hermes;hermes-std;angkor;pp;pepper-strcast;pepper-str" \
 		$(OPTIONS_NNCC)

--- a/compiler/pics/CMakeLists.txt
+++ b/compiler/pics/CMakeLists.txt
@@ -15,9 +15,9 @@ get_target_property(SCHEMA_BIN_PATH mio_circle BINARY_DIR)
 
 add_custom_command(
   OUTPUT ${CIRCLE_SCHEMA_PYTHON_DIR}
-  COMMAND "$<TARGET_FILE:flatbuffers::flatc>" --python
+  COMMAND "$<TARGET_FILE:flatc-23.5.26>" --python
           -o "${CMAKE_CURRENT_BINARY_DIR}" "${SCHEMA_BIN_PATH}/schema.fbs"
-  DEPENDS flatbuffers::flatc mio_circle
+  DEPENDS flatc-23.5.26 mio_circle
   COMMENT "Generate python interface for circle schema"
 )
 

--- a/infra/cmake/packages/FlatBuffers-23.5.26/FlatBuffersConfig.cmake
+++ b/infra/cmake/packages/FlatBuffers-23.5.26/FlatBuffersConfig.cmake
@@ -1,7 +1,30 @@
 # TODO Remove other Flatbuffers versions
 function(_FlatBuffers_import)
-  find_package(Flatbuffers 23.5.26 QUIET)
-  set(FlatBuffers_FOUND ${Flatbuffers_FOUND} PARENT_SCOPE)
+  if(TARGET flatbuffers-23.5.26)
+    # Already found
+    set(FlatBuffers_FOUND TRUE PARENT_SCOPE)
+    return()
+  endif()
+
+  set(FlatBuffers_FOUND FALSE PARENT_SCOPE)
+
+  # Don't use pre-installed FlatBuffers when cross-compiling
+  if(NOT CMAKE_CROSSCOMPILING)
+    # Clear to avoid infinite recursion
+    # Not need to backup & restore cache value
+    # - We will use same flatbuffers/flatc setting here with installed package on native build
+    # - If we fail to find installed package, cache value will be filled again on 2nd attempt,
+    #   and will not reach here again because of above TARGET checking condition
+    unset(FlatBuffers_DIR CACHE)
+    find_package(FlatBuffers EXACT 23.5.26 QUIET NO_CMAKE_PATH)
+    if(FlatBuffers_FOUND)
+      message(STATUS "Found FlatBuffers ${FlatBuffers_FIND_VERSION}")
+      add_library(flatbuffers-23.5.26 ALIAS flatbuffers::flatbuffers)
+      add_executable(flatc-23.5.26 ALIAS flatbuffers::flatc)
+      set(FlatBuffers_FOUND TRUE PARENT_SCOPE)
+      return()
+    endif(FlatBuffers_FOUND)
+  endif(NOT CMAKE_CROSSCOMPILING)
 endfunction(_FlatBuffers_import)
 
 function(_FlatBuffers_build)
@@ -9,6 +32,11 @@ function(_FlatBuffers_build)
     message(STATUS "FlatBuffersConfig !BUILD_FLATBUFFERS")
     return()
   endif(NOT BUILD_FLATBUFFERS)
+
+  if(TARGET flatbuffers-23.5.26)
+    # Already built
+    return()
+  endif()
 
   nnas_find_package(FlatBuffersSource EXACT 23.5.26 QUIET)
 
@@ -18,41 +46,67 @@ function(_FlatBuffers_build)
     return()
   endif(NOT FlatBuffersSource_FOUND)
 
-  set(ADDITIONAL_CXX_FLAGS "")
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
-    set(ADDITIONAL_CXX_FLAGS "-Wno-error=class-memaccess")
-  endif()
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 12.0)
-    set(ADDITIONAL_CXX_FLAGS "-Wno-error=stringop-overflow")
+  set(FLATBUFFERS_BUILD_TESTS OFF)
+  set(FLATBUFFERS_STATIC_FLATC ON)
+  set(FLATBUFFERS_INSTALL OFF)
+  if(CMAKE_CROSSCOMPILING)
+    set(FLATBUFFERS_BUILD_FLATC OFF)
+  endif(CMAKE_CROSSCOMPILING)
+  add_subdirectory(${FlatBuffersSource_DIR} ${CMAKE_BINARY_DIR}/externals/FLATBUFFERS-23.5.26/build)
+  if(NOT TARGET flatbuffers)
+    message(STATUS "Flatbuffers: failed to build FlatBuffers")
+    return()
   endif()
 
-  nnas_include(ExternalBuildTools)
-  ExternalBuild_CMake(CMAKE_DIR   ${FlatBuffersSource_DIR}
-                      BUILD_DIR   ${CMAKE_BINARY_DIR}/externals/FLATBUFFERS-23.5.26/build
-                      INSTALL_DIR ${EXT_OVERLAY_DIR}
-                      BUILD_FLAGS ${ADDITIONAL_CXX_FLAGS}
-                      IDENTIFIER  "23.5.26"
-                      EXTRA_OPTS  "-DFLATBUFFERS_BUILD_TESTS:BOOL=OFF"
-                                  "-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON"
-                      PKG_NAME    "FLATBUFFERS-23.5.26")
+  set_property(TARGET flatbuffers PROPERTY POSITION_INDEPENDENT_CODE ON)
+  target_compile_options(flatbuffers PUBLIC $<$<CONFIG:Debug>:-Wno-sign-compare>)
+  add_library(flatbuffers-23.5.26 ALIAS flatbuffers)
 
+  if(CMAKE_CROSSCOMPILING)
+    # Build flatc for host manually: set buildtool to gcc/g++ explicitly
+    message(STATUS "Flatbuffers: build flatbuffers for host...")
+    # Use ${FlatBufferSource_VERSION} as suffix to distinguish version change
+    set(FLATC_HOST_BINARY_DIR ${CMAKE_BINARY_DIR}/externals/FLATC-HOST-${FlatBuffersSource_VERSION})
+    execute_process(
+      COMMAND cmake -S ${FlatBuffersSource_DIR} -B ${FLATC_HOST_BINARY_DIR}
+        -DFLATBUFFERS_BUILD_FLATC=ON -DFLATBUFFERS_BUILD_FLATLIB=OFF -DFLATBUFFERS_BUILD_TESTS=OFF
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+      RESULT_VARIABLE FLATC_CONFIG_RESULT
+    )
+    if (NOT FLATC_CONFIG_RESULT EQUAL 0)
+      message(FATAL_ERROR "Flatbuffers: failed to configure host flatc")
+      return()
+    endif()
+
+    set(NUM_BUILD_THREADS 1)
+    if(DEFINED EXTERNALS_BUILD_THREADS)
+      set(NUM_BUILD_THREADS ${EXTERNALS_BUILD_THREADS})
+    endif(DEFINED EXTERNALS_BUILD_THREADS)
+    execute_process(
+      COMMAND cmake --build ${FLATC_HOST_BINARY_DIR} -j ${NUM_BUILD_THREADS}
+      RESULT_VARIABLE FLATC_BUILD_RESULT
+    )
+    if (NOT FLATC_BUILD_RESULT EQUAL 0)
+      message(FATAL_ERROR "Flatbuffers: failed to build host flatc")
+      return()
+    endif()
+
+    add_executable(flatc-23.5.26 IMPORTED GLOBAL)
+    set_property(TARGET flatc-23.5.26 APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+    set_target_properties(flatc-23.5.26 PROPERTIES
+      IMPORTED_LOCATION_RELEASE "${FLATC_HOST_BINARY_DIR}/flatc"
+    )
+  else()
+    add_executable(flatc-23.5.26 ALIAS flatc)
+  endif()
+
+  message(STATUS "Flatbuffers: built FlatBuffers from source")
 endfunction(_FlatBuffers_build)
 
 _FlatBuffers_build()
 _FlatBuffers_import()
 
-# for cross compilation BUILD_HOST_EXEC should be set for host flatc executable
-# flatc should exist as ${BUILD_HOST_EXEC}/overlay/bin/flatc.
-# and then if EXTERNAL_FLATC is set then use ${EXTERNAL_FLATC} file.
-set(FLATC_PATH "$<TARGET_FILE:flatbuffers::flatc>")
-
-if(DEFINED ENV{BUILD_HOST_EXEC})
-  set(FLATC_PATH $ENV{BUILD_HOST_EXEC}/overlay/bin/flatc)
-endif(DEFINED ENV{BUILD_HOST_EXEC})
-if(DEFINED ENV{EXTERNAL_FLATC})
-  set(FLATC_PATH $ENV{EXTERNAL_FLATC})
-endif(DEFINED ENV{EXTERNAL_FLATC})
-
+set(FLATC_PATH "$<TARGET_FILE:flatc-23.5.26>")
 if(FlatBuffers_FOUND)
   if(NOT TARGET flatbuffers-23.5.26)
     add_library(flatbuffers-23.5.26 INTERFACE)


### PR DESCRIPTION
- Remove prepare-buildtool target from Makefile
- Update compiler cmake to build host flatc on cross build when necessary instead of pre built host flatc on separated build process
  - Use almost same process with runtime's host flatc build

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>