### PR TITLE
[ggma] Update ggma debian packaging as tokenizer is added

### DIFF
--- a/runtime/infra/debian/ggma.install
+++ b/runtime/infra/debian/ggma.install
@@ -1,3 +1,3 @@
-/usr/lib/*/ggma/libggma_api.so
+/usr/lib/*/ggma/lib*
 /usr/include/ggma/*
 /usr/lib/*/pkgconfig/ggma.pc


### PR DESCRIPTION
It adds tokenizer-related files in ggma.install.

- `libggma_tokenize.so`
- `libsentencepiece.so`
- `libsentencepiece.so.0`
- `libsentencepiece.so.0.0.0`

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>