### PR TITLE
[onert] Support multiple Trix models in Bulk operation

### DIFF
--- a/runtime/onert/backend/trix/KernelGenerator.cc
+++ b/runtime/onert/backend/trix/KernelGenerator.cc
@@ -66,11 +66,18 @@ void KernelGenerator::visit(const ir::operation::Bulk &node)
   // parameters
   const auto &binary_path = node.param().binary_path;
 
-  auto fn = std::make_unique<ops::BulkLayer>();
-
-  fn->configure(input_tensors, output_tensors, binary_path, _dev_context);
-
-  _return_fn = std::move(fn);
+  if (binary_path.size() == 1)
+  {
+    // For single model execution
+    auto fn = std::make_unique<ops::BulkLayer>();
+    fn->configure(input_tensors, output_tensors, binary_path.front(), _dev_context);
+    _return_fn = std::move(fn);
+  }
+  else
+  {
+    // TODO: Implement multiple model execution
+    throw std::runtime_error("NYI: multiple model execution");
+  }
 }
 
 } // namespace onert::backend::trix

--- a/runtime/onert/core/include/ir/operation/Bulk.h
+++ b/runtime/onert/core/include/ir/operation/Bulk.h
@@ -27,7 +27,7 @@ class Bulk : public Operation
 public:
   struct Param
   {
-    std::string binary_path;
+    std::vector<std::string> binary_path;
     std::vector<ir::Shape> origin_input_shapes;
     std::vector<ir::Shape> origin_output_shapes;
   };

--- a/runtime/onert/core/src/ir/train/operation/UntrainableOperation.test.cc
+++ b/runtime/onert/core/src/ir/train/operation/UntrainableOperation.test.cc
@@ -85,7 +85,7 @@ operation::BroadcastTo generateBroadcastTo()
 operation::Bulk generateBulk()
 {
   operation::Bulk::Param param;
-  param.binary_path = "";
+  param.binary_path = {};
   param.origin_input_shapes = std::vector<onert::ir::Shape>{};
   param.origin_output_shapes = std::vector<onert::ir::Shape>{};
 

--- a/runtime/onert/core/src/loader/CircleLoader.cc
+++ b/runtime/onert/core/src/loader/CircleLoader.cc
@@ -337,7 +337,9 @@ void CircleLoader::loadRunModel(const Operator *op, ir::Graph &subg)
   auto model_base_path = std::filesystem::path(_file_path).parent_path();
   auto *options = op->builtin_options_as_RunModelOptions();
   auto location = options->location()->str();
-  auto model_path = model_base_path / location;
+  // Multiple files can be specified as ';' separated string
+  auto model_path = (location.find(';') == std::string::npos) ? model_base_path / location
+                                                              : std::filesystem::path(location);
   auto extension_path = model_path.extension();
   if (extension_path.empty())
   {


### PR DESCRIPTION
This commit revises TrixLoader and Bulk op to support multiple models.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>

---

- Related : #16280 
- Draft : #16281