### PR TITLE
[docs] Remove trailing newlines

### DIFF
--- a/docs/compiler/backend.rst
+++ b/docs/compiler/backend.rst
@@ -9,4 +9,3 @@ Backend
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
-

--- a/docs/compiler/index.rst
+++ b/docs/compiler/index.rst
@@ -17,4 +17,3 @@ Compiler
   ./interpreters
   ./libraries
   ./tools
-

--- a/docs/compiler/middleend.rst
+++ b/docs/compiler/middleend.rst
@@ -18,4 +18,3 @@ Middleend
 
   ./compiler/moco-tf/README.md
   ./compiler/moco-tf/doc/Conversion.md
-

--- a/docs/howto/how-to-contribute.md
+++ b/docs/howto/how-to-contribute.md
@@ -70,4 +70,3 @@ This section explains the steps to create a pull request (PR).
    your pull request upon such feedbacks. These update commits will be squashed into the first
    commit of your pull request later. Please do **NOT** include a sign-off message or write a full
    description for update commits.
-

--- a/docs/howto/how-to-introduce-a-new-operation-into-compiler.md
+++ b/docs/howto/how-to-introduce-a-new-operation-into-compiler.md
@@ -1,2 +1,1 @@
 # How To Introduce a New Operation Into Compiler
-

--- a/docs/overview/index.rst
+++ b/docs/overview/index.rst
@@ -15,4 +15,3 @@ Overview
   ./overall-architecture.md
   ./supported-operations.md
   ./workgroup.md
-

--- a/docs/overview/roadmap.md
+++ b/docs/overview/roadmap.md
@@ -55,4 +55,3 @@ memory bandwidth at runtime.
 - We organize WGs for major topics and each WG will be working on its own major topic by breaking
   it into small tasks/issues, performing them inside WG and collaborating between WGs.
 - The WG information can be found [here](workgroup.md).
-

--- a/docs/release/1.20/release-note-1.20.0.md
+++ b/docs/release/1.20/release-note-1.20.0.md
@@ -31,4 +31,3 @@
 
 ### API supports new data type
 - Symmetric Quantized int16 type named "NNFW_TYPE_TENSOR_QUANT16_SYMM_SIGNED"
-

--- a/docs/release/1.21/release-note_1.21.0.md
+++ b/docs/release/1.21/release-note_1.21.0.md
@@ -32,4 +32,3 @@
 
 ### Batch Execution with TRIX backend
 - TRIX backend supports batch execution which run in parallel with multicore
-

--- a/docs/release/1.8/release-note-1.8.0.md
+++ b/docs/release/1.8/release-note-1.8.0.md
@@ -39,4 +39,3 @@
 ### Support CPU backend quant8 operation
 
 - BatchToSpaceND, L2Normalization, Pad, PadV2, ResizeBilinear, Slice, Quantize, SpaceToDepth, Sum
-

--- a/docs/release/onert-micro/0.1/release-note-0.1.0.md
+++ b/docs/release/onert-micro/0.1/release-note-0.1.0.md
@@ -69,4 +69,3 @@ Binary file size overhead (bytes) | N/A | 43 444 |
 
 (*) Average for 100 inferences
 (**) Tflite-micro has not launched this model
-


### PR DESCRIPTION
This commit removes unnecessary trailing newlines at the end of several RST and Markdown documentation files.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>