### PR TITLE
[onert] Remove redundant dl library linking in CMakeLists.txt

### DIFF
--- a/runtime/onert/odc/CMakeLists.txt
+++ b/runtime/onert/odc/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(${TEST_ONERT_ODC} ${TESTS})
 target_link_libraries(${TEST_ONERT_ODC} onert_odc)
 # Requires linking nnfw_coverage: check header coverage
 target_link_libraries(${TEST_ONERT_ODC} nnfw_common nnfw_coverage)
-target_link_libraries(${TEST_ONERT_ODC} gtest gtest_main dl Threads::Threads)
+target_link_libraries(${TEST_ONERT_ODC} gtest gtest_main ${CMAKE_DL_LIBS} Threads::Threads)
 target_include_directories(${TEST_ONERT_ODC} PRIVATE $<TARGET_PROPERTY:onert_odc,INCLUDE_DIRECTORIES>)
 
 add_test(${TEST_ONERT_ODC} ${TEST_ONERT_ODC})

--- a/runtime/tests/nnfw_api/CMakeLists.txt
+++ b/runtime/tests/nnfw_api/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(${RUNTIME_NNFW_API_TEST} PRIVATE ${RUNTIME_NNFW_API_T
 
 target_link_libraries(${RUNTIME_NNFW_API_TEST} nnfw-dev jsoncpp)
 target_link_libraries(${RUNTIME_NNFW_API_TEST} gtest gmock)
-target_link_libraries(${RUNTIME_NNFW_API_TEST} Threads::Threads dl)
+target_link_libraries(${RUNTIME_NNFW_API_TEST} Threads::Threads)
 target_link_libraries(${RUNTIME_NNFW_API_TEST} circle_schema)
 target_link_libraries(${RUNTIME_NNFW_API_TEST} nnfw_common)
 

--- a/runtime/tests/tools/libs/tflite/CMakeLists.txt
+++ b/runtime/tests/tools/libs/tflite/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(nnfw_lib_tflite PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(nnfw_lib_tflite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(nnfw_lib_tflite PUBLIC tensorflow-lite)
 target_link_libraries(nnfw_lib_tflite PUBLIC nnfw_lib_misc nnfw_lib_benchmark)
-target_link_libraries(nnfw_lib_tflite PRIVATE Threads::Threads dl)
+target_link_libraries(nnfw_lib_tflite PRIVATE Threads::Threads)
 target_link_libraries(nnfw_lib_tflite PRIVATE nnfw_common)
 
 if(NOT ENABLE_TEST)

--- a/runtime/tests/tools/onert_train/CMakeLists.txt
+++ b/runtime/tests/tools/onert_train/CMakeLists.txt
@@ -51,7 +51,7 @@ add_executable(${TEST_ONERT_TRAIN} ${ONERT_TRAIN_TEST_SRCS})
 
 target_link_libraries(${TEST_ONERT_TRAIN} nnfw-dev)
 target_link_libraries(${TEST_ONERT_TRAIN} nnfw_common)
-target_link_libraries(${TEST_ONERT_TRAIN} gtest gtest_main dl Threads::Threads)
+target_link_libraries(${TEST_ONERT_TRAIN} gtest gtest_main Threads::Threads)
 
 add_test(${TEST_ONERT_TRAIN} ${TEST_ONERT_TRAIN})
 install(TARGETS ${TEST_ONERT_TRAIN} DESTINATION unittest)


### PR DESCRIPTION
This commit removes unnecessary explicit linking to 'dl' library in multiple CMakeLists.txt files as it is already included via ${CMAKE_DL_LIBS} or not required. 
It ensures cleaner and more portable build configurations.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>