### PR TITLE
[infra] Improve ccache cache keys with github.sha

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -40,38 +40,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare:
+  onecc-test:
     if: github.repository_owner == 'Samsung' && !contains(github.event.pull_request.labels.*.name, 'PR/NO TEST')
-    runs-on: ubuntu-latest
-    outputs:
-      run_matrix: ${{ steps.set-matrix.outputs.run_matrix }}
-    steps:
-      - name: set matrix
-        id: set-matrix
-        env:
-          EVENT_NAME: ${{ github.event_name }}
+    strategy:
+      matrix:
+        type: ['Debug', 'Release']
         # TODO enable focal when possible
         #      refer https://github.com/Samsung/ONE/issues/16196
-        run: |
-          JSON='{'
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            JSON+='"type": ["Debug"],'
-            JSON+='"ubuntu_code": ["jammy", "noble"]'
-          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
-            JSON+='"type": ["Debug", "Release"],'
-            JSON+='"ubuntu_code": ["jammy", "noble"],'
-            JSON+='"exclude": [{"ubuntu_code": "focal", "type": "Debug"},'
-            JSON+='{"ubuntu_code": "noble", "type": "Debug"}]'
-          else
-            exit 1
-          fi
-          JSON+='}'
-          echo "run_matrix=$JSON" >> "$GITHUB_OUTPUT"
-
-  onecc-test:
-    needs: [ prepare ]
-    strategy:
-      matrix: ${{ fromJSON(needs.prepare.outputs.run_matrix) }}
+        ubuntu_code: ['jammy', 'noble']
     runs-on: one-x64-linux
     container:
       image: samsungonedev.azurecr.io/nnfw/one-devtools:${{ matrix.ubuntu_code }}
@@ -118,9 +94,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-onecc-${{ matrix.ubuntu_code }}-${{ matrix.type }}
+          key: ccache-onecc-${{ matrix.ubuntu_code }}-${{ matrix.type }}-${{ github.sha }}
           restore-keys: |
-            ccache-onecc-${{ matrix.ubuntu_code }}
+            ccache-onecc-${{ matrix.ubuntu_code }}-${{ matrix.type }}
 
       - name: Build
         run: |

--- a/.github/workflows/run-onert-android-build.yml
+++ b/.github/workflows/run-onert-android-build.yml
@@ -67,7 +67,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-onert-android
+          key: ccache-onert-android-${{ github.sha }}
+          restore-keys: |
+            ccache-onert-android
 
       # Set ccache size
       # Release < 100MB / Debug < 250MB

--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -76,9 +76,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}
+          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}-${{ github.sha }}
           restore-keys: |
-            ccache-onert-${{ matrix.ubuntu_code }}
+            ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}
 
       - name: Download rootfs for cross build
         uses: dawidd6/action-download-artifact@v7

--- a/.github/workflows/run-onert-native-build.yml
+++ b/.github/workflows/run-onert-native-build.yml
@@ -78,9 +78,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}
+          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}-${{ github.sha }}
           restore-keys: |
-            ccache-onert-${{ matrix.ubuntu_code }}
+            ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}
 
       - name: Build onert
         run: |


### PR DESCRIPTION
This commit updates ccache cache keys to include github.sha to update cache when a new commit is pushed
- Simplify onecc-test job matrix configuration by removing dynamic matrix generation

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>