### PR TITLE
[compiler] Rmove trailing newlines

### DIFF
--- a/compiler/ann-ref/src/Validation.cpp
+++ b/compiler/ann-ref/src/Validation.cpp
@@ -260,4 +260,3 @@ bool validateRequest(const Request &request, const Model &model)
           validRequestArguments(request.outputs, model.outputIndexes, model.operands, poolCount,
                                 "output"));
 }
-

--- a/compiler/circlechef/core/src/DataChef.def
+++ b/compiler/circlechef/core/src/DataChef.def
@@ -28,4 +28,3 @@ DATA_CHEF(INT32, gaussian, GaussianInt32DataChefFactory)
 DATA_CHEF(INT16, gaussian, GaussianInt16DataChefFactory)
 DATA_CHEF(UINT8, gaussian, GaussianUint8DataChefFactory)
 DATA_CHEF(UINT4, gaussian, GaussianUint4DataChefFactory)
-

--- a/compiler/mir/Readme.md
+++ b/compiler/mir/Readme.md
@@ -33,4 +33,3 @@ Can be included as a `CMake` target.
 ### Dependencies
 
 Mir depends on the `adtitas` library, which provides the `small_vector` data type.
-

--- a/compiler/nnc/README.md
+++ b/compiler/nnc/README.md
@@ -55,4 +55,3 @@ Also assuming that we have tflite model (for example inceptionv3.tflite)
 --output inception \
 --output-dir output_dir
 ```
-

--- a/compiler/nnc/utils/model_runner/readme.md
+++ b/compiler/nnc/utils/model_runner/readme.md
@@ -30,4 +30,3 @@ $ python model_runner.py  -m onnx_runer/model.onnx -i RANDOM.hdf5
  
  -m mean pre learned model which you run
  -i mean model's input
-

--- a/compiler/onecc-docker/debian/changelog
+++ b/compiler/onecc-docker/debian/changelog
@@ -3,4 +3,3 @@ onecc-docker (0.1.0) bionic; urgency=medium
   * Introduce onecc-docker
 
  -- Seunghui Lee <dltmdgml456654@gmail.com>  Wed, 23 Sep 2022 12:00:00 +0900
-

--- a/compiler/tf2tfliteV2-conversion-test/README.md
+++ b/compiler/tf2tfliteV2-conversion-test/README.md
@@ -1,2 +1,1 @@
 # tf2tfliteV2-conversion-test
-


### PR DESCRIPTION
This commit removes unnecessary trailing newlines at the end of files  in compiler directory.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>