### PR TITLE
[circle-mlir/pass] Revise definition name in ReduceSumOp

### DIFF
--- a/circle-mlir/circle-mlir/lib/pass/src/ops/ReduceSumOp.h
+++ b/circle-mlir/circle-mlir/lib/pass/src/ops/ReduceSumOp.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __CIRCLE_MLIR_PASS_OPS_SUM_OP_H__
-#define __CIRCLE_MLIR_PASS_OPS_SUM_OP_H__
+#ifndef __CIRCLE_MLIR_PASS_OPS_REDUCE_SUM_OP_H__
+#define __CIRCLE_MLIR_PASS_OPS_REDUCE_SUM_OP_H__
 
 #include <circle-mlir/dialect/CircleDialect.h>
 
@@ -179,4 +179,4 @@ private:
 } // namespace Circle
 } // namespace mlir
 
-#endif // __CIRCLE_MLIR_PASS_OPS_SUM_OP_H__
+#endif // __CIRCLE_MLIR_PASS_OPS_REDUCE_SUM_OP_H__


### PR DESCRIPTION
This updates the definition name in the `ReduceSumOp.h` header to match the operation name.