### PR TITLE
[infra] Exclude contrib directory from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: .*/contrib/.*
 # for pre-commit 4.4.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
This commit add exclusion rule for contrib directory in pre-commit configuration.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>