### PR TITLE
[docs] Add documentation for format checker

### DIFF
--- a/docs/howto/how-to-contribute.md
+++ b/docs/howto/how-to-contribute.md
@@ -16,7 +16,7 @@ This section explains the steps to create a pull request (PR).
 
 1. Create an issue
 
-   Maintainers will accept your contribution only when it is well aligned with the 
+   Maintainers will accept your contribution only when it is well aligned with the
    [roadmap](../overview/roadmap.md) and design
    principles of **ONE**. So, it is optional, but recommended for contributors to create an issue
    and have a discussion with maintainers before writing code.
@@ -28,21 +28,22 @@ This section explains the steps to create a pull request (PR).
    your contribution into multiple small, but focused pull requests in this case. Unfortunately, it
    is possible that maintainers reject your pull request as it is hard for them to understand the
    intuition behind these changes. So, it is optional, but recommended for contributors to present
-   the full [draft](https://github.com/Samsung/ONE/pulls?q=is%3Apr+label%3ADRAFT+) of your 
+   the full [draft](https://github.com/Samsung/ONE/pulls?q=is%3Apr+label%3ADRAFT+) of your
    contribution and have a discussion with maintainers before creating PR(s).
 
 1. Create a commit
 
    It is time to create a commit for submission once you are convinced that your contribution is
-   ready to go. Please include 
-   [signed-off message](https://github.com/Samsung/ONE/wiki/ONE-Developer's-Certificate-of-Origin) 
+   ready to go. Please include
+   [signed-off message](https://github.com/Samsung/ONE/wiki/ONE-Developer's-Certificate-of-Origin)
    at the end of commit message. If not, your pull request will be **rejected** by CI.
 
 1. Check code format locally
 
    **ONE** has its code formatting rules, and any pull request that violates these rules will be
    **rejected** by CI. So, it is optional, but recommended for contributor to check code format
-   locally before submission.
+   locally before submission. Please refer [this guide](how-to-run-format-checker.md) for details
+   to run format checker locally.
 
 1. Create a PR
 

--- a/docs/howto/how-to-run-format-checker.md
+++ b/docs/howto/how-to-run-format-checker.md
@@ -1,0 +1,15 @@
+# How to run format checker
+
+We highly recommand to use pre-commit tool to run format checker automatically before commit
+
+## Install pre-commit
+
+- Install `uv` to use `pre-commit` hook to automatically format code before commit
+  - `uv`: https://docs.astral.sh/uv/
+- Install `pre-commit` hook by `uv run pre-commit install`
+
+## Run pre-commit hook manually
+
+- You can use `uv run pre-commit run` command to manually run pre-commit hook to staged files
+- You can use `uv run pre-commit run -a` command to run pre-commit hook on all files
+  - You can use pre-commit hook to apply C/C++ and python to entire project

--- a/runtime/coding-rules.md
+++ b/runtime/coding-rules.md
@@ -28,5 +28,4 @@ This is recommended coding rules for the project.
 ### Code Style
 
 - Follow .clang-format file in the repository.
-- You can use `./nnas format` command to apply clang-format to entire project.
-- You can use `./nnas format --diff-only` command to apply clang-format to only modified files.
+- Recommand to use pre-commit hook: [How to run format checker](../docs/howto/how-to-run-format-checker.md)


### PR DESCRIPTION
This commit adds new documentation file 'how-to-run-format-checker.md' with instructions on using pre-commit hooks
- Update 'how-to-contribute.md' to reference the new format checker guide
- Modify 'coding-rules.md' to recommend pre-commit hook over deprecated nnas format commands

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/16295