### PR TITLE
[infra] Enable trailing whitespace check in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@ repos:
         id: end-of-file-fixer
         # exclude .svg files
         exclude: \.(svg)$
-      # - name: 'Check trailing whitespace'
-      #   id: trailing-whitespace
+      - name: 'Check trailing whitespace'
+        id: trailing-whitespace
       # TODO add shebang to all excutable python/shell scripts
       - name: 'Check executable files'
         id: check-executables-have-shebangs


### PR DESCRIPTION
This commit uncomments the trailing whitespace check hook in pre-commit configuration

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #16295