### PR TITLE
[infra] Improve ccache key specificity in GitHub workflows

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -118,7 +118,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-onecc-${{ matrix.ubuntu_code }}
+          key: ccache-onecc-${{ matrix.ubuntu_code }}-${{ matrix.type }}
+          restore-keys: |
+            ccache-onecc-${{ matrix.ubuntu_code }}
 
       - name: Build
         run: |

--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -76,7 +76,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-onert-${{ matrix.ubuntu_code }}
+          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}
+          restore-keys: |
+            ccache-onert-${{ matrix.ubuntu_code }}
 
       - name: Download rootfs for cross build
         uses: dawidd6/action-download-artifact@v7

--- a/.github/workflows/run-onert-native-build.yml
+++ b/.github/workflows/run-onert-native-build.yml
@@ -78,7 +78,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-onert-${{ matrix.ubuntu_code }}
+          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}
+          restore-keys: |
+            ccache-onert-${{ matrix.ubuntu_code }}
 
       - name: Build onert
         run: |


### PR DESCRIPTION
This commit updates ccache keys to include matrix.type and matrix.arch for more precise caching. 
It adds restore-keys to fallback to base cache when specific cache is not found

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>