### PR TITLE
[onert] Replace hardcoded dl library with CMAKE_DL_LIBS

### DIFF
--- a/runtime/contrib/gpu_cl/CMakeLists.txt
+++ b/runtime/contrib/gpu_cl/CMakeLists.txt
@@ -22,7 +22,6 @@ endif ()
 
 target_compile_definitions(${LIB_ONERT_BACKEND_GPU_CL} PRIVATE CL_TARGET_OPENCL_VERSION=220 EGL_NO_X11)
 
-target_link_libraries(${LIB_ONERT_BACKEND_GPU_CL} PRIVATE dl)
 target_link_libraries(${LIB_ONERT_BACKEND_GPU_CL} PRIVATE tflite-gpu-delegate)
 target_link_libraries(${LIB_ONERT_BACKEND_GPU_CL} PRIVATE onert_core)
 target_link_libraries(${LIB_ONERT_BACKEND_GPU_CL} PRIVATE ${LIB_ONERT_BACKEND_CL_COMMON})

--- a/runtime/contrib/labs/tflite_examples/CMakeLists.txt
+++ b/runtime/contrib/labs/tflite_examples/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(tflite_conv_example "src/conv.cpp")
-target_link_libraries(tflite_conv_example tensorflow-lite Threads::Threads dl nnfw_lib_tflite)
+target_link_libraries(tflite_conv_example tensorflow-lite Threads::Threads nnfw_lib_tflite)

--- a/runtime/contrib/npud/core/CMakeLists.txt
+++ b/runtime/contrib/npud/core/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(npud_core PUBLIC ${DBUS_INCLUDE_DIRS})
 target_link_libraries(npud_core PRIVATE nnfw_lib_misc)
 target_link_libraries(npud_core PRIVATE ${GLIB2.0_LIBRARIES})
 target_link_libraries(npud_core PRIVATE Threads::Threads)
-target_link_libraries(npud_core PRIVATE dl)
+target_link_libraries(npud_core PRIVATE ${CMAKE_DL_LIBS})
 target_link_libraries(npud_core PRIVATE npud_dbus)
 
 if(ENVVAR_NPUD_CONFIG)

--- a/runtime/contrib/npud/tests/CMakeLists.txt
+++ b/runtime/contrib/npud/tests/CMakeLists.txt
@@ -12,6 +12,6 @@ target_include_directories(npud_gtest PUBLIC ${GLIB2.0_INCLUDE_DIRS})
 target_link_libraries(npud_gtest PRIVATE ${GLIB2.0_LIBRARIES})
 target_link_libraries(npud_gtest PRIVATE Threads::Threads)
 target_link_libraries(npud_gtest PRIVATE npud_core)
-target_link_libraries(npud_gtest PRIVATE gtest_main dl)
+target_link_libraries(npud_gtest PRIVATE gtest_main)
 
 install(TARGETS npud_gtest DESTINATION npud-gtest)

--- a/runtime/contrib/style_transfer_app/CMakeLists.txt
+++ b/runtime/contrib/style_transfer_app/CMakeLists.txt
@@ -26,7 +26,7 @@ if(JPEG_FOUND)
   target_include_directories(style_transfer_app PRIVATE ${JPEG_INCLUDE_DIRS})
 endif(JPEG_FOUND)
 
-target_link_libraries(style_transfer_app Threads::Threads dl)
+target_link_libraries(style_transfer_app Threads::Threads)
 target_link_libraries(style_transfer_app nnfw-dev)
 target_link_libraries(style_transfer_app arser)
 if(JPEG_FOUND)

--- a/runtime/contrib/tflite_classify/CMakeLists.txt
+++ b/runtime/contrib/tflite_classify/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_EXE_LINKER_FLAGS "-Wl,--as-needed -Wl,--rpath=${ROOTFS_DIR}/usr/lib/ar
 
 add_executable(tflite_classify ${SOURCES})
 target_include_directories(tflite_classify PRIVATE src)
-target_link_libraries(tflite_classify tensorflow-lite Threads::Threads dl nnfw_lib_tflite)
+target_link_libraries(tflite_classify tensorflow-lite Threads::Threads nnfw_lib_tflite)
 target_link_libraries(tflite_classify ${OpenCV_LIBRARIES})
 
 install(TARGETS tflite_classify DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/runtime/infra/cmake/packages/TensorFlowLite/CMakeLists.txt
+++ b/runtime/infra/cmake/packages/TensorFlowLite/CMakeLists.txt
@@ -301,7 +301,7 @@ target_compile_options(tensorflow-lite
   PRIVATE ${TFLITE_TARGET_PRIVATE_OPTIONS}
 )
 set_property(TARGET tensorflow-lite PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(tensorflow-lite eigen flatbuffers::flatbuffers ruy abseil farmhash oourafft::fftsg2d pthreadpool Threads::Threads dl)
+target_link_libraries(tensorflow-lite eigen flatbuffers::flatbuffers ruy abseil farmhash oourafft::fftsg2d pthreadpool Threads::Threads ${CMAKE_DL_LIBS})
 if(NOT ANDROID)
   target_link_libraries(tensorflow-lite rt)
 endif()

--- a/runtime/onert/backend/cpu/CMakeLists.txt
+++ b/runtime/onert/backend/cpu/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(${TEST_ONERT_CPU_BACKEND} ${LIB_ONERT_BACKEND_CPU})
 # Requires linking nnfw_coverage: check header coverage
 target_link_libraries(${TEST_ONERT_CPU_BACKEND} nnfw_common nnfw_coverage)
 target_link_libraries(${TEST_ONERT_CPU_BACKEND} onert_core)
-target_link_libraries(${TEST_ONERT_CPU_BACKEND} gtest gtest_main dl Threads::Threads)
+target_link_libraries(${TEST_ONERT_CPU_BACKEND} gtest gtest_main Threads::Threads)
 
 # Set install rpath to find onert_core, onert_backend_cpu, etc
 set_target_properties(${TEST_ONERT_CPU_BACKEND} PROPERTIES

--- a/runtime/onert/backend/train/CMakeLists.txt
+++ b/runtime/onert/backend/train/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(${TEST_ONERT_TRAIN_BACKEND} ${LIB_ONERT_BACKEND_TRAIN})
 # Requires linking nnfw_coverage: check header coverage
 target_link_libraries(${TEST_ONERT_TRAIN_BACKEND} nnfw_common nnfw_coverage)
 target_link_libraries(${TEST_ONERT_TRAIN_BACKEND} onert_core)
-target_link_libraries(${TEST_ONERT_TRAIN_BACKEND} gtest gtest_main dl Threads::Threads)
+target_link_libraries(${TEST_ONERT_TRAIN_BACKEND} gtest gtest_main Threads::Threads)
 
 # Set install rpath to find onert_core, onert_backend_train, etc
 set_target_properties(${TEST_ONERT_TRAIN_BACKEND} PROPERTIES

--- a/runtime/onert/core/CMakeLists.txt
+++ b/runtime/onert/core/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(onert_core PRIVATE jsoncpp half)
 target_link_libraries(onert_core PRIVATE nnfw_lib_misc nnfw_lib_cker)
 target_link_libraries(onert_core PRIVATE nnfw_common)
 target_link_libraries(onert_core PRIVATE nnfw_coverage)
-target_link_libraries(onert_core PRIVATE dl Threads::Threads)
+target_link_libraries(onert_core PRIVATE ${CMAKE_DL_LIBS} Threads::Threads)
 
 # Ruy
 nnfw_find_package(Ruy REQUIRED)
@@ -74,7 +74,7 @@ add_executable(${TEST_ONERT_CORE} ${TESTS})
 target_link_libraries(${TEST_ONERT_CORE} onert_core)
 # Requires linking nnfw_coverage: check header coverage
 target_link_libraries(${TEST_ONERT_CORE} nnfw_common nnfw_coverage)
-target_link_libraries(${TEST_ONERT_CORE} gtest gtest_main dl Threads::Threads)
+target_link_libraries(${TEST_ONERT_CORE} gtest gtest_main ${CMAKE_DL_LIBS} Threads::Threads)
 
 add_test(${TEST_ONERT_CORE} ${TEST_ONERT_CORE})
 set_target_properties(${TEST_ONERT_CORE} PROPERTIES

--- a/runtime/tests/custom_op/CMakeLists.txt
+++ b/runtime/tests/custom_op/CMakeLists.txt
@@ -37,7 +37,7 @@ function(add_nnfw_custom_op_app NAME)
   target_link_libraries(${NAME} PRIVATE ${LIBNAMELIST})
   target_link_libraries(${NAME} PRIVATE nnfw-dev)
   target_link_libraries(${NAME} PRIVATE nnfw_common)
-  target_link_libraries(${NAME} PRIVATE dl Threads::Threads)
+  target_link_libraries(${NAME} PRIVATE Threads::Threads)
 endfunction()
 
 # Add custom op kernel with nnpackage spec conforming name.

--- a/runtime/tests/nnapi/CMakeLists.txt
+++ b/runtime/tests/nnapi/CMakeLists.txt
@@ -47,7 +47,7 @@ target_compile_definitions(${RUNTIME_NNAPI_TEST} PRIVATE NNTEST_ONLY_PUBLIC_API)
 
 target_link_libraries(${RUNTIME_NNAPI_TEST} onert_nnapi)
 target_link_libraries(${RUNTIME_NNAPI_TEST} gtest gmock)
-target_link_libraries(${RUNTIME_NNAPI_TEST} Threads::Threads dl)
+target_link_libraries(${RUNTIME_NNAPI_TEST} Threads::Threads)
 target_link_libraries(${RUNTIME_NNAPI_TEST} nnfw_common)
 # Set INSTALL_RPATH to find onert_core
 set_target_properties(${RUNTIME_NNAPI_TEST} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib/nnfw")

--- a/runtime/tests/nnapi/bridge/CMakeLists.txt
+++ b/runtime/tests/nnapi/bridge/CMakeLists.txt
@@ -15,7 +15,7 @@ endif(NOT ENABLE_TEST)
 
 add_executable(test_onert_frontend_nnapi ${TESTS_FRONTEND})
 
-target_link_libraries(test_onert_frontend_nnapi ${LIB_NNAPI} dl)
+target_link_libraries(test_onert_frontend_nnapi ${LIB_NNAPI})
 target_link_libraries(test_onert_frontend_nnapi gtest)
 target_link_libraries(test_onert_frontend_nnapi gtest_main)
 # Set INSTALL_RPATH to find onert_core

--- a/runtime/tools/kbenchmark/CMakeLists.txt
+++ b/runtime/tools/kbenchmark/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(kbenchmark ${SOURCES})
 target_compile_options(kbenchmark PRIVATE -Wno-psabi)
 target_include_directories(kbenchmark PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(kbenchmark PUBLIC nonius)
-target_link_libraries(kbenchmark PUBLIC dl)
+target_link_libraries(kbenchmark PUBLIC ${CMAKE_DL_LIBS})
 target_link_libraries(kbenchmark PUBLIC pthread arser)
 install(TARGETS kbenchmark DESTINATION ${CMAKE_INSTALL_BINDIR})
 


### PR DESCRIPTION
This commit replaces hardcoded 'dl' library references with CMAKE_DL_LIBS variable across multiple CMakeLists.txt files to improve cross-platform compatibility. 
It includes removing meaningless 'dl' library linking which is not using dlopen/dlclose in the code.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>