### PR TITLE
[circle-mlir/infra] Update changelog for onnx2circle

### DIFF
--- a/circle-mlir/infra/debian/onnx2circle/changelog
+++ b/circle-mlir/infra/debian/onnx2circle/changelog
@@ -1,3 +1,9 @@
+onnx2circle (0.4.2~202602230830~jammy) jammy; urgency=medium
+
+  * Introduce ReduceSumSquare and Range operations
+
+ -- On-device AI developers <nnfw@samsung.com>  Mon, 23 Feb 2026 08:40:46 +0000
+
 onnx2circle (0.4.1~jammy) jammy; urgency=medium
 
   * Fix GatherOp to accept both int32/int64 types


### PR DESCRIPTION
This updates the changelog for onnx2circle_0.4.2~202602230830.
This PR includes updated changelog after successful debian build.
It is auto-generated PR from github workflow.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>