### PR TITLE
[onert] Add CMAKE_DL_LIBS to tensorflow-lite target link libraries

### DIFF
--- a/runtime/infra/cmake/packages/TensorFlowLiteConfig.cmake
+++ b/runtime/infra/cmake/packages/TensorFlowLiteConfig.cmake
@@ -92,6 +92,6 @@ if(Flatbuffers_FOUND)
   target_link_libraries(tensorflow-lite INTERFACE flatbuffers::flatbuffers)
 endif(Flatbuffers_FOUND)
 
-target_link_libraries(tensorflow-lite INTERFACE Threads::Threads)
+target_link_libraries(tensorflow-lite INTERFACE Threads::Threads ${CMAKE_DL_LIBS})
 
 set(TensorFlowLite_FOUND TRUE)


### PR DESCRIPTION
This change ensures that the dynamic loading library dependencies are properly linked when linking TFLite platform library.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>