### PR TITLE
[circle-mlir] Discard output from the cd command when followed by pwd

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/run_import_test.sh
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/run_import_test.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 MODEL_NAME="$1"; shift
 

--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/run_value_test.sh
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/run_value_test.sh
@@ -12,7 +12,7 @@
 
 set -e
 
-TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 VENV_PATH="$1"; shift
 MODEL_NAME="$1"; shift

--- a/circle-mlir/circle-mlir/tools-test/gen-onnx/run_gen_onnx.sh
+++ b/circle-mlir/circle-mlir/tools-test/gen-onnx/run_gen_onnx.sh
@@ -10,7 +10,7 @@
 # model_name : name of model
 # onnx_name  : name of onnx file
 
-THIS_SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+THIS_SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 PY_SCRIPT_PATH="${THIS_SCRIPT_PATH}/run_gen_onnx.py"
 
 VENV_PATH="$1"; shift

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-rewrite-test/run_circle_ops_test.sh
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-rewrite-test/run_circle_ops_test.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 VENV_PATH="$1"; shift
 RUN_PATH="$1"; shift

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/run_value_test.sh
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/run_value_test.sh
@@ -13,7 +13,7 @@
 
 set -e
 
-TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 VENV_PATH="$1"; shift
 MODEL_NAME="$1"; shift

--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -34,7 +34,7 @@ fi
 
 set -e
 
-DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 if [[ -z "$VENV_NAME" ]]; then
   VENV_NAME="venv"
 fi

--- a/circle-mlir/infra/tools/gen-coverage-report
+++ b/circle-mlir/infra/tools/gen-coverage-report
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Environment variables to override
-#   COVERAGE_RPATH : folder where coverage report is generatged,
+#   COVERAGE_RPATH : folder where coverage report is generated,
 #                    default is 'coverage'
 #   COVERAGE_PATH  : path where coverage report is generated,
 #                    default is ${PROJECT_PATH}/${COVERAGE_RPATH}
 
-PROJECT_PATH="$(cd $(dirname ${BASH_SOURCE[0]})/../.. && pwd)"
+PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)"
 
 # Set BUILD_WORKSPACE_RPATH with default 'build/coverage' if not set
 BUILD_WORKSPACE_RPATH="${BUILD_WORKSPACE_RPATH:-build/coverage}"


### PR DESCRIPTION
This PR fixes the issue when `cd` is followed by the `pwd` in a bash one-liner which should get the directory in which the executed script is located. The problem with such approach is that the `cd` command can print the destination directory in case when one has the CDPATH environmental variable set.

Also, it fixes an issues with word splitting in the `circle-mlir/infra/tools/gen-coverage-report` script in case when the path contains spaces and a small typo in the docstring for environment variables to overrides.

This PR is part of draft https://github.com/Samsung/ONE/pull/16238

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>