### PR TITLE
[infra/onert] Simplify verify-tflite test command

### DIFF
--- a/infra/scripts/common.sh
+++ b/infra/scripts/common.sh
@@ -12,7 +12,7 @@
 # CheckTestPrepared
 #   Check environment variable setting to run test
 #
-# TFLiteModelVerification $1 $2 $3
+# TFLiteModelVerification $1 $2
 #   Run ./tests/scripts/test-driver.sh script verification test
 #
 # NNAPIGTest $1 $2 $3
@@ -39,25 +39,16 @@ function CheckTestPrepared()
 }
 
 # $1: (required) backend
-# $2: (required) framework list file relative path from nnfw root directory
-#                pass empty string if there is no skiplist
-# $3: (required) relative path to report from nnfw root directory
+# $2: (required) relative path to report from nnfw root directory
 function TFLiteModelVerification()
 {
-  [[ $# -ne 3 ]] && echo "Invalid function argument setting" && exit 1
+  [[ $# -ne 2 ]] && echo "Invalid function argument setting" && exit 1
 
   pushd ${ROOT_PATH} > /dev/null
 
-  export BACKENDS=$1
-  if [[ "$2" == "" ]]; then
-    $INSTALL_PATH/test/onert-test verify-tflite \
-      --reportdir=$ROOT_PATH/$3
-  else
-    $INSTALL_PATH/test/onert-test verify-tflite \
-      --list=$2 \
-      --reportdir=$ROOT_PATH/$3
-  fi
-  unset BACKENDS
+  $INSTALL_PATH/test/onert-test verify-tflite \
+    --backend $1 \
+    --reportdir=$ROOT_PATH/$2
 
   popd > /dev/null
 }

--- a/infra/scripts/test_coverage.sh
+++ b/infra/scripts/test_coverage.sh
@@ -32,7 +32,7 @@ TENSOR_LOGGING=trace_log.txt ./infra/scripts/test_ubuntu_runtime.sh --backend ac
 ENABLE_LOG=1 GRAPH_DOT_DUMP=1 ./infra/scripts/test_ubuntu_runtime_mixed.sh
 # Enable trace event (acl_cl default backend)
 export TRACING_MODE=1
-TFLiteModelVerification "acl_cl" "Product/out/test/list/tflite_comparator.armv7l.acl_cl.list" "report/acl_cl/trace"
+TFLiteModelVerification "acl_cl" "report/acl_cl/trace"
 unset TRACING_MODE
 
 # nnpackage test suite

--- a/infra/scripts/test_ubuntu_runtime.sh
+++ b/infra/scripts/test_ubuntu_runtime.sh
@@ -51,7 +51,6 @@ CheckTestPrepared
 echo "[[ ${TEST_PLATFORM}: ${BACKEND} backend test ]]"
 
 UNITTEST_SKIPLIST="Product/out/nnapi-gtest/nnapi_gtest.skip.${TEST_PLATFORM}.${BACKEND}"
-TFLITE_TESTLIST="Product/out/test/list/tflite_comparator.${TEST_ARCH}.${BACKEND}.list"
 REPORT_BASE="report/${BACKEND}"
 EXECUTORS=("Linear" "Dataflow" "Parallel")
 
@@ -67,7 +66,7 @@ do
   export EXECUTOR="${EXECUTOR}"
 
   NNAPIGTest "${BACKEND}" "${UNITTEST_SKIPLIST}" "${REPORT_PATH}"
-  TFLiteModelVerification "${BACKEND}" "${TFLITE_TESTLIST}" "${REPORT_PATH}"
+  TFLiteModelVerification "${BACKEND}" "${REPORT_PATH}"
 
   unset EXECUTOR
 done

--- a/runtime/tests/scripts/command/verify-tflite
+++ b/runtime/tests/scripts/command/verify-tflite
@@ -14,17 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REPORT_DIR="report"
+BACKEND="cpu"
+REPORT_DIR="$(pwd)/report/$BACKEND"
 TEST_LIST_FILE=
+TEST_ALL=false
+USE_DEFAULT_DIR=true
+REPORT_DIR=""
 
 function Usage()
 {
     echo "Usage: $0 $(basename ${BASH_SOURCE[0]}) [OPTIONS]"
     echo ""
     echo "Options:"
-    echo "      --reportdir=PATH        Path to write report (default=$REPORT_DIR)"
+    echo "      --reportdir=PATH        Path to write report (default=$(pwd)/report/{BACKEND_NAME})"
     echo "      --list=FILE             List file to test. Test all if list option is not passed"
     echo "      --cachedir=PATH         Set downloaded resouces cache directory (default: $CACHE_PATH)"
+    echo "      --backend NAME          Backend to test (default: $BACKEND)"
+    echo "      --all                   Run all test cases (default: $TEST_ALL)"
 }
 
 for i in "$@"
@@ -34,14 +40,31 @@ do
             Usage
             exit 1
             ;;
+    esac
+done
+
+while [ "$#" -ne 0 ]; do
+    case $1 in
         --reportdir=*)
             REPORT_DIR=${i#*=}
+            USE_DEFAULT_DIR=false
             ;;
         --list=*)
             TEST_LIST_FILE=${i#*=}
+            # Will be deprecated
+            echo "--list option will be deprecated soon."
+            echo "Please use --backend to select backend."
+            echo "Please use --all to test all test cases."
+            ;;
+        --backend)
+            BACKEND=${2}
+            shift
             ;;
         --cachedir=*)
             CACHE_PATH=${i#*=}
+            ;;
+        --all)
+            TEST_ALL=true
             ;;
         *)
             echo "Unknown option: $i"
@@ -51,7 +74,15 @@ do
     shift
 done
 
-if [ ! -z "$TEST_LIST_FILE" ]; then
+if [[ $USE_DEFAULT_DIR == true ]]; then
+    REPORT_DIR="$(pwd)/report/$BACKEND"
+fi
+
+if [[ $TEST_ALL == false ]]; then
+    if [[  -z "$TEST_LIST_FILE" ]]; then
+        TEST_ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+        TEST_LIST_FILE="$(dirname $0)/list/tflite_comparator.${TEST_ARCH}.${BACKEND}.list"
+    fi
     MODELLIST=$(cat "${TEST_LIST_FILE}")
 fi
 
@@ -64,12 +95,20 @@ TAP_NAME=verification_test.tap
 TEST_NAME="Loader Verification"
 TEST_DRIVER=tflite_comparator
 
+BACKUP_BACKENDS=$BACKENDS
+export BACKENDS=$BACKEND
 $INSTALL_PATH/test/models/run_test.sh --driverbin=$TEST_DRIVER \
     --reportdir=$REPORT_DIR \
     --tapname=$TAP_NAME \
     --cachedir=$CACHE_PATH \
     ${MODELLIST:-} > $REPORT_DIR/verification_test.log 2>&1
 TEST_RESULT=$?
+
+if [[ $BACKUP_BACKENDS != "" ]]; then
+    export BACKENDS=$BACKUP_BACKENDS
+else
+    unset BACKENDS
+fi
 
 if [[ $TEST_RESULT -ne 0 ]]; then
     echo ""


### PR DESCRIPTION
It updates verify-tflite script to support backend selection method
- Automate test list selection
- No need to pass option to test CPU backend
- Update function to use --backend flag instead of environment variable
- Remove unused framework list parameter from TFLiteModelVerification
- Deprecate --list option in favor of --backend and --all flags

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>