### PR TITLE
[infra] Add ccache caching to GitHub Actions workflows

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -114,6 +114,12 @@ jobs:
           path: ${{ env.NNCC_WORKSPACE }}/overlay
           key: overlay-onecc-${{ matrix.ubuntu_code }}-${{ hashFiles('compiler/common-artifacts/CMakeLists.txt') }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
 
+      - name: Caching ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-onecc-${{ matrix.ubuntu_code }}
+
       - name: Build
         run: |
           ./nncc configure -DENABLE_STRICT_BUILD=ON -DCMAKE_BUILD_TYPE=${{ matrix.type }} \

--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -72,6 +72,12 @@ jobs:
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
 
+      - name: Caching ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-onert-${{ matrix.ubuntu_code }}
+
       - name: Download rootfs for cross build
         uses: dawidd6/action-download-artifact@v7
         with:

--- a/.github/workflows/run-onert-native-build.yml
+++ b/.github/workflows/run-onert-native-build.yml
@@ -74,6 +74,12 @@ jobs:
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
 
+      - name: Caching ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-onert-${{ matrix.ubuntu_code }}
+
       - name: Build onert
         run: |
           make -f Makefile.template


### PR DESCRIPTION
This commit adds ccache caching step to onecc, onert-cross-build, and onert-native-build workflows to improve build performance.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>