### PR TITLE
[onert] Add shebang to all Python script and set 0755 mode

### DIFF
--- a/runtime/onert/sample/minimal-python/dynamic_shape_inference.py
+++ b/runtime/onert/sample/minimal-python/dynamic_shape_inference.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import numpy as np
 import random
 import sys

--- a/runtime/onert/sample/minimal-python/experimental/src/train_step_with_dataset.py
+++ b/runtime/onert/sample/minimal-python/experimental/src/train_step_with_dataset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 from onert.experimental.train import session, DataLoader, optimizer, losses, metrics
 

--- a/runtime/onert/sample/minimal-python/experimental/src/train_with_dataset.py
+++ b/runtime/onert/sample/minimal-python/experimental/src/train_with_dataset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 from onert.experimental.train import session, DataLoader, optimizer, losses, metrics
 

--- a/runtime/onert/sample/minimal-python/inference_benchmark.py
+++ b/runtime/onert/sample/minimal-python/inference_benchmark.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import numpy as np
 import psutil

--- a/runtime/onert/sample/minimal-python/minimal.py
+++ b/runtime/onert/sample/minimal-python/minimal.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from onert import infer
 import numpy as np
 import sys

--- a/runtime/tests/nnapi/nnapi_test_generator/android-10/vts_generator.py
+++ b/runtime/tests/nnapi/nnapi_test_generator/android-10/vts_generator.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python3
-
+#!/usr/bin/env python3
+#
 # Copyright 2017, The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This commit makes Python scripts executable, so it will be possible to run them without python3 prefixing on the command line.

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>