### PR TITLE
[onert] Remove layer_idx from op_attention

### DIFF
--- a/runtime/onert/core/include/ir/operation/Attention.h
+++ b/runtime/onert/core/include/ir/operation/Attention.h
@@ -41,23 +41,10 @@ public:
     POS = 10,
   };
 
-  struct Param
-  {
-  };
+  Attention(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs);
 
-public:
-  Attention(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
-            const Param &param);
-
-public:
   void accept(OperationVisitor &v) const override;
   OpCode opcode() const final { return OpCode::Attention; }
-
-public:
-  const Param &param() const { return _param; }
-
-private:
-  Param _param;
 };
 
 } // namespace onert::ir::operation

--- a/runtime/onert/core/src/ir/operation/Attention.cc
+++ b/runtime/onert/core/src/ir/operation/Attention.cc
@@ -22,9 +22,8 @@ namespace onert::ir::operation
 
 void Attention::accept(OperationVisitor &v) const { v.visit(*this); }
 
-Attention::Attention(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
-                     const Param &param)
-  : Operation{OperandConstraint::createExact(11u), inputs, outputs}, _param{param}
+Attention::Attention(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
+  : Operation{OperandConstraint::createExact(11u), inputs, outputs}
 {
 }
 

--- a/runtime/onert/core/src/loader/CircleLoader.cc
+++ b/runtime/onert/core/src/loader/CircleLoader.cc
@@ -436,7 +436,7 @@ void CircleLoader::loadAttention(const Operator *op, ir::Graph &subg)
 
   loadOperationIO(op, inputs, outputs);
 
-  std::unique_ptr<ir::Operation> new_op(new ir::operation::Attention(inputs, outputs, {}));
+  std::unique_ptr<ir::Operation> new_op(new ir::operation::Attention(inputs, outputs));
   subg.addOperation(std::move(new_op));
 }
 


### PR DESCRIPTION
It removes lyaer_idx from Attention Param.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

I forgot to remove `layer_idx` from Param.

Related: https://github.com/Samsung/ONE/pull/16055#discussion_r2446445063