### PR TITLE
[onert] Remove log in NNPkg.addEdge

### DIFF
--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -180,11 +180,7 @@ public:
    * @param[in] from from IODesc
    * @param[in] to   to IODesc
    */
-  void addEdge(const IODesc &from, const IODesc &to)
-  {
-    std::cout << from << " -> " << to << std::endl;
-    _edges.edges.insert(ModelEdge{from, to});
-  }
+  void addEdge(const IODesc &from, const IODesc &to) { _edges.edges.insert(ModelEdge{from, to}); }
   /**
    * @brief   Get model edge set
    * @return  Edge set reference


### PR DESCRIPTION
It removes the verbose log messages, which always is printed.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Currently,

```
$ Product/x86_64-linux.debug/out/bin/ggma_run tinyllama
Package Filename tinyllama
0:0:0 -> 1:0:0
1:0:2 -> 2:0:0
2:0:2 -> 3:0:0
3:0:2 -> 4:0:0
4:0:2 -> 5:0:0
5:0:2 -> 6:0:0
6:0:2 -> 7:0:0
7:0:2 -> 8:0:0
...
```