### PR TITLE
[infra] Update pre-commit config to exclude yapf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,14 @@ repos:
           compiler/fm-equalize/fm-equalize$
         )
       # Ignore shell script: one-prepare-venv
+      # Exclude files in .yapfignore - yapf's pre-commit issue
       exclude:
-        ^compiler/one-cmds/one-prepare-venv$
+        (?x)^(
+          compiler/one-cmds/one-prepare-venv|
+          runtime/3rdparty/.*|
+          runtime/tests/nnapi/nnapi_test_generator/.*|
+          runtime/tests/nnapi/specs/.*
+        )$
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v16.0.6'


### PR DESCRIPTION
This commit updates yapf exclude to add files in .yapfignore list. 
It is a workaround to avoid errors when pre-commit yapf tries to check file in .yapfignore list.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://stackoverflow.com/questions/68274102/pre-commit-yapf-fails-on-file-included-in-yapfignore