### PR TITLE
[infra] Remove symlink workaround for cross-compilation

### DIFF
--- a/.github/workflows/build-pub-dev-docker.yml
+++ b/.github/workflows/build-pub-dev-docker.yml
@@ -87,14 +87,10 @@ jobs:
           branch: master
           name: rootfs_arm_${{ matrix.ubuntu_code }}
 
-      # Workaround: symlink for rootfs checker in cmake toolchain file
       - name: Install rootfs for cross build and build
         run: |
           mkdir -p tools/cross/rootfs
           tar -zxf rootfs_arm_${{ matrix.ubuntu_code }}.tar.gz -C tools/cross/rootfs
-          pushd tools/cross/rootfs/arm
-          ln -sf usr/lib lib
-          popd
           make -f Makefile.template
 
   test-x64-image:

--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -79,14 +79,10 @@ jobs:
           branch: master
           name: rootfs_${{ matrix.platform }}_${{ matrix.ubuntu_code }}
 
-      # Workaround: symlink for rootfs checker in cmake toolchain file
       - name: Install rootfs for cross build
         run: |
           mkdir -p tools/cross/rootfs
           tar -zxf rootfs_${{ matrix.platform }}_${{ matrix.ubuntu_code }}.tar.gz -C tools/cross/rootfs
-          pushd tools/cross/rootfs/${{ matrix.platform }}
-          ln -sf usr/lib lib
-          popd
 
       - name: Build onert
         run: |


### PR DESCRIPTION
This commit removes the temporary symlink creation step that was creating a symbolic link from usr/lib to lib in the cross-compilation rootfs.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>