### PR TITLE
[infra/onert] Disable SentencePiece as default all tizen platforms

### DIFF
--- a/runtime/infra/cmake/options/options_aarch64-tizen.cmake
+++ b/runtime/infra/cmake/options/options_aarch64-tizen.cmake
@@ -8,3 +8,7 @@ option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)
+
+option(BUILD_GGMA_API "Build GGMA API for Generative AI" OFF)
+option(DOWNLOAD_SENTENCEPIECE "Download SentencePiece source" OFF)
+option(BUILD_SENTENCEPIECE "Build SentencePiece library from the source" OFF)

--- a/runtime/infra/cmake/options/options_armv7hl-tizen.cmake
+++ b/runtime/infra/cmake/options/options_armv7hl-tizen.cmake
@@ -8,3 +8,7 @@ option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)
+
+option(BUILD_GGMA_API "Build GGMA API for Generative AI" OFF)
+option(DOWNLOAD_SENTENCEPIECE "Download SentencePiece source" OFF)
+option(BUILD_SENTENCEPIECE "Build SentencePiece library from the source" OFF)

--- a/runtime/infra/cmake/options/options_x86_64-tizen.cmake
+++ b/runtime/infra/cmake/options/options_x86_64-tizen.cmake
@@ -7,3 +7,7 @@ option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
 
 option(BUILD_XNNPACK "Build XNNPACK" OFF)
+
+option(BUILD_GGMA_API "Build GGMA API for Generative AI" OFF)
+option(DOWNLOAD_SENTENCEPIECE "Download SentencePiece source" OFF)
+option(BUILD_SENTENCEPIECE "Build SentencePiece library from the source" OFF)


### PR DESCRIPTION
This commit disables SentencePiece as default for all tizen platforms. 
BUILD_GGMA_API also disabled, but enabled by nnfw.spec.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>