### PR TITLE
[github] Add Ubuntu 24.04 onecc build for push event

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -56,7 +56,7 @@ jobs:
           JSON='{'
           if [[ "$EVENT_NAME" == "push" ]]; then
             JSON+='"type": ["Debug"],'
-            JSON+='"ubuntu_code": ["jammy"]'
+            JSON+='"ubuntu_code": ["jammy", "noble"]'
           elif [[ "$EVENT_NAME" == "pull_request" ]]; then
             JSON+='"type": ["Debug", "Release"],'
             JSON+='"ubuntu_code": ["jammy", "noble"],'


### PR DESCRIPTION
This commit adds Ubuntu Noble (24.04) to the list of supported Ubuntu versions for push events in the onecc build workflow. 
It will maintain external source, overlay, ccache cache for main branch and be used by PRs. 
Without this, each PR will create each own cache which is spending cache space and time.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>