### PR TITLE
[infra] Add pre-commit hook to check executable files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
         exclude: \.(svg)$
       # - name: 'Check trailing whitespace'
       #   id: trailing-whitespace
+      # TODO add shebang to all excutable python/shell scripts
+      - name: 'Check executable files'
+        id: check-executables-have-shebangs
+        exclude: \.(py|sh)$
 
   - repo: https://github.com/rhysd/actionlint
     rev: 'v1.7.9'


### PR DESCRIPTION
This commit adds a new pre-commit hook configuration to verify that executable files contain proper shebang lines. 
This ensures file does not have execution permission except executable script.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #16295