### PR TITLE
[onert/infra] Fix GGMA tizen package file declarations in spec file

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -97,15 +97,6 @@ Summary: GGMA generative AI framework
 
 %description ggma
 GGMA package for on-device generative AI framework
-
-%files ggma
-%manifest %{name}.manifest
-%defattr(-,root,root,-)
-%ifarch arm armv7l armv7hl aarch64 x86_64 %ix86 riscv64
-%{_libdir}/ggma/lib*
-%{_includedir}/ggma/*
-%{_libdir}/pkgconfig/ggma.pc
-%endif
 %endif # ggma_build
 
 %if %{test_build} == 1
@@ -334,6 +325,19 @@ install -m 644 %{overlay_path}/lib/libloco*.so %{buildroot}%{_libdir}/nnfw/odc
 %endif # asan
 %endif # arm armv7l armv7hl aarch64 x86_64 %ix86
 %endif # odc_build
+
+%if %{ggma_build} == 1
+%files ggma
+%manifest %{name}.manifest
+%defattr(-,root,root,-)
+%ifarch arm armv7l armv7hl aarch64 x86_64 %ix86 riscv64
+%dir %{_libdir}/ggma
+%dir %{_includedir}/ggma
+%{_libdir}/ggma/lib*
+%{_includedir}/ggma/*
+%{_libdir}/pkgconfig/ggma.pc
+%endif
+%endif # ggma_build
 
 %changelog
 * Thu Mar 15 2018 Chunseok Lee <chunseok.lee@samsung.com>


### PR DESCRIPTION
This commit moves ggma files section to proper location after install section and add directory declarations for ggma lib and include paths to ensure correct directory ownership.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>