### PR TITLE
[luci-value-test] Add tolerance for Mean_U8_000 test

### DIFF
--- a/compiler/luci-value-test/test.lst
+++ b/compiler/luci-value-test/test.lst
@@ -90,7 +90,7 @@ addeval(MaxPool2D_000)
 addeval(MaxPool2D_U8_000)
 addeval(Mean_000)
 addeval(Mean_001)
-addeval(Mean_U8_000)
+#addeval(Mean_U8_000) --> test with tolerance
 addeval(Minimum_000)
 #addeval(MirrorPad_000)
 addeval(Mul_000)
@@ -207,3 +207,4 @@ addevaltol(SVDF_001 8e-3 8e-3)
 addevaltol(Conv2D_U8_000 5 5)
 # refer https://github.com/Samsung/ONE/issues/10438
 addevaltol(YUV_TO_RGB_U8_000 1 1)
+addevaltol(Mean_U8_000 8e-3 1)


### PR DESCRIPTION
This commit adds Mean_U8_000 to tolerance-based evaluation with 1 absolute tolerance to handle precision issues in uint8 operations.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>