### PR TITLE
[infra] Remove trailing newlines

### DIFF
--- a/infra/cmake/packages/LibnpySourceConfig.cmake
+++ b/infra/cmake/packages/LibnpySourceConfig.cmake
@@ -17,4 +17,3 @@ function(_LibnpySource_import)
 endfunction(_LibnpySource_import)
 
 _LibnpySource_import()
-

--- a/infra/debian/compiler/docs/onecc.1
+++ b/infra/debian/compiler/docs/onecc.1
@@ -193,4 +193,3 @@ programs are properly installed at your site, the command
 .B info onecc
 .PP
 should give you access to the complete manual.
-

--- a/infra/debian/compiler/rules
+++ b/infra/debian/compiler/rules
@@ -16,4 +16,3 @@ override_dh_auto_install:
 override_dh_install:
 	install -T -m 755 -D "infra/packaging/res/tf2nnpkg.${PRESET}" "$(_DESTDIR)/bin/tf2nnpkg"
 	dh_install
-

--- a/infra/nncc/cmake/options/options_aarch64-darwin.cmake
+++ b/infra/nncc/cmake/options/options_aarch64-darwin.cmake
@@ -1,4 +1,3 @@
 #
 # aarch64 darwin cmake options
 #
-

--- a/infra/nncc/cmake/options/options_aarch64-linux.cmake
+++ b/infra/nncc/cmake/options/options_aarch64-linux.cmake
@@ -1,4 +1,3 @@
 #
 # aarch64 linux cmake options
 #
-

--- a/infra/nncc/cmake/options/options_aarch64-tizen.cmake
+++ b/infra/nncc/cmake/options/options_aarch64-tizen.cmake
@@ -1,4 +1,3 @@
 #
 # aarch64 tizen cmake options
 #
-

--- a/infra/nncc/cmake/options/options_x86_64-darwin.cmake
+++ b/infra/nncc/cmake/options/options_x86_64-darwin.cmake
@@ -1,4 +1,3 @@
 #
 # x86_64 darwin cmake options
 #
-


### PR DESCRIPTION
This commit removes unnecessary trailing empty lines from CMake configuration files, debian packaging rules in infra/ directory.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>