### PR TITLE
[onert] Remove naming redundancy from runtime exceptions

### DIFF
--- a/runtime/onert/core/include/util/Exceptions.h
+++ b/runtime/onert/core/include/util/Exceptions.h
@@ -22,11 +22,11 @@
 namespace onert
 {
 
-class OnertException : public std::exception
+class Exception : public std::exception
 {
 public:
-  OnertException(const std::string &msg) : _msg{msg} {}
-  OnertException(const std::string &tag, const std::string &msg) : _msg{tag + " : " + msg} {}
+  Exception(const std::string &msg) : _msg{msg} {}
+  Exception(const std::string &tag, const std::string &msg) : _msg{tag + " : " + msg} {}
 
   const char *what() const noexcept override { return _msg.c_str(); }
 
@@ -34,11 +34,11 @@ private:
   std::string _msg;
 };
 
-class InsufficientBufferSizeException : public OnertException
+class InsufficientBufferSizeException : public Exception
 {
 public:
   InsufficientBufferSizeException(const std::string &msg)
-    : OnertException{"InsufficientBufferSize", msg}
+    : Exception{"Insufficient buffer size", msg}
   {
   }
 };


### PR DESCRIPTION
This commit removes redundancy from the runtime base exception by renaming `onert::OnertException` to `onert::Exception`. Also, added spaces to the `InsufficientBufferSizeException` exception message so it will be easier to read it - exception message is for humans after all.

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>