### PR TITLE
[circle-mlir/infra] Update changelog for onnx2circle

### DIFF
--- a/circle-mlir/infra/debian/onnx2circle/changelog
+++ b/circle-mlir/infra/debian/onnx2circle/changelog
@@ -1,3 +1,9 @@
+onnx2circle (0.4.1~jammy) jammy; urgency=medium
+
+  * Fix GatherOp to accept both int32/int64 types
+
+ -- On-device AI developers <nnfw@samsung.com>  Wed, 28 Jan 2026 10:59:35 +0000
+
 onnx2circle (0.4.0~202507100754~jammy) jammy; urgency=medium
 
   * Supprot folding of SplitOp


### PR DESCRIPTION
This updates the changelog for onnx2circle_0.4.1.
This PR includes updated changelog after successful debian build.
It is auto-generated PR from github workflow.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>