### PR TITLE
[infra] Add pyproject.toml for ONE project configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "ONE"
+version = "1.31.0"
+maintainers = [
+  { name="NNFW", email="nnfw@samsung.com" },
+]
+description = "ONE(On-device Neural Engine): A high-performance, on-device neural network inference framework"
+readme = "README.md"
+requires-python = ">=3.10"
+license-files = [
+  "LICENSE"
+]
+
+[project.urls]
+"Homepage" = "https://github.com/Samsung/ONE"
+"Documentation" = "https://nnfw.readthedocs.io/"
+"Repository" = "https://github.com/Samsung/ONE/ONE.git"
+"Issues" = "https://github.com/Samsung/ONE/issues"
+
+[dependency-groups]
+dev = [
+  "pre-commit==4.4.0",
+]
+
+# This file does not describe packaging details for compiler and runtime


### PR DESCRIPTION
This commit adds pyproject.toml file to define project metadata, dependencies, and URLs for the ONE. 
This helps to set developer environment easily.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>