### PR TITLE
[infra] Add SVG files to binary file handling in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,4 @@ res/** linguist-detectable=false
 *.png binary
 *.tar.gz binary
 *.tflite binary
+*.svg binary


### PR DESCRIPTION
This commit adds the .svg file extension to the list of binary files that are handled by gitattributes. 
This ensures that SVG files are not text files, which can prevent issues with line endings and other text-related settings.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>