### PR TITLE
[onert] Fix Python typing for the benchmark_inference() function

### DIFF
--- a/runtime/onert/sample/minimal-python/inference_benchmark.py
+++ b/runtime/onert/sample/minimal-python/inference_benchmark.py
@@ -4,7 +4,7 @@ import argparse
 import numpy as np
 import psutil
 import os
-from typing import List
+from typing import List, Optional
 from onert import infer, tensorinfo
 
 
@@ -47,8 +47,8 @@ def get_validated_input_tensorinfos(sess: infer.session,
     return updated_infos
 
 
-def benchmark_inference(nnpackage_path: str, backends: str, input_shapes: List[List[int]],
-                        repeat: int):
+def benchmark_inference(nnpackage_path: str, backends: str,
+                        input_shapes: Optional[List[List[int]]], repeat: int):
     mem_before_kb = get_memory_usage_mb() * 1024
 
     sess = infer.session(path=nnpackage_path, backends=backends)


### PR DESCRIPTION
This commits fixes the typing by allowing passing None as a value for the `input_shapes` parameter in the `benchmark_inference()` function. In case of `input_shapes` being `None`, the function uses the shape retrieved from the initialized session.

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>