### PR TITLE
[onert-micro] Trim trailing whitespace

### DIFF
--- a/onert-micro/README.md
+++ b/onert-micro/README.md
@@ -52,13 +52,13 @@ Please refer to `tflite2circle` tool(https://github.com/Samsung/ONE/tree/master/
 
 ### Convert to c array model
 
-Many MCU platforms are lack of file system support. The proper way to provide a model to onert-micro is to convert it into c array so that it can be compiled into MCU binary. 
+Many MCU platforms are lack of file system support. The proper way to provide a model to onert-micro is to convert it into c array so that it can be compiled into MCU binary.
 
 ``` bash
 xxi -i model.circle > model.h
 ```
 
-Then, model.h looks like this: 
+Then, model.h looks like this:
 
 ``` cpp
 unsigned char model_circle[] = {
@@ -72,7 +72,7 @@ unsigned int model_circle_len = 1004;
 
 Once you have c array model, you are ready to use onert-micro.
 
-To run a model with onert-micro, follow the instruction: 
+To run a model with onert-micro, follow the instruction:
 
 1. Include onert-micro header
 
@@ -125,4 +125,4 @@ onert-micro provides compile flags to generate reduced-size binary.
 - `DIS_DYN_SHAPES` : Flag for Disabling Dynamic Shape Support
 
 Also, you can build onert-micro library only with kernels in target models.
-For this, please remove all the kernels from [KernelsToBuild.lst](./luci-interpreter/pal/mcu/KernelsToBuild.lst) except kernels in your target model. 
+For this, please remove all the kernels from [KernelsToBuild.lst](./luci-interpreter/pal/mcu/KernelsToBuild.lst) except kernels in your target model.

--- a/onert-micro/externals/flatbuffers/stl_emulation.h
+++ b/onert-micro/externals/flatbuffers/stl_emulation.h
@@ -320,7 +320,7 @@ namespace internal {
     SpanIterator(pointer ptr) : ptr_(ptr) {}
     reference operator*() const { return *ptr_; }
     pointer operator->() { return ptr_; }
-    SpanIterator& operator++() { ptr_++; return *this; }  
+    SpanIterator& operator++() { ptr_++; return *this; }
     SpanIterator  operator++(int) { auto tmp = *this; ++(*this); return tmp; }
 
     friend bool operator== (const SpanIterator& lhs, const SpanIterator& rhs) { return lhs.ptr_ == rhs.ptr_; }

--- a/onert-micro/luci-interpreter/README.md
+++ b/onert-micro/luci-interpreter/README.md
@@ -22,12 +22,12 @@ Interpreter object is reusable and can run multiple inferences.
 Elements in tensors (input/output/internal) are stored contiguously and have C-like layout:
 This means for tensor t=[[0, 1],[2, 3]], t[0,1] == 1.
 
-Input and output tensors have the same indexes as in original luci model. 
+Input and output tensors have the same indexes as in original luci model.
 
 **Usage example:**
 ``` c++
 // Note getTensorSize is a function that computes tensor size,
-// it is not part of interpreter and should be implemented by user 
+// it is not part of interpreter and should be implemented by user
 
 luci_interpreter::Interpreter interpreter(luci_module);
 
@@ -107,7 +107,7 @@ This is done by `MemoryManger` interface, see `luci-interpreter/include/luci_int
 This header contains `IMemoryManager` abstract class which is responsible for allocation and dealocation of tensors' memory.
 
 User can construct an interpreter with one of predefined memory managers or their own custom memory manager.
-Note that one memory manager could be shared between multiple interpreter instances, because an interpreter does not own the manager object. 
+Note that one memory manager could be shared between multiple interpreter instances, because an interpreter does not own the manager object.
 
 List of predefined memory managers:
 - `SimpleMemoryManager` This is a simple wrapper around new/delete, default one.

--- a/onert-micro/onert-micro/include/core/OMQuantizationData.h
+++ b/onert-micro/onert-micro/include/core/OMQuantizationData.h
@@ -54,7 +54,7 @@ public:
     assert(tensor->quantization() != nullptr);
 
     _params = tensor->quantization();
-    
+
     if (Scales().Length() > 1)
     {
       _type = CWQ;

--- a/onert-micro/onert-micro/include/test_models/logical_and/BoolLogicalAndKernel.h
+++ b/onert-micro/onert-micro/include/test_models/logical_and/BoolLogicalAndKernel.h
@@ -101,7 +101,7 @@ public:
     _reference_output_data = logical_and_bool::reference_output_data;
     _test_kernel_model_circle = logical_and_bool::test_kernel_model_circle;
   }
-  
+
   ~TestDataBoolLogicalAnd() override = default;
 };
 

--- a/onert-micro/onert-micro/include/test_models/logical_not/BoolLogicalNotKernel.h
+++ b/onert-micro/onert-micro/include/test_models/logical_not/BoolLogicalNotKernel.h
@@ -87,7 +87,7 @@ public:
     _reference_output_data = logical_not_bool::reference_output_data;
     _test_kernel_model_circle = logical_not_bool::test_kernel_model_circle;
   }
-  
+
   ~TestDataBoolLogicalNot() override = default;
 };
 

--- a/onert-micro/onert-micro/include/test_models/logical_or/BoolLogicalOrKernel.h
+++ b/onert-micro/onert-micro/include/test_models/logical_or/BoolLogicalOrKernel.h
@@ -101,7 +101,7 @@ public:
     _reference_output_data = logical_or_bool::reference_output_data;
     _test_kernel_model_circle = logical_or_bool::test_kernel_model_circle;
   }
-  
+
   ~TestDataBoolLogicalOr() override = default;
 };
 

--- a/onert-micro/remove_stablehlo_from_cir0.8.patch
+++ b/onert-micro/remove_stablehlo_from_cir0.8.patch
@@ -54,11 +54,11 @@ index 460fa43ee1..be67c3f83c 100644
 -  REDUCE_WINDOW = 205,
  }
  // LINT.ThenChange(nnapi_linter/linter.proto)
- 
+
 @@ -625,187 +579,8 @@ union BuiltinOptions {
    InstanceNormOptions = 254,
  }
- 
+
 -union BuiltinOptions2{
 -  StablehloConcatenateOptions,
 -  StablehloBroadcastInDimOptions,
@@ -242,7 +242,7 @@ index 460fa43ee1..be67c3f83c 100644
 -}
 +//union BuiltinOptions2{
 +//}
- 
+
  // LINT.IfChange
  enum Padding : byte { SAME, VALID }
 @@ -1582,7 +1357,7 @@ table Operator {
@@ -252,5 +252,5 @@ index 460fa43ee1..be67c3f83c 100644
 -  builtin_options_2 : BuiltinOptions2;
 +  //builtin_options_2 : BuiltinOptions2;
  }
- 
+
  // The root type, defining a subgraph, which typically represents an entire


### PR DESCRIPTION
This commit removes trailing whitespace from all files in onert-micro directory.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>