### PR TITLE
[circle-mlir] Add test models for GatherOp pass

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/test.lst
@@ -68,8 +68,10 @@ AddModel(Flatten_F32_R4_0)
 AddModel(Flatten_F32_R4_1)
 AddModel(Floor_F32_R4)
 AddModel(Gather_F32_R2)
+# AddModel(Gather_F32_R2_2) # Need to enable after int32 indices type support
 AddModel(Gather_F32_R2_C1)
 AddModel(Gather_F32_R2_C1_2)
+# AddModel(Gather_F32_R2_C1_3) # Need to enable after int32 indices type support
 AddModel(Gemm_F32_R2)
 AddModel(Gemm_F32_R2_a0b1)
 AddModel(Gemm_F32_R2_a1b0)

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-models/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-models/test.lst
@@ -70,8 +70,10 @@ AddModel(Flatten_F32_R4_0)
 AddModel(Flatten_F32_R4_1)
 AddModel(Floor_F32_R4)
 AddModel(Gather_F32_R2)
+# AddModel(Gather_F32_R2_2) # Need to enable after int32 indices type support
 AddModel(Gather_F32_R2_C1)
 AddModel(Gather_F32_R2_C1_2)
+# AddModel(Gather_F32_R2_C1_3) # Need to enable after int32 indices type support
 AddModel(Gemm_F32_R2)
 AddModel(Gemm_F32_R2_a0b1)
 AddModel(Gemm_F32_R2_a1b0)

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/test.lst
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/test.lst
@@ -70,8 +70,10 @@ AddModel(Flatten_F32_R4_0)
 AddModel(Flatten_F32_R4_1)
 AddModel(Floor_F32_R4)
 AddModel(Gather_F32_R2)
+# AddModel(Gather_F32_R2_2) # Need to enable after int32 indices type support
 AddModel(Gather_F32_R2_C1)
 AddModel(Gather_F32_R2_C1_2)
+# AddModel(Gather_F32_R2_C1_3) # Need to enable after int32 indices type support
 AddModel(Gemm_F32_R2)
 AddModel(Gemm_F32_R2_a0b1)
 AddModel(Gemm_F32_R2_a1b0)

--- a/circle-mlir/models/unit/Gather_F32_R2_2/__init__.py
+++ b/circle-mlir/models/unit/Gather_F32_R2_2/__init__.py
@@ -1,0 +1,23 @@
+import torch
+import numpy as np
+
+
+# Generate Gather operator with Float32, Rank-2, no constant inputs
+class net_Gather(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input0, input1):
+        return input0[input1]
+
+    def onnx_opset_version(self):
+        # TODO set to appropriate value
+        return 14
+
+
+_model_ = net_Gather()
+
+# NOTE onnx2circle-value-test's exec_onnx.py generates random int32 into the range [0, 100).
+#      Let's use the same range for this test to prevent index values out of data bounds.
+rand = np.random.randint(0, 100, size=(3, 9), dtype=np.int32)
+_inputs_ = (torch.randn(100, 9), torch.from_numpy(rand))

--- a/circle-mlir/models/unit/Gather_F32_R2_C1_3/__init__.py
+++ b/circle-mlir/models/unit/Gather_F32_R2_C1_3/__init__.py
@@ -1,0 +1,22 @@
+import torch
+import numpy as np
+
+
+# Generate Gather operator with Float32, Rank-2, constant int32 type of index
+class net_Gather(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        rand = np.random.randint(0, 9, size=(3, 9), dtype=np.int32)
+        self.index = torch.from_numpy(rand)
+
+    def forward(self, input):
+        return input[self.index]
+
+    def onnx_opset_version(self):
+        # TODO set to appropriate value
+        return 14
+
+
+_model_ = net_Gather()
+
+_inputs_ = torch.randn(9, 9)


### PR DESCRIPTION
This adds test models to cover int32 indices in the GatherOp pass.
These tests will be enabled after the related pass is updated.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>