### PR TITLE
[res/CircleSchema] Update circle_schema.fbs in 0.10

### DIFF
--- a/res/CircleSchema/0.10/circle_schema.fbs
+++ b/res/CircleSchema/0.10/circle_schema.fbs
@@ -37,6 +37,7 @@
 //              ROPE op is added. MXFP4, MXINT8 types are added.
 //              MXQuantization is added.
 // Version 0.10: Base up to TensorFlow Lite v2.20.0 schema. RUN_MODEL op is added.
+//               ATTENTION op is added.
 
 namespace circle;
 
@@ -317,6 +318,7 @@ table Tensor {
 // set of acceptable options.
 // LINT.IfChange
 enum BuiltinOperator : int32 {
+  ATTENTION = -9,
   RUN_MODEL = -8,
   ROPE = -7,
   RMS_NORM = -6,
@@ -673,6 +675,7 @@ union BuiltinOptions {
   BitcastOptions,
   BitwiseXorOptions,
   RightShiftOptions,
+  AttentionOptions = 247,
   RunModelOptions = 248,
   RoPEOptions = 249,
   RmsNormOptions = 250,
@@ -1586,6 +1589,9 @@ table RunModelOptions {
   // Entry subgraph signature.
   // Empty means default entry subgraph (ex. 0th on circle & tflite)
   signature:string;
+}
+
+table AttentionOptions {
 }
 
 // An OperatorCode can be an enum value (BuiltinOperator) if the operator is a


### PR DESCRIPTION
It updates res/CircleSchema/0.10/circle_schema.fbs. It is required to update circle-schema python package.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>