### PR TITLE
[onert] Rename nnfw_session to Session with namespace

### DIFF
--- a/runtime/onert/api/nnfw/src/Session.cc
+++ b/runtime/onert/api/nnfw/src/Session.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "nnfw_session.h"
+#include "Session.h"
 
 #include "compiler/CompilerFactory.h"
 #include "exporter/CircleExporter.h"
@@ -245,7 +245,10 @@ uint64_t getBufSize(const nnfw_tensorinfo *info)
 }
 } // namespace
 
-nnfw_session::nnfw_session()
+namespace onert::api
+{
+
+Session::Session()
   : _nnpkg{nullptr}, _coptions{onert::compiler::CompilerOptions::fromGlobalConfig()},
     _compiler_artifact{nullptr}, _execution{nullptr}, _kernel_registry{nullptr},
     _train_info{nullptr}, _quant_manager{std::make_unique<onert::odc::QuantizeManager>()},
@@ -255,13 +258,13 @@ nnfw_session::nnfw_session()
   // DO NOTHING
 }
 
-NNFW_STATUS nnfw_session::create(nnfw_session **session)
+NNFW_STATUS Session::create(Session **session)
 {
   if (session == nullptr)
     return NNFW_STATUS_UNEXPECTED_NULL;
   try
   {
-    auto new_session = std::unique_ptr<nnfw_session>(new nnfw_session());
+    auto new_session = std::unique_ptr<Session>(new Session());
     new_session->_kernel_registry = std::make_shared<onert::api::CustomKernelRegistry>();
     *session = new_session.release();
   }
@@ -280,9 +283,9 @@ NNFW_STATUS nnfw_session::create(nnfw_session **session)
   return NNFW_STATUS_NO_ERROR;
 }
 
-nnfw_session::~nnfw_session() = default;
+Session::~Session() = default;
 
-NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
+NNFW_STATUS Session::load_circle_from_buffer(uint8_t *buffer, size_t size)
 {
   if (!isStateInitialized())
     return NNFW_STATUS_INVALID_STATE;
@@ -309,7 +312,7 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::load_model_from_path(const char *path)
+NNFW_STATUS Session::load_model_from_path(const char *path)
 {
   if (!isStateInitialized())
     return NNFW_STATUS_INVALID_STATE;
@@ -448,7 +451,7 @@ NNFW_STATUS nnfw_session::load_model_from_path(const char *path)
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::prepare()
+NNFW_STATUS Session::prepare()
 {
   // NOTE. If users want to run prepare() more than one time, this could be removed.
   if (!isStateModelLoaded())
@@ -483,11 +486,11 @@ NNFW_STATUS nnfw_session::prepare()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::run()
+NNFW_STATUS Session::run()
 {
   if (!isStatePreparedOrFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::run : "
+    std::cerr << "Error during Session::run : "
               << "run should be run after prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
@@ -499,12 +502,12 @@ NNFW_STATUS nnfw_session::run()
   catch (const onert::InsufficientBufferSizeException &e)
   {
     // Currently insufficient buffer always means output buffer.
-    std::cerr << "Error during nnfw_session::run : " << e.what() << std::endl;
+    std::cerr << "Error during Session::run : " << e.what() << std::endl;
     return NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE;
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::run : " << e.what() << std::endl;
+    std::cerr << "Error during Session::run : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
@@ -512,11 +515,11 @@ NNFW_STATUS nnfw_session::run()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::run_async()
+NNFW_STATUS Session::run_async()
 {
   if (!isStatePreparedOrFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::run_async : "
+    std::cerr << "Error during Session::run_async : "
               << "run_async should be run after prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
@@ -527,11 +530,11 @@ NNFW_STATUS nnfw_session::run_async()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::await()
+NNFW_STATUS Session::await()
 {
   if (!isStateRunning())
   {
-    std::cerr << "Error during nnfw_session::run_await : "
+    std::cerr << "Error during Session::run_await : "
               << "run_await should be run after run_async" << std::endl;
     return NNFW_STATUS_ERROR;
   }
@@ -542,19 +545,18 @@ NNFW_STATUS nnfw_session::await()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_input(uint32_t index, NNFW_TYPE, const void *buffer, size_t length)
+NNFW_STATUS Session::set_input(uint32_t index, NNFW_TYPE, const void *buffer, size_t length)
 {
   if (!isStatePreparedOrFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::set_input : invalid state" << std::endl;
+    std::cerr << "Error during Session::set_input : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
   if (!buffer && length != 0)
   {
-    std::cerr
-      << "Error during nnfw_session::set_input : given buffer is NULL but the length is not 0"
-      << std::endl;
+    std::cerr << "Error during Session::set_input : given buffer is NULL but the length is not 0"
+              << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
@@ -564,25 +566,24 @@ NNFW_STATUS nnfw_session::set_input(uint32_t index, NNFW_TYPE, const void *buffe
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_input : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_input : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_output(uint32_t index, NNFW_TYPE, void *buffer, size_t length)
+NNFW_STATUS Session::set_output(uint32_t index, NNFW_TYPE, void *buffer, size_t length)
 {
   if (!isStatePreparedOrFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::set_output : invalid state" << std::endl;
+    std::cerr << "Error during Session::set_output : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
   if (!buffer && length != 0)
   {
-    std::cerr
-      << "Error during nnfw_session::set_output : given buffer is NULL but the length is not 0"
-      << std::endl;
+    std::cerr << "Error during Session::set_output : given buffer is NULL but the length is not 0"
+              << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
@@ -592,13 +593,13 @@ NNFW_STATUS nnfw_session::set_output(uint32_t index, NNFW_TYPE, void *buffer, si
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_output : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_output : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::input_size(uint32_t *number)
+NNFW_STATUS Session::input_size(uint32_t *number)
 {
   if (isStateInitialized()) // Model is not loaded
     return NNFW_STATUS_INVALID_STATE;
@@ -607,20 +608,20 @@ NNFW_STATUS nnfw_session::input_size(uint32_t *number)
   {
     if (number == nullptr)
     {
-      std::cerr << "Error during nnfw_session::input_size, number is null pointer." << std::endl;
+      std::cerr << "Error during Session::input_size, number is null pointer." << std::endl;
       return NNFW_STATUS_UNEXPECTED_NULL;
     }
     *number = getInputSize();
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::input_size : " << e.what() << std::endl;
+    std::cerr << "Error during Session::input_size : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::output_size(uint32_t *number)
+NNFW_STATUS Session::output_size(uint32_t *number)
 {
   if (isStateInitialized()) // Model is not loaded
     return NNFW_STATUS_INVALID_STATE;
@@ -629,24 +630,24 @@ NNFW_STATUS nnfw_session::output_size(uint32_t *number)
   {
     if (number == nullptr)
     {
-      std::cerr << "Error during nnfw_session::output_size, number is null pointer." << std::endl;
+      std::cerr << "Error during Session::output_size, number is null pointer." << std::endl;
       return NNFW_STATUS_UNEXPECTED_NULL;
     }
     *number = getOutputSize();
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::output_size" << e.what() << std::endl;
+    std::cerr << "Error during Session::output_size" << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_input_layout(uint32_t index, NNFW_LAYOUT layout)
+NNFW_STATUS Session::set_input_layout(uint32_t index, NNFW_LAYOUT layout)
 {
   if (!isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::set_input_layout : "
+    std::cerr << "Error during Session::set_input_layout : "
               << "run should be run before prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
@@ -656,14 +657,14 @@ NNFW_STATUS nnfw_session::set_input_layout(uint32_t index, NNFW_LAYOUT layout)
     if (layout != NNFW_LAYOUT_NONE && layout != NNFW_LAYOUT_CHANNELS_FIRST &&
         layout != NNFW_LAYOUT_CHANNELS_LAST)
     {
-      std::cerr << "Error during nnfw_session::set_input_layout, not supported layout" << std::endl;
+      std::cerr << "Error during Session::set_input_layout, not supported layout" << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
     if (_selected_signature.valid())
     {
       // TODO Support this
-      std::cerr << "Error during nnfw_session::set_input_layout : "
+      std::cerr << "Error during Session::set_input_layout : "
                 << "set_input_layout after signature selection is not supported yet" << std::endl;
       return NNFW_STATUS_ERROR;
     }
@@ -680,17 +681,17 @@ NNFW_STATUS nnfw_session::set_input_layout(uint32_t index, NNFW_LAYOUT layout)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_input_layout : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_input_layout : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
+NNFW_STATUS Session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
 {
   if (!isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::set_output_layout : "
+    std::cerr << "Error during Session::set_output_layout : "
               << "run should be run before prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
@@ -700,15 +701,14 @@ NNFW_STATUS nnfw_session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
     if (layout != NNFW_LAYOUT_NONE && layout != NNFW_LAYOUT_CHANNELS_FIRST &&
         layout != NNFW_LAYOUT_CHANNELS_LAST)
     {
-      std::cerr << "Error during nnfw_session::set_output_layout, not supported layout"
-                << std::endl;
+      std::cerr << "Error during Session::set_output_layout, not supported layout" << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
     if (_selected_signature.valid())
     {
       // TODO Support this
-      std::cerr << "Error during nnfw_session::set_output_layout : "
+      std::cerr << "Error during Session::set_output_layout : "
                 << "set_output_layout after signature selection is not supported yet" << std::endl;
       return NNFW_STATUS_ERROR;
     }
@@ -726,17 +726,17 @@ NNFW_STATUS nnfw_session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_output_layout : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_output_layout : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_input_type(uint32_t index, NNFW_TYPE type)
+NNFW_STATUS Session::set_input_type(uint32_t index, NNFW_TYPE type)
 {
   if (!isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::set_input_type : "
+    std::cerr << "Error during Session::set_input_type : "
               << "set_input_type should be called before prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
@@ -745,14 +745,14 @@ NNFW_STATUS nnfw_session::set_input_type(uint32_t index, NNFW_TYPE type)
   {
     if (type != NNFW_TYPE_TENSOR_FLOAT32)
     {
-      std::cerr << "Error during nnfw_session::set_input_type, not supported type" << std::endl;
+      std::cerr << "Error during Session::set_input_type, not supported type" << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
     if (_selected_signature.valid())
     {
       // TODO Support this
-      std::cerr << "Error during nnfw_session::set_input_type : "
+      std::cerr << "Error during Session::set_input_type : "
                 << "set_input_type after signature selection is not supported yet" << std::endl;
       return NNFW_STATUS_ERROR;
     }
@@ -770,18 +770,18 @@ NNFW_STATUS nnfw_session::set_input_type(uint32_t index, NNFW_TYPE type)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_input_type : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_input_type : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
+NNFW_STATUS Session::set_output_type(uint32_t index, NNFW_TYPE type)
 {
   if (!isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::set_output_type : "
+    std::cerr << "Error during Session::set_output_type : "
               << "set_output_type should be called before prepare" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
@@ -790,14 +790,14 @@ NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
   {
     if (type != NNFW_TYPE_TENSOR_FLOAT32)
     {
-      std::cerr << "Error during nnfw_session::set_output_type, not supported type" << std::endl;
+      std::cerr << "Error during Session::set_output_type, not supported type" << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
     if (_selected_signature.valid())
     {
       // TODO Support this
-      std::cerr << "Error during nnfw_session::set_output_type : "
+      std::cerr << "Error during Session::set_output_type : "
                 << "set_output_type after signature selection is not supported yet" << std::endl;
       return NNFW_STATUS_ERROR;
     }
@@ -815,14 +815,14 @@ NNFW_STATUS nnfw_session::set_output_type(uint32_t index, NNFW_TYPE type)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_output_type : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_output_type : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti)
+NNFW_STATUS Session::set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti)
 {
   // sanity check
   {
@@ -835,8 +835,7 @@ NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensor
 
     if (ti == nullptr)
     {
-      std::cerr << "Error during nnfw_session::set_input_tensorinfo : tensorinfo is null"
-                << std::endl;
+      std::cerr << "Error during Session::set_input_tensorinfo : tensorinfo is null" << std::endl;
       return NNFW_STATUS_UNEXPECTED_NULL;
     }
 
@@ -867,13 +866,13 @@ NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensor
     _selected_signature.valid() ? _nnpkg->changeInputShape(_selected_signature, index, new_shape)
                                 : _nnpkg->changeInputShape(input_index, new_shape);
   }
-  else // when called after nnfw_session::prepare()
+  else // when called after Session::prepare()
     _execution->changeInputShape(input_index, new_shape);
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
+NNFW_STATUS Session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
 {
   if (isStateInitialized())
     return NNFW_STATUS_INVALID_STATE;
@@ -882,15 +881,14 @@ NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
   {
     if (ti == nullptr)
     {
-      std::cerr << "Error during nnfw_session::input_tensorinfo, tensorinfo is null pointer."
+      std::cerr << "Error during Session::input_tensorinfo, tensorinfo is null pointer."
                 << std::endl;
       return NNFW_STATUS_UNEXPECTED_NULL;
     }
 
     if (index >= getInputSize())
     {
-      std::cerr << "Error during nnfw_session::input_tensorinfo, index is out of range."
-                << std::endl;
+      std::cerr << "Error during Session::input_tensorinfo, index is out of range." << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
@@ -909,20 +907,20 @@ NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::input_tensorinfo : " << e.what() << std::endl;
+    std::cerr << "Error during Session::input_tensorinfo : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
+NNFW_STATUS Session::output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
 {
   if (isStateInitialized())
     return NNFW_STATUS_INVALID_STATE;
 
   if (ti == nullptr)
   {
-    std::cerr << "Error during nnfw_session::output_tensorinfo, tensorinfo is null pointer."
+    std::cerr << "Error during Session::output_tensorinfo, tensorinfo is null pointer."
               << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
@@ -931,8 +929,7 @@ NNFW_STATUS nnfw_session::output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
   {
     if (index >= getOutputSize())
     {
-      std::cerr << "Error during nnfw_session::output_tensorinfo, index is out of range."
-                << std::endl;
+      std::cerr << "Error during Session::output_tensorinfo, index is out of range." << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
@@ -952,37 +949,36 @@ NNFW_STATUS nnfw_session::output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::output_tensorinfo : " << e.what() << std::endl;
+    std::cerr << "Error during Session::output_tensorinfo : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::register_custom_operation(const std::string &id,
-                                                    nnfw_custom_eval eval_func)
+NNFW_STATUS Session::register_custom_operation(const std::string &id, nnfw_custom_eval eval_func)
 {
   _kernel_registry->registerKernel(id, eval_func);
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::get_output(uint32_t index, nnfw_tensorinfo *ti, const void **out_buffer)
+NNFW_STATUS Session::get_output(uint32_t index, nnfw_tensorinfo *ti, const void **out_buffer)
 {
   if (ti == nullptr)
   {
-    std::cerr << "Error during nnfw_session::get_output : tensor info is null" << std::endl;
+    std::cerr << "Error during Session::get_output : tensor info is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (out_buffer == nullptr)
   {
-    std::cerr << "Error during nnfw_session::get_output : output buffer is null" << std::endl;
+    std::cerr << "Error during Session::get_output : output buffer is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (!isStateFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::get_output : invalid state" << std::endl;
+    std::cerr << "Error during Session::get_output : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -990,14 +986,14 @@ NNFW_STATUS nnfw_session::get_output(uint32_t index, nnfw_tensorinfo *ti, const 
   {
     if (index >= getOutputSize())
     {
-      std::cerr << "Error during nnfw_session::get_output, index " << index
+      std::cerr << "Error during Session::get_output, index " << index
                 << " is out of range. (output count: " << getOutputSize() << ")" << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
     if (!_coptions->internal_output_alloc)
     {
-      std::cerr << "Error during nnfw_session::get_output: "
+      std::cerr << "Error during Session::get_output: "
                 << "internal output allocation is not enabled. "
                 << "Call nnfw_set_prepare_config(session, "
                    "NNFW_PREPARE_CONFIG_ENABLE_INTERNAL_OUTPUT_ALLOC, \"true\") "
@@ -1015,14 +1011,14 @@ NNFW_STATUS nnfw_session::get_output(uint32_t index, nnfw_tensorinfo *ti, const 
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::get_output : " << e.what() << std::endl;
+    std::cerr << "Error during Session::get_output : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
+NNFW_STATUS Session::set_available_backends(const char *backends)
 {
   if (!isStateModelLoaded())
     return NNFW_STATUS_INVALID_STATE;
@@ -1040,13 +1036,13 @@ NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_available_backends : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_available_backends : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_workspace(const char *dir)
+NNFW_STATUS Session::set_workspace(const char *dir)
 {
   // TODO Check dir read & write permission
 
@@ -1061,14 +1057,14 @@ NNFW_STATUS nnfw_session::set_workspace(const char *dir)
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::configure_signature(const char *signature)
+NNFW_STATUS Session::configure_signature(const char *signature)
 {
   if (!signature)
     return NNFW_STATUS_UNEXPECTED_NULL;
 
   if (!isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::configure_signature : invalid state" << std::endl;
+    std::cerr << "Error during Session::configure_signature : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1082,19 +1078,19 @@ NNFW_STATUS nnfw_session::configure_signature(const char *signature)
     }
   }
 
-  std::cerr << "Error during nnfw_session::configure_signature : cannot find signature \""
-            << signature << "\"" << std::endl;
+  std::cerr << "Error during Session::configure_signature : cannot find signature \"" << signature
+            << "\"" << std::endl;
   return NNFW_STATUS_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_signature_run(const char *signature)
+NNFW_STATUS Session::set_signature_run(const char *signature)
 {
   if (!signature)
     return NNFW_STATUS_UNEXPECTED_NULL;
 
   if (!isStatePreparedOrFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::set_signature_run : invalid state" << std::endl;
+    std::cerr << "Error during Session::set_signature_run : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1108,17 +1104,17 @@ NNFW_STATUS nnfw_session::set_signature_run(const char *signature)
     }
   }
 
-  std::cerr << "Error during nnfw_session::set_signature_run : cannot find signature" << std::endl;
+  std::cerr << "Error during Session::set_signature_run : cannot find signature" << std::endl;
   return NNFW_STATUS_ERROR;
 }
 
-NNFW_STATUS nnfw_session::deprecated(const char *msg)
+NNFW_STATUS Session::deprecated(const char *msg)
 {
   std::cerr << msg << std::endl;
   return NNFW_STATUS_DEPRECATED_API;
 }
 
-NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
+NNFW_STATUS Session::set_config(const char *key, const char *value)
 {
   if (!isStateModelLoaded())
     return NNFW_STATUS_INVALID_STATE;
@@ -1164,7 +1160,7 @@ NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
   return NNFW_STATUS_NO_ERROR;
 }
 
-const onert::ir::IGraph *nnfw_session::primary_subgraph()
+const onert::ir::IGraph *Session::primary_subgraph()
 {
   if (_nnpkg != nullptr)
   {
@@ -1179,7 +1175,7 @@ const onert::ir::IGraph *nnfw_session::primary_subgraph()
   }
 }
 
-uint32_t nnfw_session::getInputSize()
+uint32_t Session::getInputSize()
 {
   if (isStateInitialized())
     throw std::runtime_error{"Model is not loaded yet"};
@@ -1191,7 +1187,7 @@ uint32_t nnfw_session::getInputSize()
   return _execution->inputSize();
 }
 
-uint32_t nnfw_session::getOutputSize()
+uint32_t Session::getOutputSize()
 {
   if (isStateInitialized())
     throw std::runtime_error{"Model is not loaded yet"};
@@ -1203,8 +1199,8 @@ uint32_t nnfw_session::getOutputSize()
   return _execution->outputSize();
 }
 
-NNFW_STATUS nnfw_session::loadModelFile(const std::string &model_file_path,
-                                        const std::string &model_type)
+NNFW_STATUS Session::loadModelFile(const std::string &model_file_path,
+                                   const std::string &model_type)
 {
   auto model = loadModel(model_file_path, model_type);
   if (model == nullptr)
@@ -1222,7 +1218,7 @@ NNFW_STATUS nnfw_session::loadModelFile(const std::string &model_file_path,
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::get_config(const char *key, char *value, size_t value_size)
+NNFW_STATUS Session::get_config(const char *key, char *value, size_t value_size)
 {
   if (!isStateModelLoaded())
     return NNFW_STATUS_INVALID_STATE;
@@ -1269,7 +1265,7 @@ NNFW_STATUS nnfw_session::get_config(const char *key, char *value, size_t value_
   return NNFW_STATUS_NO_ERROR;
 }
 
-bool nnfw_session::isStateInitialized()
+bool Session::isStateInitialized()
 {
   if (_state == State::INITIALIZED)
   {
@@ -1283,7 +1279,7 @@ bool nnfw_session::isStateInitialized()
   }
 }
 
-bool nnfw_session::isStateModelLoaded()
+bool Session::isStateModelLoaded()
 {
   if (_state == State::MODEL_LOADED)
   {
@@ -1297,7 +1293,7 @@ bool nnfw_session::isStateModelLoaded()
   }
 }
 
-bool nnfw_session::isStatePrepared()
+bool Session::isStatePrepared()
 {
   if (_state == State::PREPARED)
   {
@@ -1311,7 +1307,7 @@ bool nnfw_session::isStatePrepared()
   }
 }
 
-bool nnfw_session::isStateRunning()
+bool Session::isStateRunning()
 {
   if (_state == State::RUNNING)
   {
@@ -1322,7 +1318,7 @@ bool nnfw_session::isStateRunning()
   return false;
 }
 
-bool nnfw_session::isStateFinishedRun()
+bool Session::isStateFinishedRun()
 {
   if (_state == State::FINISHED_RUN)
   {
@@ -1336,22 +1332,19 @@ bool nnfw_session::isStateFinishedRun()
   }
 }
 
-bool nnfw_session::isStatePreparedOrFinishedRun()
-{
-  return isStatePrepared() || isStateFinishedRun();
-}
+bool Session::isStatePreparedOrFinishedRun() { return isStatePrepared() || isStateFinishedRun(); }
 
-NNFW_STATUS nnfw_session::input_tensorindex(const char *tensorname, uint32_t *index)
+NNFW_STATUS Session::input_tensorindex(const char *tensorname, uint32_t *index)
 {
   return getTensorIndexImpl(*primary_subgraph(), tensorname, index, true);
 }
 
-NNFW_STATUS nnfw_session::output_tensorindex(const char *tensorname, uint32_t *index)
+NNFW_STATUS Session::output_tensorindex(const char *tensorname, uint32_t *index)
 {
   return getTensorIndexImpl(*primary_subgraph(), tensorname, index, false);
 }
 
-NNFW_STATUS nnfw_session::set_backends_per_operation(const char *backend_settings)
+NNFW_STATUS Session::set_backends_per_operation(const char *backend_settings)
 {
   if (backend_settings == NULL)
     return NNFW_STATUS_ERROR;
@@ -1375,25 +1368,25 @@ NNFW_STATUS nnfw_session::set_backends_per_operation(const char *backend_setting
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_backends_per_operation" << e.what() << std::endl;
+    std::cerr << "Error during Session::set_backends_per_operation" << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_get_traininfo(nnfw_train_info *info)
+NNFW_STATUS Session::train_get_traininfo(nnfw_train_info *info)
 {
   if (isStateInitialized())
   {
     // There is no _train_info in INITIALIZED, since _train_info is set when a model loaded
-    std::cerr << "Error during nnfw_session::train_get_traininfo : invalid state";
+    std::cerr << "Error during Session::train_get_traininfo : invalid state";
     return NNFW_STATUS_INVALID_STATE;
   }
 
   if (info == nullptr)
   {
-    std::cerr << "Error during nnfw_session::train_get_traininfo : info is nullptr" << std::endl;
+    std::cerr << "Error during Session::train_get_traininfo : info is nullptr" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
@@ -1493,24 +1486,24 @@ NNFW_STATUS nnfw_session::train_get_traininfo(nnfw_train_info *info)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_get_traininfo" << e.what() << std::endl;
+    std::cerr << "Error during Session::train_get_traininfo" << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
+NNFW_STATUS Session::train_set_traininfo(const nnfw_train_info *info)
 {
   if (not isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::train_set_traininfo : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_set_traininfo : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
   if (info == nullptr)
   {
-    std::cerr << "nnfw_session::train_set_traininfo : info is nullptr" << std::endl;
+    std::cerr << "Session::train_set_traininfo : info is nullptr" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
@@ -1560,7 +1553,7 @@ NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
 
     if (info->num_of_trainable_ops < -1)
     {
-      std::cerr << "Error during nnfw_session::train_set_traininfo: provided num_of_trainable_ops "
+      std::cerr << "Error during Session::train_set_traininfo: provided num_of_trainable_ops "
                    "has incorrect value: "
                 << info->num_of_trainable_ops << std::endl;
       return NNFW_STATUS_ERROR;
@@ -1580,10 +1573,9 @@ NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
     {
       if (static_cast<uint32_t>(info->num_of_trainable_ops) > ops_size)
       {
-        std::cerr
-          << "Error during nnfw_session::train_set_traininfo: provided num_of_trainable_ops="
-          << info->num_of_trainable_ops << " is out of operators range equals: " << ops_size
-          << std::endl;
+        std::cerr << "Error during Session::train_set_traininfo: provided num_of_trainable_ops="
+                  << info->num_of_trainable_ops << " is out of operators range equals: " << ops_size
+                  << std::endl;
         return NNFW_STATUS_ERROR;
       }
       for (uint32_t i = 1; i <= static_cast<uint32_t>(info->num_of_trainable_ops); ++i)
@@ -1596,14 +1588,14 @@ NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_set_traininfo : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_set_traininfo : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_prepare()
+NNFW_STATUS Session::train_prepare()
 {
   // We may need different state to represent training model is loaded
   if (!isStateModelLoaded())
@@ -1635,7 +1627,7 @@ NNFW_STATUS nnfw_session::train_prepare()
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_prepare : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_prepare : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
@@ -1643,11 +1635,11 @@ NNFW_STATUS nnfw_session::train_prepare()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
+NNFW_STATUS Session::train_input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
 {
   if (!isStatePreparedOrFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_input_tensorinfo : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_input_tensorinfo : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1659,12 +1651,11 @@ NNFW_STATUS nnfw_session::train_input_tensorinfo(uint32_t index, nnfw_tensorinfo
   return NNFW_STATUS_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_expected_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
+NNFW_STATUS Session::train_expected_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
 {
   if (!isStatePreparedOrFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_expected_tensorinfo : invalid state"
-              << std::endl;
+    std::cerr << "Error during Session::train_expected_tensorinfo : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1676,24 +1667,24 @@ NNFW_STATUS nnfw_session::train_expected_tensorinfo(uint32_t index, nnfw_tensori
   return NNFW_STATUS_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_set_input(uint32_t index, const void *input,
-                                          const nnfw_tensorinfo *input_tensorinfo)
+NNFW_STATUS Session::train_set_input(uint32_t index, const void *input,
+                                     const nnfw_tensorinfo *input_tensorinfo)
 {
   if (input == nullptr)
   {
-    std::cerr << "Error during nnfw_session::train_set_input : input buffer is null" << std::endl;
+    std::cerr << "Error during Session::train_set_input : input buffer is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (!isStatePreparedOrFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_set_input : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_set_input : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
   if (index >= getInputSize())
   {
-    std::cerr << "Error during nnfw_session::train_set_input : index is out of range" << std::endl;
+    std::cerr << "Error during Session::train_set_input : index is out of range" << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
@@ -1703,9 +1694,8 @@ NNFW_STATUS nnfw_session::train_set_input(uint32_t index, const void *input,
     auto size = _execution->inputInfo(ind).total_size();
     if (input_tensorinfo && getBufSize(input_tensorinfo) != size)
     {
-      std::cerr
-        << "Error during nnfw_session::train_set_input : not supporeted to change tensorinfo"
-        << std::endl;
+      std::cerr << "Error during Session::train_set_input : not supporeted to change tensorinfo"
+                << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
@@ -1713,33 +1703,31 @@ NNFW_STATUS nnfw_session::train_set_input(uint32_t index, const void *input,
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_set_input : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_set_input : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_set_expected(uint32_t index, const void *expected,
-                                             const nnfw_tensorinfo *expected_tensorinfo)
+NNFW_STATUS Session::train_set_expected(uint32_t index, const void *expected,
+                                        const nnfw_tensorinfo *expected_tensorinfo)
 {
   if (expected == nullptr)
   {
-    std::cerr << "Error during nnfw_session::train_set_expected : expected buffer is null"
-              << std::endl;
+    std::cerr << "Error during Session::train_set_expected : expected buffer is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (!isStatePreparedOrFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_set_expected : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_set_expected : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
   if (index >= getOutputSize())
   {
-    std::cerr << "Error during nnfw_session::train_set_expected : index is out of range"
-              << std::endl;
+    std::cerr << "Error during Session::train_set_expected : index is out of range" << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
@@ -1749,8 +1737,7 @@ NNFW_STATUS nnfw_session::train_set_expected(uint32_t index, const void *expecte
     auto size = _execution->outputInfo(ind).total_size();
     if (expected_tensorinfo && getBufSize(expected_tensorinfo) != size)
     {
-      std::cerr << "Error during nnfw_session::train_set_expected : invalid tensorinfo"
-                << std::endl;
+      std::cerr << "Error during Session::train_set_expected : invalid tensorinfo" << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
@@ -1764,25 +1751,25 @@ NNFW_STATUS nnfw_session::train_set_expected(uint32_t index, const void *expecte
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_set_expected : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_set_expected : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_set_output(uint32_t index, NNFW_TYPE /*type*/, void *buffer,
-                                           size_t length)
+NNFW_STATUS Session::train_set_output(uint32_t index, NNFW_TYPE /*type*/, void *buffer,
+                                      size_t length)
 {
   if (!isStatePreparedOrFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_set_output : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_set_output : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
   if (!buffer && length != 0)
   {
-    std::cerr << "Error during nnfw_session::train_set_output : given buffer is NULL but the "
+    std::cerr << "Error during Session::train_set_output : given buffer is NULL but the "
                  "length is not 0"
               << std::endl;
     return NNFW_STATUS_ERROR;
@@ -1794,17 +1781,17 @@ NNFW_STATUS nnfw_session::train_set_output(uint32_t index, NNFW_TYPE /*type*/, v
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_set_output : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_set_output : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_run(bool update_weights)
+NNFW_STATUS Session::train_run(bool update_weights)
 {
   if (!isStatePreparedOrFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_run : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_run : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1821,12 +1808,12 @@ NNFW_STATUS nnfw_session::train_run(bool update_weights)
   catch (const onert::InsufficientBufferSizeException &e)
   {
     // Currently insufficient buffer always means output buffer.
-    std::cerr << "Error during nnfw_session::train_run : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_run : " << e.what() << std::endl;
     return NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE;
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_run : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_run : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
@@ -1834,23 +1821,23 @@ NNFW_STATUS nnfw_session::train_run(bool update_weights)
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_get_loss(uint32_t index, float *loss)
+NNFW_STATUS Session::train_get_loss(uint32_t index, float *loss)
 {
   if (loss == nullptr)
   {
-    std::cerr << "Error during nnfw_session::train_get_loss : loss is null" << std::endl;
+    std::cerr << "Error during Session::train_get_loss : loss is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (!isStateFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_get_loss : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_get_loss : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
   if (index >= getOutputSize())
   {
-    std::cerr << "Error during nnfw_session::train_get_loss : index is out of range" << std::endl;
+    std::cerr << "Error during Session::train_get_loss : index is out of range" << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
@@ -1861,25 +1848,25 @@ NNFW_STATUS nnfw_session::train_get_loss(uint32_t index, float *loss)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_get_loss : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_get_loss : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_export_circle(const char *path)
+NNFW_STATUS Session::train_export_circle(const char *path)
 {
   if (path == nullptr)
   {
-    std::cerr << "Error during nnfw_session::train_export_circle : path is null" << std::endl;
+    std::cerr << "Error during Session::train_export_circle : path is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   // Check training mode is enabled
   if (!isStateFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_export_circle : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_export_circle : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1890,24 +1877,24 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_export_circle : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_export_circle : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_export_circleplus(const char *path)
+NNFW_STATUS Session::train_export_circleplus(const char *path)
 {
   if (path == nullptr)
   {
-    std::cerr << "Error during nnfw_session::train_export_circleplus : path is null" << std::endl;
+    std::cerr << "Error during Session::train_export_circleplus : path is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (!isStatePreparedOrFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_export_circleplus : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_export_circleplus : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1919,24 +1906,24 @@ NNFW_STATUS nnfw_session::train_export_circleplus(const char *path)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_export_circleplus : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_export_circleplus : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_import_checkpoint(const char *path)
+NNFW_STATUS Session::train_import_checkpoint(const char *path)
 {
   if (path == nullptr)
   {
-    std::cerr << "Error during nnfw_session::train_import_checkpoint : path is null" << std::endl;
+    std::cerr << "Error during Session::train_import_checkpoint : path is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (!isStatePreparedOrFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_import_checkpoint : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_import_checkpoint : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1946,25 +1933,25 @@ NNFW_STATUS nnfw_session::train_import_checkpoint(const char *path)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_import_checkpoint : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_import_checkpoint : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::train_export_checkpoint(const char *path)
+NNFW_STATUS Session::train_export_checkpoint(const char *path)
 {
   if (path == nullptr)
   {
-    std::cerr << "Error during nnfw_session::train_export_checkpoint : path is null" << std::endl;
+    std::cerr << "Error during Session::train_export_checkpoint : path is null" << std::endl;
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   // Check training mode is enabled
   if (!isStateFinishedTraining())
   {
-    std::cerr << "Error during nnfw_session::train_export_checkpoint : invalid state" << std::endl;
+    std::cerr << "Error during Session::train_export_checkpoint : invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1974,14 +1961,14 @@ NNFW_STATUS nnfw_session::train_export_checkpoint(const char *path)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::train_export_checkpoint : " << e.what() << std::endl;
+    std::cerr << "Error during Session::train_export_checkpoint : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-bool nnfw_session::isStatePreparedTraining()
+bool Session::isStatePreparedTraining()
 {
   if (_state == State::PREPARED_TRAINING)
   {
@@ -1993,7 +1980,7 @@ bool nnfw_session::isStatePreparedTraining()
     return false;
 }
 
-bool nnfw_session::isStateFinishedTraining()
+bool Session::isStateFinishedTraining()
 {
   if (_state == State::FINISHED_TRAINING)
   {
@@ -2005,12 +1992,12 @@ bool nnfw_session::isStateFinishedTraining()
     return false;
 }
 
-bool nnfw_session::isStatePreparedOrFinishedTraining()
+bool Session::isStatePreparedOrFinishedTraining()
 {
   return isStatePreparedTraining() || isStateFinishedTraining();
 }
 
-NNFW_STATUS nnfw_session::set_quantization_type(NNFW_QUANTIZE_TYPE qtype)
+NNFW_STATUS Session::set_quantization_type(NNFW_QUANTIZE_TYPE qtype)
 {
   using onert::odc::QuantizeType;
   try
@@ -2043,14 +2030,14 @@ NNFW_STATUS nnfw_session::set_quantization_type(NNFW_QUANTIZE_TYPE qtype)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_quantization_type : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_quantization_type : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_quantized_model_path(const char *path)
+NNFW_STATUS Session::set_quantized_model_path(const char *path)
 {
   try
   {
@@ -2064,14 +2051,14 @@ NNFW_STATUS nnfw_session::set_quantized_model_path(const char *path)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_quantized_model_path : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_quantized_model_path : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::quantize()
+NNFW_STATUS Session::quantize()
 {
   try
   {
@@ -2091,12 +2078,12 @@ NNFW_STATUS nnfw_session::quantize()
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::quantize : " << e.what() << std::endl;
+    std::cerr << "Error during Session::quantize : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 }
 
-NNFW_STATUS nnfw_session::set_codegen_model_path(const char *path)
+NNFW_STATUS Session::set_codegen_model_path(const char *path)
 {
   try
   {
@@ -2111,20 +2098,20 @@ NNFW_STATUS nnfw_session::set_codegen_model_path(const char *path)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_codegen_model_path : " << e.what() << std::endl;
+    std::cerr << "Error during Session::set_codegen_model_path : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::codegen(const char *target, NNFW_CODEGEN_PREF pref)
+NNFW_STATUS Session::codegen(const char *target, NNFW_CODEGEN_PREF pref)
 {
   try
   {
     if (isStateInitialized() || isStateRunning())
     {
-      std::cerr << "Error during nnfw_session::codegen : Invalid state" << std::endl;
+      std::cerr << "Error during Session::codegen : Invalid state" << std::endl;
       return NNFW_STATUS_INVALID_STATE;
     }
 
@@ -2132,7 +2119,7 @@ NNFW_STATUS nnfw_session::codegen(const char *target, NNFW_CODEGEN_PREF pref)
     if (target_str.empty() || target_str.size() < 5 ||
         target_str.substr(target_str.size() - 4) != "-gen")
     {
-      std::cerr << "Error during nnfw_session::codegen : Invalid target" << std::endl;
+      std::cerr << "Error during Session::codegen : Invalid target" << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
@@ -2152,7 +2139,7 @@ NNFW_STATUS nnfw_session::codegen(const char *target, NNFW_CODEGEN_PREF pref)
         codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_COMPILE_TIME_FIRST;
         break;
       default:
-        std::cerr << "Error during nnfw_session::codegen : Invalid preference" << std::endl;
+        std::cerr << "Error during Session::codegen : Invalid preference" << std::endl;
         return NNFW_STATUS_ERROR;
     }
 
@@ -2177,16 +2164,16 @@ NNFW_STATUS nnfw_session::codegen(const char *target, NNFW_CODEGEN_PREF pref)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::compile : " << e.what() << std::endl;
+    std::cerr << "Error during Session::compile : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 }
 
-NNFW_STATUS nnfw_session::set_prepare_config(const NNFW_PREPARE_CONFIG key, const char *)
+NNFW_STATUS Session::set_prepare_config(const NNFW_PREPARE_CONFIG key, const char *)
 {
   if (!isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::set_prepare_config : Invalid state" << std::endl;
+    std::cerr << "Error during Session::set_prepare_config : Invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -2205,11 +2192,11 @@ NNFW_STATUS nnfw_session::set_prepare_config(const NNFW_PREPARE_CONFIG key, cons
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::reset_prepare_config()
+NNFW_STATUS Session::reset_prepare_config()
 {
   if (!isStateModelLoaded())
   {
-    std::cerr << "Error during nnfw_session::reset_prepare_config : Invalid state" << std::endl;
+    std::cerr << "Error during Session::reset_prepare_config : Invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -2218,11 +2205,11 @@ NNFW_STATUS nnfw_session::reset_prepare_config()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_execute_config(const NNFW_RUN_CONFIG key, const char *)
+NNFW_STATUS Session::set_execute_config(const NNFW_RUN_CONFIG key, const char *)
 {
   if (!isStatePreparedOrFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::set_execution_config : Invalid state" << std::endl;
+    std::cerr << "Error during Session::set_execution_config : Invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -2248,11 +2235,11 @@ NNFW_STATUS nnfw_session::set_execute_config(const NNFW_RUN_CONFIG key, const ch
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::reset_execute_config()
+NNFW_STATUS Session::reset_execute_config()
 {
   if (!isStatePreparedOrFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::set_execution_config : Invalid state" << std::endl;
+    std::cerr << "Error during Session::set_execution_config : Invalid state" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -2263,7 +2250,7 @@ NNFW_STATUS nnfw_session::reset_execute_config()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_odc_param_minmax_records_count(int minmax_records_count)
+NNFW_STATUS Session::set_odc_param_minmax_records_count(int minmax_records_count)
 {
   if (isStateInitialized() || isStateRunning())
   {
@@ -2277,7 +2264,7 @@ NNFW_STATUS nnfw_session::set_odc_param_minmax_records_count(int minmax_records_
     return NNFW_STATUS_ERROR;
 }
 
-NNFW_STATUS nnfw_session::delete_odc_minmax_file()
+NNFW_STATUS Session::delete_odc_minmax_file()
 {
   if (isStateRunning())
   {
@@ -2292,12 +2279,12 @@ NNFW_STATUS nnfw_session::delete_odc_minmax_file()
 }
 
 // run with auto compilation
-NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_CODEGEN_PREF pref)
+NNFW_STATUS Session::run_with_auto_compilation(const char *target, NNFW_CODEGEN_PREF pref)
 {
 
   if (!isStatePreparedOrFinishedRun())
   {
-    std::cerr << "Error during nnfw_session::run_with_auto_compilation : "
+    std::cerr << "Error during Session::run_with_auto_compilation : "
               << "run should be after preparation" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
@@ -2307,7 +2294,7 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
   if (_quant_manager->exportModelPath().empty() || _codegen_manager->exportModelPath().empty() ||
       target_str.empty() || target_str.substr(target_str.size() - 4) != "-gen")
   {
-    std::cerr << "Error during nnfw_session::run_with_auto_compilation : "
+    std::cerr << "Error during Session::run_with_auto_compilation : "
               << "quantization and code generation parameters should be set" << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
@@ -2333,14 +2320,12 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
       catch (const onert::InsufficientBufferSizeException &e)
       {
         // Currently insufficient buffer always means output buffer.
-        std::cerr << "Error during nnfw_session::run_with_auto_compilation : " << e.what()
-                  << std::endl;
+        std::cerr << "Error during Session::run_with_auto_compilation : " << e.what() << std::endl;
         return NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE;
       }
       catch (const std::exception &e)
       {
-        std::cerr << "Error during nnfw_session::run_with_auto_compilation : " << e.what()
-                  << std::endl;
+        std::cerr << "Error during Session::run_with_auto_compilation : " << e.what() << std::endl;
         return NNFW_STATUS_ERROR;
       }
 
@@ -2371,9 +2356,8 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         }
         catch (const std::exception &e)
         {
-          std::cerr
-            << "Error during nnfw_session::run_with_auto_compilation in quantize operation: "
-            << e.what() << std::endl;
+          std::cerr << "Error during Session::run_with_auto_compilation in quantize operation: "
+                    << e.what() << std::endl;
           return NNFW_STATUS_ERROR;
         }
       }
@@ -2388,12 +2372,12 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
     _execution->executionOptions().dump_minmax = false;
 
     // save initial buffers if quantized model or compiled model is not loaded
-    if (_autoCompilationState == nnfw_session::AutoCompilationState::INITIAL_STATE)
+    if (_autoCompilationState == Session::AutoCompilationState::INITIAL_STATE)
     {
       auto dotidx = _codegen_manager->exportModelPath().rfind('.');
       if (dotidx == std::string::npos)
       {
-        std::cerr << "Error during nnfw_session::run_with_auto_compilation : Invalid compiled "
+        std::cerr << "Error during Session::run_with_auto_compilation : Invalid compiled "
                      "model path. Please use a "
                      "path that includes the extension."
                   << std::endl;
@@ -2406,7 +2390,7 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
       dotidx = _quant_manager->exportModelPath().rfind('.');
       if (dotidx == std::string::npos)
       {
-        std::cerr << "Error during nnfw_session::run_with_auto_compilation : Invalid quantized "
+        std::cerr << "Error during Session::run_with_auto_compilation : Invalid quantized "
                      "model path. Please use a "
                      "path that includes the extension."
                   << std::endl;
@@ -2443,7 +2427,7 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         status = loadModelFile(_codegen_manager->exportModelPath(), compiled_model_type);
         if (status == NNFW_STATUS_NO_ERROR)
         {
-          _autoCompilationState = nnfw_session::AutoCompilationState::COMPILED_MODEL_LOADED;
+          _autoCompilationState = Session::AutoCompilationState::COMPILED_MODEL_LOADED;
         }
       }
       else // there is no compiled model - try to compile and load it
@@ -2458,20 +2442,20 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
         status = codegen(target, pref);
         if (status == NNFW_STATUS_NO_ERROR)
         {
-          _autoCompilationState = nnfw_session::AutoCompilationState::COMPILED_MODEL_LOADED;
+          _autoCompilationState = Session::AutoCompilationState::COMPILED_MODEL_LOADED;
           // TODO delete quantized model
         }
       }
 
       // loading compiled model is fail - try to load quantized model
-      if (_autoCompilationState != nnfw_session::AutoCompilationState::COMPILED_MODEL_LOADED)
+      if (_autoCompilationState != Session::AutoCompilationState::COMPILED_MODEL_LOADED)
       {
         // load quantized model
         status = loadModelFile(_quant_manager->exportModelPath(), quantized_model_type);
         if (status != NNFW_STATUS_NO_ERROR)
           return status;
         else
-          _autoCompilationState = nnfw_session::AutoCompilationState::QUANTIZED_MODEL_LOADED;
+          _autoCompilationState = Session::AutoCompilationState::QUANTIZED_MODEL_LOADED;
       }
 
       status = prepare();
@@ -2485,7 +2469,7 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
     // Run quantized model
     if (!isStatePreparedOrFinishedRun())
     {
-      std::cerr << "Error during nnfw_session::run_with_auto_compilation : "
+      std::cerr << "Error during Session::run_with_auto_compilation : "
                 << "run should be run after prepare" << std::endl;
       return NNFW_STATUS_INVALID_STATE;
     }
@@ -2497,14 +2481,12 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
     catch (const onert::InsufficientBufferSizeException &e)
     {
       // Currently insufficient buffer always means output buffer.
-      std::cerr << "Error during nnfw_session::run_with_auto_compilation : " << e.what()
-                << std::endl;
+      std::cerr << "Error during Session::run_with_auto_compilation : " << e.what() << std::endl;
       return NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE;
     }
     catch (const std::exception &e)
     {
-      std::cerr << "Error during nnfw_session::run_with_auto_compilation : " << e.what()
-                << std::endl;
+      std::cerr << "Error during Session::run_with_auto_compilation : " << e.what() << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
@@ -2513,3 +2495,5 @@ NNFW_STATUS nnfw_session::run_with_auto_compilation(const char *target, NNFW_COD
 
   return NNFW_STATUS_NO_ERROR;
 }
+
+} // namespace onert::api

--- a/runtime/onert/api/nnfw/src/Session.h
+++ b/runtime/onert/api/nnfw/src/Session.h
@@ -36,7 +36,10 @@
 #include <thread>
 #include <vector>
 
-struct nnfw_session
+namespace onert::api
+{
+
+struct Session
 {
 private:
   /**
@@ -94,17 +97,17 @@ private:
 
 public:
   /**
-   * @brief Factory method. It creates and initialize nnfw_session
+   * @brief Factory method. It creates and initialize Session
    *
    * @note  Use factory instead of constructor to get status
    */
-  static NNFW_STATUS create(nnfw_session **session);
+  static NNFW_STATUS create(Session **session);
 
 private:
-  nnfw_session();
+  Session();
 
 public:
-  ~nnfw_session();
+  ~Session();
   NNFW_STATUS load_model_from_path(const char *path);
   NNFW_STATUS prepare();
   NNFW_STATUS run();
@@ -236,5 +239,7 @@ private:
   std::unordered_map<onert::ir::SubgraphIndex, std::string> _signature_map;
   onert::ir::SubgraphIndex _selected_signature;
 };
+
+} // namespace onert::api
 
 #endif // __API_NNFW_SESSION_H__

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -18,7 +18,7 @@
 #include "nnfw_experimental.h"
 #include "nnfw_version.h"
 
-#include "nnfw_session.h"
+#include "Session.h"
 
 // Double-check enum value changes
 
@@ -55,136 +55,141 @@ STATIC_ASSERT_ENUM_CHECK(NNFW_INFO_ID_VERSION, 0);
       return NNFW_STATUS_UNEXPECTED_NULL; \
   } while (0)
 
-NNFW_STATUS nnfw_create_session(nnfw_session **session) { return nnfw_session::create(session); }
+using Session = onert::api::Session;
+
+NNFW_STATUS nnfw_create_session(nnfw_session **session)
+{
+  return Session::create(reinterpret_cast<Session **>(session));
+}
 
 NNFW_STATUS nnfw_close_session(nnfw_session *session)
 {
-  delete session;
+  delete reinterpret_cast<Session *>(session);
   return NNFW_STATUS_NO_ERROR;
 }
 
 NNFW_STATUS nnfw_load_model_from_file(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->load_model_from_path(path);
+  return reinterpret_cast<Session *>(session)->load_model_from_path(path);
 }
 
 NNFW_STATUS nnfw_prepare(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->prepare();
+  return reinterpret_cast<Session *>(session)->prepare();
 }
 
 NNFW_STATUS nnfw_run(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->run();
+  return reinterpret_cast<Session *>(session)->run();
 }
 
 NNFW_STATUS nnfw_run_async(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->run_async();
+  return reinterpret_cast<Session *>(session)->run_async();
 }
 
 NNFW_STATUS nnfw_await(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->await();
+  return reinterpret_cast<Session *>(session)->await();
 }
 
 NNFW_STATUS nnfw_set_input(nnfw_session *session, uint32_t index, NNFW_TYPE type,
                            const void *buffer, size_t length)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_input(index, type, buffer, length);
+  return reinterpret_cast<Session *>(session)->set_input(index, type, buffer, length);
 }
 
 NNFW_STATUS nnfw_set_output(nnfw_session *session, uint32_t index, NNFW_TYPE type, void *buffer,
                             size_t length)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_output(index, type, buffer, length);
+  return reinterpret_cast<Session *>(session)->set_output(index, type, buffer, length);
 }
 
 NNFW_STATUS nnfw_input_size(nnfw_session *session, uint32_t *number)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->input_size(number);
+  return reinterpret_cast<Session *>(session)->input_size(number);
 }
 
 NNFW_STATUS nnfw_output_size(nnfw_session *session, uint32_t *number)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->output_size(number);
+  return reinterpret_cast<Session *>(session)->output_size(number);
 }
 
 NNFW_STATUS nnfw_set_input_layout(nnfw_session *session, uint32_t index, NNFW_LAYOUT layout)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_input_layout(index, layout);
+  return reinterpret_cast<Session *>(session)->set_input_layout(index, layout);
 }
 
 NNFW_STATUS nnfw_set_output_layout(nnfw_session *session, uint32_t index, NNFW_LAYOUT layout)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_output_layout(index, layout);
+  return reinterpret_cast<Session *>(session)->set_output_layout(index, layout);
 }
 
 NNFW_STATUS nnfw_set_input_type(nnfw_session *session, uint32_t index, NNFW_TYPE type)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_input_type(index, type);
+  return reinterpret_cast<Session *>(session)->set_input_type(index, type);
 }
 
 NNFW_STATUS nnfw_set_output_type(nnfw_session *session, uint32_t index, NNFW_TYPE type)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_output_type(index, type);
+  return reinterpret_cast<Session *>(session)->set_output_type(index, type);
 }
 
 NNFW_STATUS nnfw_input_tensorinfo(nnfw_session *session, uint32_t index,
                                   nnfw_tensorinfo *tensor_info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->input_tensorinfo(index, tensor_info);
+  return reinterpret_cast<Session *>(session)->input_tensorinfo(index, tensor_info);
 }
 
 NNFW_STATUS nnfw_output_tensorinfo(nnfw_session *session, uint32_t index,
                                    nnfw_tensorinfo *tensor_info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->output_tensorinfo(index, tensor_info);
+  return reinterpret_cast<Session *>(session)->output_tensorinfo(index, tensor_info);
 }
 
 NNFW_STATUS nnfw_register_custom_op_info(nnfw_session *session, const char *id,
                                          custom_kernel_registration_info *info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->register_custom_operation(id, info->eval_function);
+  return reinterpret_cast<Session *>(session)->register_custom_operation(id, info->eval_function);
 }
 
 NNFW_STATUS nnfw_apply_tensorinfo(nnfw_session *, uint32_t, nnfw_tensorinfo)
 {
-  return nnfw_session::deprecated("nnfw_apply_tensorinfo: Deprecated");
+  return Session::deprecated("nnfw_apply_tensorinfo: Deprecated");
 }
 
 NNFW_STATUS nnfw_set_input_tensorinfo(nnfw_session *session, uint32_t index,
                                       const nnfw_tensorinfo *tensor_info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_input_tensorinfo(index, tensor_info);
+  return reinterpret_cast<Session *>(session)->set_input_tensorinfo(index, tensor_info);
 }
 
 NNFW_STATUS nnfw_set_available_backends(nnfw_session *session, const char *backends)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_available_backends(backends);
+  return reinterpret_cast<Session *>(session)->set_available_backends(backends);
 }
 
 NNFW_STATUS nnfw_set_op_backend(nnfw_session *, const char *, const char *)
 {
-  return nnfw_session::deprecated("nnfw_set_op_backend: Deprecated");
+  return Session::deprecated("nnfw_set_op_backend: Deprecated");
 }
 
 NNFW_STATUS nnfw_query_info_u32(nnfw_session *session, NNFW_INFO_ID id, uint32_t *val)
@@ -209,52 +214,52 @@ NNFW_STATUS nnfw_query_info_u32(nnfw_session *session, NNFW_INFO_ID id, uint32_t
 NNFW_STATUS nnfw_input_tensorindex(nnfw_session *session, const char *tensorname, uint32_t *index)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->input_tensorindex(tensorname, index);
+  return reinterpret_cast<Session *>(session)->input_tensorindex(tensorname, index);
 }
 
 NNFW_STATUS nnfw_output_tensorindex(nnfw_session *session, const char *tensorname, uint32_t *index)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->output_tensorindex(tensorname, index);
+  return reinterpret_cast<Session *>(session)->output_tensorindex(tensorname, index);
 }
 
 NNFW_STATUS nnfw_set_backends_per_operation(nnfw_session *session, const char *backend_settings)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_backends_per_operation(backend_settings);
+  return reinterpret_cast<Session *>(session)->set_backends_per_operation(backend_settings);
 }
 
 NNFW_STATUS nnfw_prepare_pipeline(nnfw_session *, const char *)
 {
-  return nnfw_session::deprecated("nnfw_prepare_pipeline: Deprecated");
+  return Session::deprecated("nnfw_prepare_pipeline: Deprecated");
 }
 
 NNFW_STATUS nnfw_push_pipeline_input(nnfw_session *, void *, void *)
 {
-  return nnfw_session::deprecated("nnfw_push_pipeline_input: Deprecated");
+  return Session::deprecated("nnfw_push_pipeline_input: Deprecated");
 }
 
 NNFW_STATUS nnfw_pop_pipeline_output(nnfw_session *, void *)
 {
-  return nnfw_session::deprecated("nnfw_pop_pipeline_output: Deprecated");
+  return Session::deprecated("nnfw_pop_pipeline_output: Deprecated");
 }
 
 NNFW_STATUS nnfw_set_workspace(nnfw_session *session, const char *dir)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_workspace(dir);
+  return reinterpret_cast<Session *>(session)->set_workspace(dir);
 }
 
 NNFW_STATUS nnfw_configure_signature(nnfw_session *session, const char *signature)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->configure_signature(signature);
+  return reinterpret_cast<Session *>(session)->configure_signature(signature);
 }
 
 NNFW_STATUS nnfw_set_signature_run(nnfw_session *session, const char *signature)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_signature_run(signature);
+  return reinterpret_cast<Session *>(session)->set_signature_run(signature);
 }
 
 // Training
@@ -262,84 +267,84 @@ NNFW_STATUS nnfw_set_signature_run(nnfw_session *session, const char *signature)
 NNFW_STATUS nnfw_train_get_traininfo(nnfw_session *session, nnfw_train_info *info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_get_traininfo(info);
+  return reinterpret_cast<Session *>(session)->train_get_traininfo(info);
 }
 
 NNFW_STATUS nnfw_train_set_traininfo(nnfw_session *session, const nnfw_train_info *info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_set_traininfo(info);
+  return reinterpret_cast<Session *>(session)->train_set_traininfo(info);
 }
 
 NNFW_STATUS nnfw_train_prepare(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_prepare();
+  return reinterpret_cast<Session *>(session)->train_prepare();
 }
 
 NNFW_STATUS nnfw_train_input_tensorinfo(nnfw_session *session, uint32_t index,
                                         nnfw_tensorinfo *info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_input_tensorinfo(index, info);
+  return reinterpret_cast<Session *>(session)->train_input_tensorinfo(index, info);
 }
 
 NNFW_STATUS nnfw_train_expected_tensorinfo(nnfw_session *session, uint32_t index,
                                            nnfw_tensorinfo *info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_expected_tensorinfo(index, info);
+  return reinterpret_cast<Session *>(session)->train_expected_tensorinfo(index, info);
 }
 
 NNFW_STATUS nnfw_train_set_input(nnfw_session *session, uint32_t index, const void *input,
                                  const nnfw_tensorinfo *input_info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_set_input(index, input, input_info);
+  return reinterpret_cast<Session *>(session)->train_set_input(index, input, input_info);
 }
 
 NNFW_STATUS nnfw_train_set_expected(nnfw_session *session, uint32_t index, const void *expected,
                                     const nnfw_tensorinfo *expected_info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_set_expected(index, expected, expected_info);
+  return reinterpret_cast<Session *>(session)->train_set_expected(index, expected, expected_info);
 }
 
 NNFW_STATUS nnfw_train_set_output(nnfw_session *session, uint32_t index, NNFW_TYPE type,
                                   void *buffer, size_t length)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_set_output(index, type, buffer, length);
+  return reinterpret_cast<Session *>(session)->train_set_output(index, type, buffer, length);
 }
 
 NNFW_STATUS nnfw_train(nnfw_session *session, bool update_weights)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_run(update_weights);
+  return reinterpret_cast<Session *>(session)->train_run(update_weights);
 }
 
 NNFW_STATUS nnfw_train_get_loss(nnfw_session *session, uint32_t index, float *loss)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_get_loss(index, loss);
+  return reinterpret_cast<Session *>(session)->train_get_loss(index, loss);
 }
 
 NNFW_STATUS nnfw_train_export_circle(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_export_circle(path);
+  return reinterpret_cast<Session *>(session)->train_export_circle(path);
 }
 
 NNFW_STATUS nnfw_train_import_checkpoint(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_import_checkpoint(path);
+  return reinterpret_cast<Session *>(session)->train_import_checkpoint(path);
 }
 
 NNFW_STATUS nnfw_train_export_checkpoint(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_export_checkpoint(path);
+  return reinterpret_cast<Session *>(session)->train_export_checkpoint(path);
 }
 
 // Quantization
@@ -347,50 +352,51 @@ NNFW_STATUS nnfw_train_export_checkpoint(nnfw_session *session, const char *path
 NNFW_STATUS nnfw_set_quantization_type(nnfw_session *session, NNFW_QUANTIZE_TYPE qtype)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_quantization_type(qtype);
+  return reinterpret_cast<Session *>(session)->set_quantization_type(qtype);
 }
 
 NNFW_STATUS nnfw_set_quantized_model_path(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_quantized_model_path(path);
+  return reinterpret_cast<Session *>(session)->set_quantized_model_path(path);
 }
 
 NNFW_STATUS nnfw_quantize(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->quantize();
+  return reinterpret_cast<Session *>(session)->quantize();
 }
 
 NNFW_STATUS nnfw_set_codegen_model_path(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_codegen_model_path(path);
+  return reinterpret_cast<Session *>(session)->set_codegen_model_path(path);
 }
 
 NNFW_STATUS nnfw_codegen(nnfw_session *session, const char *target, NNFW_CODEGEN_PREF pref)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->codegen(target, pref);
+  return reinterpret_cast<Session *>(session)->codegen(target, pref);
 }
 
 NNFW_STATUS nnfw_set_odc_param_minmax_records_count(nnfw_session *session, int minmax_records_count)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_odc_param_minmax_records_count(minmax_records_count);
+  return reinterpret_cast<Session *>(session)->set_odc_param_minmax_records_count(
+    minmax_records_count);
 }
 
 NNFW_STATUS nnfw_odc_delete_minmax_file(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->delete_odc_minmax_file();
+  return reinterpret_cast<Session *>(session)->delete_odc_minmax_file();
 }
 
 NNFW_STATUS nnfw_run_with_auto_compilation(nnfw_session *session, const char *target,
                                            NNFW_CODEGEN_PREF pref)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->run_with_auto_compilation(target, pref);
+  return reinterpret_cast<Session *>(session)->run_with_auto_compilation(target, pref);
 }
 
 // Configuration
@@ -399,24 +405,24 @@ NNFW_STATUS nnfw_set_prepare_config(nnfw_session *session, const NNFW_PREPARE_CO
                                     const char *value)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_prepare_config(key, value);
+  return reinterpret_cast<Session *>(session)->set_prepare_config(key, value);
 }
 
 NNFW_STATUS nnfw_reset_prepare_config(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->reset_prepare_config();
+  return reinterpret_cast<Session *>(session)->reset_prepare_config();
 }
 
 NNFW_STATUS nnfw_set_execute_config(nnfw_session *session, const NNFW_RUN_CONFIG key,
                                     const char *value)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_execute_config(key, value);
+  return reinterpret_cast<Session *>(session)->set_execute_config(key, value);
 }
 
 NNFW_STATUS nnfw_reset_execute_config(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->reset_execute_config();
+  return reinterpret_cast<Session *>(session)->reset_execute_config();
 }

--- a/runtime/onert/api/nnfw/src/nnfw_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_internal.cc
@@ -16,7 +16,7 @@
 
 #include "nnfw_internal.h"
 
-#include "nnfw_session.h"
+#include "Session.h"
 
 #include <util/ConfigSource.h>
 
@@ -27,33 +27,35 @@
       return NNFW_STATUS_UNEXPECTED_NULL; \
   } while (0)
 
+using Session = onert::api::Session;
+
 NNFW_STATUS nnfw_set_config(nnfw_session *session, const char *key, const char *value)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_config(key, value);
+  return reinterpret_cast<Session *>(session)->set_config(key, value);
 }
 
 NNFW_STATUS nnfw_get_config(nnfw_session *session, const char *key, char *value, size_t value_size)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->get_config(key, value, value_size);
+  return reinterpret_cast<Session *>(session)->get_config(key, value, value_size);
 }
 
 NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer, size_t size)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->load_circle_from_buffer(buffer, size);
+  return reinterpret_cast<Session *>(session)->load_circle_from_buffer(buffer, size);
 }
 
 NNFW_STATUS nnfw_train_export_circleplus(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_export_circleplus(path);
+  return reinterpret_cast<Session *>(session)->train_export_circleplus(path);
 }
 
 NNFW_STATUS nnfw_get_output(nnfw_session *session, uint32_t index, nnfw_tensorinfo *out_info,
                             const void **out_buffer)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->get_output(index, out_info, out_buffer);
+  return reinterpret_cast<Session *>(session)->get_output(index, out_info, out_buffer);
 }


### PR DESCRIPTION
This commit renames nnfw_session class to Session and move it to onert::api namespace. 
It updates C API wrapper functions to use reinterpret_cast for backward compatibility.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>