### PR TITLE
[onert] Ensure proper pipeline cleanup on exceptions and shutdown

### DIFF
--- a/runtime/onert/backend/trix/ops/BulkPipelineLayer.cc
+++ b/runtime/onert/backend/trix/ops/BulkPipelineLayer.cc
@@ -61,6 +61,7 @@ void BulkPipelineLayer::run()
   }
   catch (const std::exception &e)
   {
+    _pipeline_manager->shutdown();
     std::cerr << "BulkPipelineLayer execution failed: " << e.what() << std::endl;
     throw;
   }

--- a/runtime/onert/backend/trix/ops/BulkPipelineManager.cc
+++ b/runtime/onert/backend/trix/ops/BulkPipelineManager.cc
@@ -59,11 +59,6 @@ bool BulkPipelineManager::initialize()
 
 void BulkPipelineManager::shutdown()
 {
-  if (!_initialized.load())
-  {
-    return;
-  }
-
   _initialized = false;
 
   // Wait until all executions are finished

--- a/runtime/onert/backend/trix/ops/BulkPipelineModel.cc
+++ b/runtime/onert/backend/trix/ops/BulkPipelineModel.cc
@@ -79,11 +79,6 @@ bool BulkPipelineModel::prepare()
 
 void BulkPipelineModel::release()
 {
-  if (!_prepared.load())
-  {
-    return;
-  }
-
   // Cancel a asynchronous job
   if (_async_fill_future.valid())
   {

--- a/runtime/onert/backend/trix/ops/test/BulkPipelineManager.test.cc
+++ b/runtime/onert/backend/trix/ops/test/BulkPipelineManager.test.cc
@@ -61,6 +61,7 @@ protected:
   void TearDown() override {}
 
   std::unique_ptr<BulkPipelineManager> manager;
+  const int nr_models = 1;
 };
 
 TEST_F(BulkPipelineManagerTest, test_initilize)
@@ -71,9 +72,17 @@ TEST_F(BulkPipelineManagerTest, test_initilize)
 
 TEST_F(BulkPipelineManagerTest, test_shutdown)
 {
+  int nr_fclose_calls = 0;
   EXPECT_TRUE(manager->initialize());
+  // This hook will checking the number of fclose() calls
+  MockSyscallsManager::getInstance().setFcloseHook([&nr_fclose_calls](FILE *) -> int {
+    nr_fclose_calls++;
+    return 0;
+  });
   manager->shutdown();
   EXPECT_FALSE(manager->isInitialized());
+  // fclose() should be called as the same number of models
+  EXPECT_EQ(nr_fclose_calls, nr_models);
 }
 
 TEST_F(BulkPipelineManagerTest, test_execute)


### PR DESCRIPTION
These changes ensure that pipeline resources are properly released even in error scenarios or when the pipeline was not fully initialized, preventing potential resource leaks.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>