### PR TITLE
[infra] Fix relative paths in nnas, nncc and nnfw scripts

### DIFF
--- a/nnas
+++ b/nnas
@@ -3,12 +3,13 @@
 NNAS_CONFIG_RPATH="infra/config"
 NNAS_COMMAND_RPATH="infra/command"
 NNAS_PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NNAS_COMMAND_PATH="${NNAS_PROJECT_PATH}/${NNAS_COMMAND_RPATH}"
 
 function Usage()
 {
   echo "Usage: $0 [COMMAND] ..."
   echo "Command:"
-  for file in "$NNAS_COMMAND_RPATH"/*;
+  for file in "$NNAS_COMMAND_PATH"/*;
   do
     echo "  $(basename "$file")"
   done
@@ -26,7 +27,7 @@ if [[ -z "${COMMAND}" ]]; then
   exit 255
 fi
 
-COMMAND_FILE="${NNAS_PROJECT_PATH}/${NNAS_COMMAND_RPATH}/${COMMAND}"
+COMMAND_FILE="${NNAS_COMMAND_PATH}/${COMMAND}"
 
 if [[ ! -f "${COMMAND_FILE}" ]]; then
   echo "ERROR: '${COMMAND}' is not supported"

--- a/nncc
+++ b/nncc
@@ -4,13 +4,14 @@ NNCC_SCRIPT_RPATH="scripts"
 NNCC_COMMAND_RPATH="infra/nncc/command"
 
 NNCC_PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NNCC_COMMAND_PATH="${NNCC_PROJECT_PATH}/${NNCC_COMMAND_RPATH}"
 NNCC_SCRIPT_PATH="${NNCC_PROJECT_PATH}/${NNCC_SCRIPT_RPATH}"
 
 function Usage()
 {
   echo "Usage: $0 [COMMAND] ..."
   echo "Command:"
-  for file in "$NNCC_COMMAND_RPATH"/*;
+  for file in "$NNCC_COMMAND_PATH"/*;
   do
     echo "  $(basename "$file")"
   done
@@ -24,7 +25,7 @@ if [[ -z "${COMMAND}" ]]; then
   exit 255
 fi
 
-COMMAND_FILE="${NNCC_PROJECT_PATH}/${NNCC_COMMAND_RPATH}/${COMMAND}"
+COMMAND_FILE="${NNCC_COMMAND_PATH}/${COMMAND}"
 
 if [[ ! -f "${COMMAND_FILE}" ]]; then
   echo "ERROR: '${COMMAND}' is not supported"

--- a/nnfw
+++ b/nnfw
@@ -4,13 +4,14 @@ NNFW_SCRIPT_RPATH="runtime/infra"
 NNFW_COMMAND_RPATH="${NNFW_SCRIPT_RPATH}/command"
 
 NNFW_PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NNFW_COMMAND_PATH="${NNFW_PROJECT_PATH}/${NNFW_COMMAND_RPATH}"
 NNFW_SCRIPT_PATH="${NNFW_PROJECT_PATH}/${NNFW_SCRIPT_RPATH}"
 
 function Usage()
 {
   echo "Usage: $0 [COMMAND] ..."
   echo "Command:"
-  for file in "$NNFW_COMMAND_RPATH"/*;
+  for file in "$NNFW_COMMAND_PATH"/*;
   do
     echo "  $(basename "$file")"
   done
@@ -23,7 +24,7 @@ if [[ -z "${COMMAND}" ]]; then
   exit 255
 fi
 
-COMMAND_FILE="${NNFW_PROJECT_PATH}/${NNFW_COMMAND_RPATH}/${COMMAND}"
+COMMAND_FILE="${NNFW_COMMAND_PATH}/${COMMAND}"
 
 if [[ ! -f "${COMMAND_FILE}" ]]; then
   echo "ERROR: '${COMMAND}' is not supported"


### PR DESCRIPTION
This commit fixes the problem where it is not possible to use the nn* scripts outside of the project's root directory.

#### Testing

Verified locally that now it is possible to list and run commands when outside of the repo dir:

```console
$ ONE/nnas
Usage: ONE/nnas [COMMAND] ...
Command:
  copyright-check
  ...
  verify-package
$ ONE/nncc configure
-- The C compiler identification is GNU 13.3.0
  ...
$ ONE/nnfw configure
-- Building for x86-64 Linux
  ...
```

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>