### PR TITLE
[onert] Remove unused threads member missed in e5ba20d

### DIFF
--- a/runtime/onert/api/nnfw/src/Session.h
+++ b/runtime/onert/api/nnfw/src/Session.h
@@ -33,7 +33,6 @@
 #include <filesystem>
 #include <memory>
 #include <string>
-#include <thread>
 #include <vector>
 
 namespace onert::api
@@ -221,7 +220,6 @@ private:
   std::unique_ptr<onert::compiler::CompilerArtifact> _compiler_artifact;
   std::unique_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;
-  std::vector<std::thread> _threads;
   std::unique_ptr<onert::ir::train::TrainingInfo> _train_info;
   std::unique_ptr<onert::odc::QuantizeManager> _quant_manager;
   std::unique_ptr<onert::odc::CodegenManager> _codegen_manager;


### PR DESCRIPTION
Commit e5ba20d removed deprecated pipeline API, but it left the Session::_threads member.

ONE-DCO-1.0-Signed-off-by: Arkadiusz Bokowy <a.bokowy@samsung.com>