### PR TITLE
[circle-mlir] Support int32 type in exec_onnx.py

### DIFF
--- a/circle-mlir/circle-mlir/tools-test/circle-impexp-test/exec_onnx.py
+++ b/circle-mlir/circle-mlir/tools-test/circle-impexp-test/exec_onnx.py
@@ -14,6 +14,8 @@ import util_h5_file
 def get_np_type(onnx_type):
     if onnx_type == 'tensor(float)':
         return np.float32
+    if onnx_type == 'tensor(int32)':
+        return np.int32
     if onnx_type == 'tensor(int64)':
         return np.int64
     if onnx_type == 'tensor(bool)':
@@ -70,6 +72,8 @@ def exec_model(filepath, is_nchw=False):
             random_data = np.random.random(inputs[i].shape).astype(np_type)
         elif np_type == np.uint8:
             random_data = np.random.randint(0, 256, size=inputs[i].shape).astype(np_type)
+        elif np_type == np.int32:
+            random_data = np.random.randint(0, 100, size=inputs[i].shape).astype(np_type)
         elif np_type == np.int64:
             random_data = np.random.randint(0, 100, size=inputs[i].shape).astype(np_type)
         elif np_type == np.bool_:

--- a/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/exec_onnx.py
+++ b/circle-mlir/circle-mlir/tools-test/onnx2circle-value-test/exec_onnx.py
@@ -16,6 +16,8 @@ import util_h5_file
 def get_np_type(onnx_type):
     if onnx_type == 'tensor(float)':
         return np.float32
+    if onnx_type == 'tensor(int32)':
+        return np.int32
     if onnx_type == 'tensor(int64)':
         return np.int64
     if onnx_type == 'tensor(bool)':
@@ -91,6 +93,10 @@ def exec_model(filepath, is_nchw=False):
             random_data = np.random.random(inputs[i].shape).astype(np_type)
         elif np_type == np.uint8:
             random_data = np.random.randint(0, 256, size=inputs[i].shape).astype(np_type)
+        elif np_type == np.int32:
+            low, high = get_input_limit(onnx_model.graph.input[i], 0, 100)
+            random_data = np.random.randint(low, high,
+                                            size=inputs[i].shape).astype(np_type)
         elif np_type == np.int64:
             low, high = get_input_limit(onnx_model.graph.input[i], 0, 100)
             random_data = np.random.randint(low, high,


### PR DESCRIPTION
This revises the `exec_opnnx.py` to support the `int32` type for circle-mlir tests.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>