### PR TITLE
[infra] Install ubuntu gcc-arm-non-eabi

### DIFF
--- a/.github/workflows/run-onert-micro-unit-tests.yml
+++ b/.github/workflows/run-onert-micro-unit-tests.yml
@@ -39,9 +39,11 @@ jobs:
 
     steps:
       - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
-        with:
-          release: '12.2.Rel1' # <-- The compiler release to use
+        # Not working now
+        # uses: carlosperate/arm-none-eabi-gcc-action@v1
+        #   release: '12.2.Rel1' # <-- The compiler release to use
+        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This commit updates run-onert-micro-unit-tests workflow to install ubuntu gcc-arm-non-eabi.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>