### PR TITLE
[infra] Add copyright header check to pre-commit hooks

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Fetch all history and branch (default: 1)
+          # Require all history to get file creation date
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -32,19 +36,3 @@ jobs:
       - name: Check format all files
         run: |
           uv run pre-commit run -a
-
-  check-copyright:
-    name: Check copyright
-    runs-on: ubuntu-22.04
-    if: github.repository_owner == 'Samsung'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # Fetch all history and branch (default: 1)
-          # Require all history to get file creation date
-          fetch-depth: 0
-
-      - name: Check copyright
-        run: ./nnas copyright-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,11 @@ repos:
       id: clang-format
       types_or: [file]  # override default type check to cl files
       files: ((\.c[cl]?)|(\.cpp)|(\.h(pp)?))$
+
+  - repo: local
+    hooks:
+      - name: 'Check copyright headers'
+        id: copyright-check
+        entry: 'nnas copyright-check' # Use trick to use nnas command
+        language: script
+        pass_filenames: false


### PR DESCRIPTION
This commit adds a new local pre-commit hook to check for copyright headers in source files. 
The hook uses the 'nnas copyright-check' command and runs as a script, ensuring all files have proper copyright notices.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>