### PR TITLE
[onert] Remove OP_BACKEND_ALLOPS

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_session.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_session.cc
@@ -1117,10 +1117,6 @@ NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
   {
     _coptions->executor = value;
   }
-  else if (skey == config::OP_BACKEND_ALLOPS)
-  {
-    _coptions->manual_scheduler_options.backend_for_all = value;
-  }
   else if (skey == config::USE_SCHEDULER)
   {
     _coptions->he_scheduler = toBool(value);

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -34,7 +34,6 @@ struct ManualSchedulerOptions
 {
   void setBackendMap(const std::string &str);
 
-  std::string backend_for_all;
   std::unordered_map<ir::OpCode, std::string> opcode_to_backend;
   std::unordered_map<ir::OperationIndex, std::string> index_to_backend;
 };

--- a/runtime/onert/core/include/util/Config.lst
+++ b/runtime/onert/core/include/util/Config.lst
@@ -21,7 +21,6 @@
 //     Name                    | Type         | Default
 CONFIG(GRAPH_DOT_DUMP          , int          , "0")
 CONFIG(BACKENDS                , std::string  , "cpu;acl_cl;acl_neon;ruy;xnnpack;gpu_cl;trix;bcq") // FIXME Remove bcq
-CONFIG(OP_BACKEND_ALLOPS       , std::string  , "")
 CONFIG(OP_BACKEND_MAP          , std::string  , "")
 CONFIG(ENABLE_LOG              , bool         , "0")
 CONFIG(CPU_MEMORY_PLANNER      , std::string  , "WIC")

--- a/runtime/onert/core/src/compiler/CompilerOptions.cc
+++ b/runtime/onert/core/src/compiler/CompilerOptions.cc
@@ -86,9 +86,6 @@ std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig()
     // Backend for all
     auto &ms_options = o->manual_scheduler_options;
 
-    // Default value for op_backend_all is first element in the backend list
-    ms_options.backend_for_all = util::getConfigString(util::config::OP_BACKEND_ALLOPS);
-
 // Opcode to Backend
 #define OP(OpName)                                                                      \
   {                                                                                     \
@@ -136,8 +133,6 @@ void CompilerOptions::verboseOptions()
                     << nnfw::misc::join(backend_list.begin(), backend_list.end(), "/") << std::endl;
   VERBOSE(Compiler) << "graph_dump_level         : " << graph_dump_level << std::endl;
   VERBOSE(Compiler) << "executor                 : " << executor << std::endl;
-  VERBOSE(Compiler) << "manual backend_for_all   : " << manual_scheduler_options.backend_for_all
-                    << std::endl;
   VERBOSE(Compiler) << "manual_scheduler_options : "
                     << getOpBackends(manual_scheduler_options.opcode_to_backend) << std::endl;
   VERBOSE(Compiler) << "he_scheduler             : " << he_scheduler << std::endl;

--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -49,18 +49,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
   if (backend_order.size() == 0)
     throw std::runtime_error{"No loaded backends available."};
 
-  // 1. Backend for All operations
-  const backend::Backend *backend_all = resolveBackend(manual_options.backend_for_all);
-  if (backend_all)
-  {
-    VERBOSE(ManualScheduler) << "Default backend for all ops: " << backend_all->config()->id()
-                             << std::endl;
-    graph.operations().iterate([&](const ir::OperationIndex &index, const ir::IOperation &) {
-      backend_resolver->setBackend(index, backend_all);
-    });
-  }
-
-  // 2. Backend per operation type
+  // 1. Backend per operation type
   std::unordered_map<ir::OpCode, backend::Backend *> op_type_map;
   for (const auto &[op_code, backend_name] : manual_options.opcode_to_backend)
   {
@@ -75,7 +64,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
     }
   });
 
-  // 3. Backend per operation index
+  // 2. Backend per operation index
   for (const auto &[key, val] : manual_options.index_to_backend)
   {
     try
@@ -90,7 +79,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
     }
   }
 
-  // 4. Fallback - backend priority order
+  // 3. Fallback - backend priority order
   std::unordered_map<const backend::Backend *, std::unique_ptr<backend::ValidatorBase>> validators;
   for (auto &&backend : backend_order)
   {

--- a/runtime/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
+++ b/runtime/tests/nnfw_api/src/NNPackageTests/AddModelLoaded.test.cc
@@ -213,7 +213,6 @@ TEST_F(ValidationTestAddModelLoaded, debug_set_config)
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "1"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "2"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "EXECUTOR", "Linear"));
-  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "OP_BACKEND_ALLOPS", "cpu"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "USE_SCHEDULER", "0"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "USE_SCHEDULER", "1"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "PROFILING_MODE", "0"));

--- a/runtime/tests/scripts/benchmark_ops.sh
+++ b/runtime/tests/scripts/benchmark_ops.sh
@@ -105,14 +105,13 @@ function run_onert_with_all_config()
         BACKENDS_TO_USE+=$backend';'
         ((++PROFILING_RUN_CNT))
     done
-    export BACKENDS=$BACKENDS_TO_USE
     export EXECUTOR="Linear"
     for backend in $BACKEND_LIST; do
-        export OP_BACKEND_ALLOPS=$backend
+        export BACKENDS=$backend
         run_benchmark_and_print "onert_$backend" "ONERT-${backend^^}"\
                                 $MODEL $REPORT_MODEL_DIR $BENCHMARK_DRIVER_BIN
     done
-    unset EXECUTOR OP_BACKEND_ALLOPS BACKENDS
+    unset EXECUTOR BACKENDS
 }
 
 function run_benchmark_test()

--- a/runtime/tests/scripts/test_scheduler_with_profiling.sh
+++ b/runtime/tests/scripts/test_scheduler_with_profiling.sh
@@ -41,7 +41,7 @@ function run_without_sched()
     local BACKEND=$5
 
     LOG_FILE=$REPORT_MODEL_DIR/tflite_${EXECUTOR,,}_$BACKEND.txt
-    export OP_BACKEND_ALLOPS=$BACKEND
+    export BACKENDS=$BACKEND
     export EXECUTOR=$EXECUTOR
 
     print_with_dots "$EXECUTOR $BACKEND without scheduler"
@@ -180,7 +180,6 @@ function run_benchmark_test()
         unset USE_SCHEDULER
         unset PROFILING_MODE
         unset EXECUTOR
-        unset OP_BACKEND_ALLOPS
     done
     unset BACKENDS
     echo "============================================"

--- a/runtime/tests/scripts/test_scheduler_with_profiling_android.sh
+++ b/runtime/tests/scripts/test_scheduler_with_profiling_android.sh
@@ -76,7 +76,7 @@ function run_without_sched()
 
     #LOG_FILE=$REPORT_MODEL_DIR/tflite_${EXECUTOR,,}_$BACKEND.txt
     LOG_FILE=$REPORT_MODEL_DIR/tflite_$EXECUTOR_$BACKEND.txt
-    export OP_BACKEND_ALLOPS=$BACKEND
+    export BACKENDS=$BACKEND
     export EXECUTOR=$EXECUTOR
 
     print_with_dots "$EXECUTOR $BACKEND without scheduler"
@@ -216,7 +216,6 @@ function run_benchmark_test()
         unset USE_SCHEDULER
         unset PROFILING_MODE
         unset EXECUTOR
-        unset OP_BACKEND_ALLOPS
     done
     unset BACKENDS
     echo "============================================"

--- a/tools/nnpackage_tool/sth2nnpkgtc/pb2nnpkgtc.md
+++ b/tools/nnpackage_tool/sth2nnpkgtc/pb2nnpkgtc.md
@@ -54,7 +54,7 @@ test_model.conv2d_transpose
                         └── input.h5
 
 # @ target
-$ OP_BACKEND_ALLOPS=cpu \
+$ BACKENDS=cpu \
 onert/test/onert-test nnpkg-test test_model.conv2d_transpose
 [  Run  ] ./test_model.out   Pass
 [Compare] ./test_model.out   Pass


### PR DESCRIPTION
This commit removes actually unused OP_BACKEND_ALLOPS configuration option and its associated backend_for_all field from ManualSchedulerOptions. 
Currently, only one BACKENDS list setting is used for this purpose.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>