### PR TITLE
[infra] Update python packaging workflow

### DIFF
--- a/.github/workflows/pub-onert-pypi.yml
+++ b/.github/workflows/pub-onert-pypi.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository_owner == 'Samsung'
     strategy:
       matrix:
-        python-version: [ 'python3.10', 'python3.11', 'python3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         arch: [ 'x86_64', 'aarch64' ]
         include:
           - arch: x86_64
@@ -36,7 +36,9 @@ jobs:
     env:
       BUILD_TYPE: release
       OPTIONS: "-DENABLE_TEST=OFF -DBUILD_ARMCOMPUTE=OFF"
-      DEV_TAG: ""
+      # Set env to decide package name: refer runtime/infra/python/wheel_target_hook.py
+      PLATFORM: ${{ matrix.arch }}
+      GLIBC_VERSION: "2.28"
 
     steps:
       - name: Checkout
@@ -50,11 +52,11 @@ jobs:
           restore-keys: |
             external-onert-jammy-
 
-      - name: Install venv for python version
-        run: |
-          ${{ matrix.python-version }} -m venv ./venv
-          source ./venv/bin/activate
-          pip3 install -U setuptools wheel
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.10"
+          python-version: "${{ matrix.python-version }}"
 
       # For flatc build
       - name: Install glibc-static
@@ -63,8 +65,7 @@ jobs:
 
       - name: Build
         run: |
-          source ./venv/bin/activate
-          make -f Makefile.template configure build install
+          uv run --python "${{ matrix.python-version }}" make -f Makefile.template configure build install
 
       # Pre-release build
       # 1) Release branch test build
@@ -73,23 +74,17 @@ jobs:
       - name: Pre-release packaging
         if: github.event.inputs.official == 'false' || github.event_name == 'pull_request' || github.ref_name == 'master'
         run: |
-          source ./venv/bin/activate
-          cd runtime/infra/python
-          python3 setup.py bdist_wheel --plat-name manylinux_2_28_${{ matrix.arch }} egg_info --tag-build "dev$(date -u "+%y%m%d")"
+          uv version "$(uv version --short --project runtime)-dev$(date -u "+%y%m%d")" --project runtime --python "${{ matrix.python-version }}"
 
-      # Allow official release on release branch only
-      - name: Release packaging
-        if: github.event.inputs.official == 'true' && startsWith(github.ref_name, 'release/')
+      - name: Build package
         run: |
-          source ./venv/bin/activate
-          cd runtime/infra/python
-          python3 setup.py bdist_wheel --plat-name manylinux_2_28_${{ matrix.arch }} egg_info
+          uv build --wheel --project runtime --python "${{ matrix.python-version }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: onert-wheel-${{ matrix.python-version }}-${{ matrix.arch }}
-          path: runtime/infra/python/dist/*.whl
+          name: onert-wheel-python${{ matrix.python-version }}-${{ matrix.arch }}
+          path: runtime/dist/*.whl
 
   publish-to-pypi:
     needs: [ build ]

--- a/runtime/infra/python/wheel_target_hook.py
+++ b/runtime/infra/python/wheel_target_hook.py
@@ -61,7 +61,6 @@ class WheelBuildHook(BuildHookInterface):
         self.copy_libraries(src_libs_base_dir, self.whl_binaries_target_dir, "nnfw")
         self.copy_libraries(src_libs_base_dir, self.whl_binaries_target_dir,
                             "nnfw/backend")
-        self.copy_libraries(src_libs_base_dir, self.whl_binaries_target_dir, "nnfw/odc")
 
     def get_libs_dir(self):
         """Retrieve the path of a directory where the required shared libraries are"""
@@ -156,7 +155,7 @@ class WheelBuildHook(BuildHookInterface):
             )
             return supported_platforms[0]
         elif value not in supported_platforms:
-            raise ValueError(f"""Unsupported platform detected: {value}. 
+            raise ValueError(f"""Unsupported platform detected: {value}.
                 Please use one of the following values: {','.join(supported_platforms)}"""
                              )
         else:


### PR DESCRIPTION
This commit updates python packaging workflow
- Use uv for building wheels instead of setup.py bdist_wheel
- Replace virtual environment setup with uv venv command
- Set platform-specific environment variables (PLATFORM, GLIBC_VERSION)
- Set dev version by using uv version command

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>