### PR TITLE
[onert] Implement buffer sharing optimization for BulkPipeline

### DIFF
--- a/runtime/onert/backend/trix/ops/BulkPipelineLayer.cc
+++ b/runtime/onert/backend/trix/ops/BulkPipelineLayer.cc
@@ -42,7 +42,8 @@ void BulkPipelineLayer::configure(const std::vector<const IPortableTensor *> &in
   // Configure BulkPipeLineManager
   BulkPipelineManager::PipelineConfig config;
   config.model_paths = binary_path;
-  config.device_id = 0; // default device id = 0
+  config.device_id = 0;      // default device id = 0
+  config.n_owner_models = 2; // Use 2 owner models for buffer sharing
 
   _pipeline_manager = std::make_unique<BulkPipelineManager>(config);
 

--- a/runtime/onert/backend/trix/ops/BulkPipelineManager.h
+++ b/runtime/onert/backend/trix/ops/BulkPipelineManager.h
@@ -37,6 +37,7 @@ public:
   {
     std::vector<std::string> model_paths;
     int device_id{0};
+    int n_owner_models{2}; // number of models that share the buffers
   };
 
 public:
@@ -56,11 +57,13 @@ public:
 
 private:
   void createModels();
+  void linkModels();
   void prepareModels();
 
 private:
   PipelineConfig _config;
   std::atomic<bool> _initialized{false};
+  std::atomic<bool> _use_buffer_sharing;
   std::atomic<bool> _executing{false};
 
   std::vector<std::shared_ptr<BulkPipelineModel>> _models;


### PR DESCRIPTION
This commit adds buffer sharing mechanism to reduce memory usage in bulk pipeline execution.
Link models for async buffer preparation and optimize execution performance when models have identical program and weight sizes.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>

---

- #16280
- #16281 