### PR TITLE
[onert] Remove backend assignment workarounds

### DIFF
--- a/runtime/onert/core/src/compiler/CompilerOptions.cc
+++ b/runtime/onert/core/src/compiler/CompilerOptions.cc
@@ -119,14 +119,6 @@ void CompilerOptions::forceInternalOptions()
 
   // Set builtin backend for custom operator
   manual_scheduler_options.opcode_to_backend[ir::OpCode::Custom] = builtin_id;
-
-  // FIXME This is a workaround for bcq operations, should remove it
-  manual_scheduler_options.opcode_to_backend[ir::OpCode::BCQFullyConnected] = "bcq";
-  manual_scheduler_options.opcode_to_backend[ir::OpCode::BCQGather] = "bcq";
-  manual_scheduler_options.opcode_to_backend[ir::OpCode::BCQUnembedding] = "bcq";
-
-  // FIXME This is a workaround for bulk operations, should remove it
-  manual_scheduler_options.opcode_to_backend[ir::OpCode::Bulk] = "trix";
 }
 
 void CompilerOptions::verboseOptions()


### PR DESCRIPTION
This commit removes workarounds for BCQ and Bulk operations that were forcing specific backend assignments. 
Now these operations are assigned by backend ordering and validator automatically.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #16177 