### PR TITLE
[infra] Split workflow cache restore and save

### DIFF
--- a/.github/workflows/build-pub-dev-docker.yml
+++ b/.github/workflows/build-pub-dev-docker.yml
@@ -72,11 +72,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore onecc external cache
+        uses: actions/cache/restore@v4
         with:
           path: externals
-          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onecc-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
+          restore-keys: |
+            external-onecc-
+
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
+        with:
+          path: runtime/externals
+          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('runtime/infra/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
 
@@ -115,11 +123,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore onecc external cache
+        uses: actions/cache/restore@v4
         with:
           path: externals
-          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onecc-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
+          restore-keys: |
+            external-onecc-
+
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
+        with:
+          path: runtime/externals
+          key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('runtime/infra/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
 
@@ -145,11 +161,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore onecc external cache
+        uses: actions/cache/restore@v4
         with:
           path: externals
-          key: external-onert-ndk-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
+          key: external-onecc-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
+          restore-keys: |
+            external-onecc-
+
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
+        with:
+          path: runtime/externals
+          key: external-onert-ndk-${{ hashFiles('runtime/infra/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-ndk-
 
@@ -178,10 +202,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore onecc external cache
+        uses: actions/cache/restore@v4
         with:
           path: externals
+          key: external-onecc-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
+          restore-keys: |
+            external-onecc-
+
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
+        with:
+          path: runtime/externals
           key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('infra/nnfw/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-

--- a/.github/workflows/pub-onert-pypi.yml
+++ b/.github/workflows/pub-onert-pypi.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
         with:
           path: runtime/externals
           key: external-onert-jammy-${{ hashFiles('runtime/infra/cmake/packages/**/*.cmake') }}

--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -75,8 +75,9 @@ jobs:
           apt-get -qqy install python3.10 python3.10-dev python3.10-venv
           python3.10 -m ensurepip --upgrade
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
+        id: externals-cache
         with:
           path: externals
           key: external-onecc-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
@@ -84,14 +85,16 @@ jobs:
             external-onecc-
             external-
 
-      - name: Caching overlay
-        uses: actions/cache@v4
+      - name: Restore overlay cache
+        uses: actions/cache/restore@v4
+        id: overlay-cache
         with:
           path: ${{ env.NNCC_WORKSPACE }}/overlay
           key: overlay-onecc-${{ matrix.ubuntu_code }}-${{ hashFiles('compiler/common-artifacts/CMakeLists.txt') }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
 
-      - name: Caching ccache
-        uses: actions/cache@v4
+      - name: Restore ccache cache
+        uses: actions/cache/restore@v4
+        id: ccache-cache
         with:
           path: ~/.cache/ccache
           key: ccache-onecc-${{ matrix.ubuntu_code }}-${{ matrix.type }}-${{ github.sha }}
@@ -104,6 +107,31 @@ jobs:
             -DEXTERNALS_BUILD_THREADS="$(nproc)" -DCMAKE_INSTALL_PREFIX="${NNCC_INSTALL_PREFIX}"
           ./nncc build "-j$(nproc)"
           cmake --build "${NNCC_WORKSPACE}" -- install
+
+      # Save cache on push to reduce the size of cache storage
+      #   ccache cache: only for master branch
+      #   overlay cache: only for master branch and Release build
+      #   externals cache: only for master branch and Release build and jammy
+      - name: Save ccache cache
+        if: github.event_name == 'push' && github.ref_name == 'master'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/ccache
+          key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
+
+      - name: Save overlay cache
+        if: github.event_name == 'push' && github.ref_name == 'master' && matrix.type == 'Release'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.NNCC_WORKSPACE }}/overlay
+          key: ${{ steps.overlay-cache.outputs.cache-primary-key }}
+
+      - name: Save externals cache
+        if: github.event_name == 'push' && github.ref_name == 'master' && matrix.type == 'Release' && matrix.ubuntu_code == 'jammy'
+        uses: actions/cache/save@v4
+        with:
+          path: externals
+          key: ${{ steps.externals-cache.outputs.cache-primary-key }}
 
       - name: Test(Debug)
         if: matrix.type == 'Debug'

--- a/.github/workflows/run-onert-android-build.yml
+++ b/.github/workflows/run-onert-android-build.yml
@@ -55,16 +55,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore onecc external cache
+        uses: actions/cache/restore@v4
+        with:
+          path: externals
+          key: external-onecc-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
+          restore-keys: |
+            external-onecc-
+
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
+        id: cache-externals
         with:
           path: runtime/externals
           key: external-onert-ndk-${{ hashFiles('runtime/infra/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-ndk-
 
-      - name: Caching ccache
-        uses: actions/cache@v4
+      - name: Restore ccache cache
+        uses: actions/cache/restore@v4
+        id: cache-ccache
         with:
           path: ~/.cache/ccache
           key: ccache-onert-android-${{ github.sha }}
@@ -87,3 +97,20 @@ jobs:
       - name: Build onert
         run: |
           make -f Makefile.template
+
+      # Save cache on push to reduce the size of cache storage
+      #   ccache cache: only for master branch
+      #   externals cache: only for master branch
+      - name: Save ccache cache
+        uses: actions/cache/save@v4
+        if: github.event_name == 'push' && github.ref_name == 'master'
+        with:
+          path: ~/.cache/ccache
+          key: ${{ steps.cache-ccache.outputs.cache-primary-key }}
+
+      - name: Save externals cache
+        uses: actions/cache/save@v4
+        if: github.event_name == 'push' && github.ref_name == 'master'
+        with:
+          path: runtime/externals
+          key: ${{ steps.cache-externals.outputs.cache-primary-key }}

--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -64,16 +64,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore onecc external cache
+        uses: actions/cache/restore@v4
+        with:
+          path: externals
+          key: external-onecc-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
+          restore-keys: |
+            external-onecc-
+
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
         with:
           path: runtime/externals
           key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('runtime/infra/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
 
-      - name: Caching ccache
-        uses: actions/cache@v4
+      - name: Restore ccache cache
+        uses: actions/cache/restore@v4
+        id: ccache-cache
         with:
           path: ~/.cache/ccache
           key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}-${{ github.sha }}
@@ -95,6 +104,15 @@ jobs:
       - name: Build onert
         run: |
           make -f Makefile.template create-testsuite
+
+      # Save cache on push to reduce the size of cache storage
+      #   ccache cache: only for master branch
+      - name: Save ccache cache
+        uses: actions/cache/save@v4
+        if: github.event_name == 'push' && github.ref_name =='master'
+        with:
+          path: ~/.cache/ccache
+          key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-onert-native-build.yml
+++ b/.github/workflows/run-onert-native-build.yml
@@ -66,16 +66,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Caching externals
-        uses: actions/cache@v4
+      - name: Restore onecc external cache
+        uses: actions/cache/restore@v4
+        with:
+          path: externals
+          key: external-onecc-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
+          restore-keys: |
+            external-onecc-
+
+      - name: Restore externals cache
+        uses: actions/cache/restore@v4
+        id: external-cache
         with:
           path: runtime/externals
           key: external-onert-${{ matrix.ubuntu_code }}-${{ hashFiles('runtime/infra/cmake/packages/**/*.cmake') }}
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
 
-      - name: Caching ccache
-        uses: actions/cache@v4
+      - name: Restore ccache cache
+        uses: actions/cache/restore@v4
+        id: ccache-cache
         with:
           path: ~/.cache/ccache
           key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}-${{ github.sha }}
@@ -89,3 +99,20 @@ jobs:
         run: |
           ./Product/out/test/onert-test unittest
           ./Product/out/test/onert-test unittest --unittestdir=./Product/out/nnapi-gtest
+
+      # Save cache on push to reduce the size of cache storage
+      #   ccache cache: only for master branch
+      #   externals cache: only for master branch and Release build and x86_64
+      - name: Save ccache cache
+        uses: actions/cache/save@v4
+        if: github.event_name == 'push' && github.ref_name =='master'
+        with:
+          path: ~/.cache/ccache
+          key: ${{ steps.ccache-cache.outputs.cache-primary-key }}
+
+      - name: Save externals cache
+        uses: actions/cache/save@v4
+        if: github.event_name == 'push' && github.ref_name =='master' && matrix.type =='release' && matrix.arch == 'x86_64'
+        with:
+          path: runtime/externals
+          key: ${{ steps.external-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
This commit splits the generic caching step into separate 'restore' and 'save' steps for more precise cache management. 
This change improves cache key specificity and reduce unnecessary cache save for PR.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>