### PR TITLE
[circle-mlir] Update onnx2circle version - 0.4.2

### DIFF
--- a/circle-mlir/circle-mlir/tools/onnx2circle/src/onnx2circle.cpp
+++ b/circle-mlir/circle-mlir/tools/onnx2circle/src/onnx2circle.cpp
@@ -205,7 +205,7 @@ int convertToCircle(const O2Cparam &param)
 } // namespace onnx2circle
 
 // NOTE sync version number with 'infra/debian/*/changelog' for upgrade
-const char *__version = "0.4.1";
+const char *__version = "0.4.2";
 
 int entry(const O2Cparam &param)
 {


### PR DESCRIPTION
This updates the version of `onnx2circle` to `0.4.2`.
It includes the changes for ReduceSumSquare and Range operations.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>