### PR TITLE
[circle-schema] Add MX dtype restrictions comment

### DIFF
--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -87,6 +87,13 @@ enum TensorType : byte {
   GGML_Q8_1 = -5,
 
   // MX dtypes
+  // Current restrictions of MX dtypes
+  // - MX dtypes are not used for model I/O
+  // - MX dtypes are used for activations, not for constant inputs (ex. weight)
+  // - MX dtype's parameters (block size, exponent scale, etc) follows
+  //   OCP Microscaling Formats Specification
+  // - Model does not have exponent scale data.
+  //   Backend should define and use internally if needed
   MXFP4 = -6,
   MXINT8 = -7,
 }

--- a/res/CircleSchema/0.10/circle_schema.fbs
+++ b/res/CircleSchema/0.10/circle_schema.fbs
@@ -87,6 +87,13 @@ enum TensorType : byte {
   GGML_Q8_1 = -5,
 
   // MX dtypes
+  // Current restrictions of MX dtypes
+  // - MX dtypes are not used for model I/O
+  // - MX dtypes are used for activations, not for constant inputs (ex. weight)
+  // - MX dtype's parameters (block size, exponent scale, etc) follows
+  //   OCP Microscaling Formats Specification
+  // - Model does not have exponent scale data.
+  //   Backend should define and use internally if needed
   MXFP4 = -6,
   MXINT8 = -7,
 }

--- a/runtime/libs/circle-schema/circle_schema.fbs
+++ b/runtime/libs/circle-schema/circle_schema.fbs
@@ -87,6 +87,13 @@ enum TensorType : byte {
   GGML_Q8_1 = -5,
 
   // MX dtypes
+  // Current restrictions of MX dtypes
+  // - MX dtypes are not used for model I/O
+  // - MX dtypes are used for activations, not for constant inputs (ex. weight)
+  // - MX dtype's parameters (block size, exponent scale, etc) follows
+  //   OCP Microscaling Formats Specification
+  // - Model does not have exponent scale data.
+  //   Backend should define and use internally if needed
   MXFP4 = -6,
   MXINT8 = -7,
 }


### PR DESCRIPTION
This commit adds comprehensive comments documenting current restrictions for MX dtypes (MXFP4, MXINT8) in the circle schema.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>