### PR TITLE
[docs] Trim trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A high-performance, on-device neural network inference framework.
 This project **ONE** aims at providing a high-performance, on-device neural network (NN) inference
 framework that performs inference of a given NN model on processors, such as CPU, GPU, DSP or NPU.
 
-We develop a runtime that runs on a Linux kernel-based OS platform such as Ubuntu, Tizen, or 
-Android, and a compiler toolchain to support NN models created using various NN training frameworks such 
+We develop a runtime that runs on a Linux kernel-based OS platform such as Ubuntu, Tizen, or
+Android, and a compiler toolchain to support NN models created using various NN training frameworks such
 as Tensorflow or PyTorch in a unified form at runtime.
 
 ## Overview

--- a/docs/overview/roadmap.md
+++ b/docs/overview/roadmap.md
@@ -3,8 +3,8 @@
 This document describes the roadmap of the **ONE** project.
 
 Project **ONE** aims at providing a high-performance, on-device neural network (NN) inference
-framework that performs inference of a given NN model on processors, such as CPU, GPU, DSP, or NPU, 
-on the target platform, such as Tizen, Android and Ubuntu. 
+framework that performs inference of a given NN model on processors, such as CPU, GPU, DSP, or NPU,
+on the target platform, such as Tizen, Android and Ubuntu.
 
 ## Progress
 

--- a/docs/release/1.11/release-note-1.11.0.md
+++ b/docs/release/1.11/release-note-1.11.0.md
@@ -5,7 +5,7 @@
 ### Compiler supports more operations
 - MaxPoolWithArgMax by CustomOp
 
-### Changes 
+### Changes
 - `one-build` command added as representative command
 - one-cmds are now revised to python script and supports configuration file as input parameters
 - added `rawdata2hdf5` tool to help creating input datasets for calibration

--- a/docs/release/1.13/release-note-1.13.0.md
+++ b/docs/release/1.13/release-note-1.13.0.md
@@ -4,7 +4,7 @@
 
 ### Compiler Frontend
 
-- Add optimization pass: ConvertNCHWToNHWC, FoldSparseToDensePass, FuseBatchNormWithConvPass, ForwardReshapeToUnaryOpPass, RemoveUnnecessarySlicePass, RemoveUnnecessarySplitPass,  RemoveUnnecessaryReshapePass, RemoveRedundantReshape, SubstituteTransposeToReshapePass, SubstituteSqueezeToReshapePass, 
+- Add optimization pass: ConvertNCHWToNHWC, FoldSparseToDensePass, FuseBatchNormWithConvPass, ForwardReshapeToUnaryOpPass, RemoveUnnecessarySlicePass, RemoveUnnecessarySplitPass,  RemoveUnnecessaryReshapePass, RemoveRedundantReshape, SubstituteTransposeToReshapePass, SubstituteSqueezeToReshapePass,
 - Support more operators: FAKE_QUANT
 - Enhancements: Support auto generated random input for record-minmax (for better quantization testing)
 - Changes: `--all` option to `--O1` in circle2circle(and one-optimize)

--- a/docs/release/1.15/release-note-1.15.0.md
+++ b/docs/release/1.15/release-note-1.15.0.md
@@ -27,7 +27,7 @@
   - Maximum: uint8
   - MaxPool2D: int8
   - Minimum: uint8
-  - Mul: int8 
+  - Mul: int8
   - Pad: int8
   - PadV2: int8
   - Quantize: uint8, int8
@@ -37,6 +37,6 @@
   - Squeeze: int8
   - Sub: int8
 
-### ARM Compute Library Update 
+### ARM Compute Library Update
 
 - ONERT uses Compute Library v21.02

--- a/docs/release/1.17/release-note-1.17.0.md
+++ b/docs/release/1.17/release-note-1.17.0.md
@@ -21,4 +21,4 @@
 ### gpu_cl backend added
 
 - New backend(gpu_cl) added. This backend exploits tensorflow lite's gpu delegate.
-- This backend supports the following operations : Add, Convolution, Depthwise Convolution, Pooling, Reshape, Relu, Softmax 
+- This backend supports the following operations : Add, Convolution, Depthwise Convolution, Pooling, Reshape, Relu, Softmax

--- a/docs/release/1.21/release-note_1.21.0.md
+++ b/docs/release/1.21/release-note_1.21.0.md
@@ -28,7 +28,7 @@
 - Runtime supports to run nnpackage with two models
 
 ### Channel Wise Quantization on Conv2D and Depthwise Conv2D
-- Conv2D and Depthwise Conv2D supports per-channel quantization of uint8 type. 
+- Conv2D and Depthwise Conv2D supports per-channel quantization of uint8 type.
 
 ### Batch Execution with TRIX backend
 - TRIX backend supports batch execution which run in parallel with multicore

--- a/docs/release/1.27/release-note-1.27.0.md
+++ b/docs/release/1.27/release-note-1.27.0.md
@@ -3,7 +3,7 @@
 ## ONE Compiler
 
 - Support more Op(s): CircleGRU, CircleRelu0To1
-- Support more optimization option(s): `resolve_former_customop`, `--forward_transpose_op`, 
+- Support more optimization option(s): `resolve_former_customop`, `--forward_transpose_op`,
     `fold_shape`, `remove_gather_guard`, `fuse_add_with_conv`, `fold_squeeze`, `fuse_rsqrt`
 - Support INT4, UINT4 data types
 - Support 4bit quantization of ONNX fake quantize model

--- a/docs/release/1.30/release-note-1.30.0.md
+++ b/docs/release/1.30/release-note-1.30.0.md
@@ -2,20 +2,20 @@
 
 ## ONE Compiler
 
-- Support more optimization option(s): `--dynamic_batch_to_single_batch`, `--fuse_rmsnorm`, 
+- Support more optimization option(s): `--dynamic_batch_to_single_batch`, `--fuse_rmsnorm`,
  `--fuse_rope`, `--fuse_rsqrt`.
-- Introduce _one-import-pytorch_ for direct PyTorch import that converts PyTorch modules 
+- Introduce _one-import-pytorch_ for direct PyTorch import that converts PyTorch modules
  straight to Circle.
 - Support MX (microscaling) data type.
-- Introduce _circle-mlir_ that converts new ops (e.g., ConvTranspose2D, DepthwiseConv2D, 
- ArgMax, Reduce*, Resize, Pooling, GELU, Sigmoid, Softmax, Slice/StridedSlice, Select, 
+- Introduce _circle-mlir_ that converts new ops (e.g., ConvTranspose2D, DepthwiseConv2D,
+ ArgMax, Reduce*, Resize, Pooling, GELU, Sigmoid, Softmax, Slice/StridedSlice, Select,
  Gather, BatchMatMul) and validates shape inference.
 - ONNX is converted from new _circle-mlir/onnx2circle_ tool (onnx-tf tool is deprecated)
-- _luci-interpreter_ handles scalar indices in Gather and additional element types across 
+- _luci-interpreter_ handles scalar indices in Gather and additional element types across
  several kernels.
-- Ubuntu22.04 with python3.10 is official supported platform, python3.10 is necessary 
+- Ubuntu22.04 with python3.10 is official supported platform, python3.10 is necessary
  for Ubuntu20.04 and Ubuntu24.04 with python3.12 is experimentally supported.
-- Python packages are upgraded to TensorFlow 2.19.0, ONNX 1.18.0, ONNXRuntime 1.21.1, 
+- Python packages are upgraded to TensorFlow 2.19.0, ONNX 1.18.0, ONNXRuntime 1.21.1,
  Torch 2.7.0.
 
 ## ONE Runtime
@@ -29,19 +29,19 @@
 ### Runtime API Updates
 
 - NNAPI is not official API anymore. It is still supported but used for test purpose only.
-- Model loading from model file without NN package is supported by C/Python APIs. Supporting 
+- Model loading from model file without NN package is supported by C/Python APIs. Supporting
  model types are TFLite, Circle, and TVN.
 - Python API supports training APIs.
 - Python API supports dynamic shapes.
-- Supporting custom BroadcastTo, AddV2, BatchMatMul are deprecated. These custom operations 
+- Supporting custom BroadcastTo, AddV2, BatchMatMul are deprecated. These custom operations
  loading was introduced to support custom operations by compiler but now it is replaced with
  general operations.
 
 ### Runtime Core Updates
 
-- Layout conversion is supported for input and output only. It does not support for 
+- Layout conversion is supported for input and output only. It does not support for
  intermediate tensors.
-- HDF5 dependency on minmax dumper is removed. Now it uses runtime's own tensor dumping 
+- HDF5 dependency on minmax dumper is removed. Now it uses runtime's own tensor dumping
  functions.
 - Block quantization type (GGML_Q4_0, GGML_Q8_0) is supported for quantized models.
 - RMSNorm, RoPE and GELU operations are supported.
@@ -59,7 +59,7 @@
 ### On-device Training Updates
 
 - Memory usage is enhanced during training by usedef analysis and tensor planning.
-- Checkpoint is introduced to export and load tensor and optimizer data, making it 
+- Checkpoint is introduced to export and load tensor and optimizer data, making it
  easier to save and restore training states.
 
 ### On-device Compilation Updates

--- a/docs/release/1.7/release-note-1.7.0.md
+++ b/docs/release/1.7/release-note-1.7.0.md
@@ -8,7 +8,7 @@
   - Runtime CPU backend supports more quant8 operations
   - API changes
   - New optimization
-  
+
 ## ONE Compiler
 
 ### Compiler supports more operations
@@ -42,5 +42,5 @@
 - Introduce basic asynchronous execution API
 
 ### New optimization
-    
+
 - Remove dynamic tensor overhead from static models

--- a/docs/release/1.9/release-note-1.9.0.md
+++ b/docs/release/1.9/release-note-1.9.0.md
@@ -12,7 +12,7 @@
 - Experimental requantization from INT8 to UINT8
 - Adding more operator value tests
 - tf2tfliteV2 supports conversion from Keras model, saved model
-- Refactoring for better maintenance long Class codes using visitor patterns 
+- Refactoring for better maintenance long Class codes using visitor patterns
 - Introducing optimization pass that fuses batch normalization with Transposed Convolution.
 
 

--- a/docs/release/onert-micro/0.1/release-note-0.1.0.md
+++ b/docs/release/onert-micro/0.1/release-note-0.1.0.md
@@ -4,9 +4,9 @@ _onert-micro_ is tiny runtime specialized for running NN model in MCU boards. No
 
 ### Supported operations
 
-For MCU board, we support 22 operations as follows : 
+For MCU board, we support 22 operations as follows :
 
-   ADD, FULLY_CONNECTED, CONV_2D, LOGISTIC ,GATHER, EXPAND_DIMS, PACK, RESHAPE, REDUCE_PROD, LESS, MUL, MAX_POOL_2D, CONCATENATION, SHAPE, SLICE, SUB, SPLIT, STRIDED_SLICE, TANH, SOFTMAX, WHILE, UNIDIRECTIONAL_SEQUENCE_LSTM  
+   ADD, FULLY_CONNECTED, CONV_2D, LOGISTIC ,GATHER, EXPAND_DIMS, PACK, RESHAPE, REDUCE_PROD, LESS, MUL, MAX_POOL_2D, CONCATENATION, SHAPE, SLICE, SUB, SPLIT, STRIDED_SLICE, TANH, SOFTMAX, WHILE, UNIDIRECTIONAL_SEQUENCE_LSTM
 
 ### RNN Model
 
@@ -14,20 +14,20 @@ For MCU board, we support 22 operations as follows :
 
 onert-micro supports Keras model with LSTM operations. But, it should be converted to UNIDIRECTIONAL_SEQUENCE_LSTM operation in circle format.
 
-#### GRU 
+#### GRU
 
-onert-micro supports model with GRU Operations, which is converted from Keras Model. Please refer to https://github.com/Samsung/ONE/issues/10465 to see GRU operation supported by onert-micro. 
+onert-micro supports model with GRU Operations, which is converted from Keras Model. Please refer to https://github.com/Samsung/ONE/issues/10465 to see GRU operation supported by onert-micro.
 
 ### Benchmark
 
 onert-micro shows better performance than tflite-micro especially in memory consumption, binary size.
 
-The measurement is done on TizenRT running reference models on the development board with the following spec : 
+The measurement is done on TizenRT running reference models on the development board with the following spec :
 
 - 32-bit Arm Cortex-M33 200MHz
 - 4MB RAM, 8MB Flash
 
-Commit for measurement : 
+Commit for measurement :
 - tflite-micro commit: https://github.com/tensorflow/tflite-micro/commit/4e62ea7b821c1e6af004912132395fb81922ea8d
 
 - onert-micro commit: https://github.com/Samsung/ONE/commit/c763867500fe3d80bfd1ef834990d34a81640d17
@@ -43,16 +43,16 @@ Commit for measurement :
 #### T1 model
 
 Params | Tflite micro | Onert-micro |
---- | --- | --- 
-Execution time(us)* | **1 340** | 1 510 | 
+--- | --- | ---
+Execution time(us)* | **1 340** | 1 510 |
 RAM consumption(bytes) | 1 640 | **1 152** |
 Binary file size overhead (bytes) | 35 040 | **19 432** |
 
 #### T2 model
 
 Params | Tflite micro** | Onert-micro |
---- | --- | --- 
-Execution time(us)* | N/A | 5 090 | 
+--- | --- | ---
+Execution time(us)* | N/A | 5 090 |
 RAM consumption(bytes) | N/A | 3 360 |
 Binary file size overhead (bytes) | N/A | 30 488 |
 
@@ -61,8 +61,8 @@ Binary file size overhead (bytes) | N/A | 30 488 |
 - model link : https://github.com/Samsung/ONE/files/8368702/gru.zip
 
 Params | Tflite micro** | Onert-micro |
---- | --- | --- 
-Execution time(us)* | N/A | 335 000 | 
+--- | --- | ---
+Execution time(us)* | N/A | 335 000 |
 RAM consumption(bytes) | N/A | 14 816 |
 Binary file size overhead (bytes) | N/A | 43 444 |
 

--- a/docs/release/onert-micro/1.0/release-note-1.0.0.md
+++ b/docs/release/onert-micro/1.0/release-note-1.0.0.md
@@ -2,7 +2,7 @@
 
 ### Supported operations
 
-More operations are supported as follows: 
+More operations are supported as follows:
 
 - AveragePool2D, Elu, Exp, Abs, Neg, Div, AddN, Relu, Relu6, Leak_Relu, Pad, PadV2, ArgMin, ArgMax, Resize_Bilinear, LogicalAnd, LogicalOr, Equal, NotEqual, Greater, GreaterEqual, LessEqual
 

--- a/docs/release/onert-micro/2.0/release-note-2.0.0-pre.md
+++ b/docs/release/onert-micro/2.0/release-note-2.0.0-pre.md
@@ -1,4 +1,4 @@
-## Release Notes for onert-micro 2.0.0-pre 
+## Release Notes for onert-micro 2.0.0-pre
 
 ### Overall Structure Refactored
 


### PR DESCRIPTION
This commit removes trailing whitespace from all files in docs directory and README.md.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>