### PR TITLE
[infra] Update .gitignore to exclude Python local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@
 # Makefile
 /Makefile
 
-# Python virtualenv
-/.venv
+# Python environment
+**/.venv
+
+# Root uv.lock
+/uv.lock
 
 # Debian folder for multiple packages
 /debian


### PR DESCRIPTION
The commit updates pattern `/.venv` to `**/.venv` to match virtual environments in any directory level, and root uv.lock.


ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>