### PR TITLE
[onert-micro] Add index bounds checks to fix security vulnerabilities

### DIFF
--- a/onert-micro/onert-micro/include/OMStatus.h
+++ b/onert-micro/onert-micro/include/OMStatus.h
@@ -35,6 +35,7 @@ enum OMStatus
   FailReadWOFFile,
   FailReadCheckpointFile,
   CmsisNNError,
+  IndexError,
 };
 
 } // namespace onert_micro

--- a/onert-micro/onert-micro/include/core/OMRuntimeShape.h
+++ b/onert-micro/onert-micro/include/core/OMRuntimeShape.h
@@ -123,9 +123,13 @@ public:
     if (_size == 0)
       return 0;
 
-    auto it = _dims.cbegin();
-
-    return std::accumulate(it, it + _size, 1u, std::multiplies<size_t>());
+    size_t result = 1;
+    for (size_t i = 0; i < _size; ++i)
+    {
+      if (__builtin_mul_overflow(result, static_cast<size_t>(_dims[i]), &result))
+        return 0;
+    }
+    return result;
   }
 
   // clang-format off

--- a/onert-micro/onert-micro/include/pal/common/PALGatherND.h
+++ b/onert-micro/onert-micro/include/pal/common/PALGatherND.h
@@ -72,6 +72,13 @@ inline OMStatus GatherND(core::OMRuntimeShape params_shape, const ParamsT *param
     {
       int offset = i * indices_nd + j;
       IndicesT index = index_data[offset];
+
+      // Bounds check: index must be non-negative and within dimension size
+      if (index < 0 || index >= params_shape.dims(j))
+      {
+        return IndexError;
+      }
+
       from_pos += index * dims_to_count[j];
     }
     if (from_pos < 0 || from_pos + slice_size > params_flat_size)

--- a/onert-micro/onert-micro/include/pal/common/PALSlice.h
+++ b/onert-micro/onert-micro/include/pal/common/PALSlice.h
@@ -42,6 +42,18 @@ OMStatus Slice(const core::SliceParams &op_params, const core::OMRuntimeShape &i
     stop[i] = (size_count < padded_i || op_params.size[size_count - padded_i] == -1)
                 ? ext_shape.dims(i)
                 : start[i] + op_params.size[size_count - padded_i];
+
+    // Bounds check: start must be non-negative and within dimension size
+    if (start[i] < 0 || start[i] > ext_shape.dims(i))
+    {
+      return IndexError;
+    }
+
+    // Bounds check: stop must be within dimension size and >= start
+    if (stop[i] < start[i] || stop[i] > ext_shape.dims(i))
+    {
+      return IndexError;
+    }
   }
 
   for (int i0 = start[0]; i0 < stop[0]; ++i0)

--- a/onert-micro/onert-micro/src/execute/kernels/Pad.cpp
+++ b/onert-micro/onert-micro/src/execute/kernels/Pad.cpp
@@ -113,6 +113,12 @@ OMStatus execute_kernel_CirclePad(const OMExecuteArgs &execute_args)
   {
     pad_params.left_padding[idx] = paddings_data[idx * 2];
     pad_params.right_padding[idx] = paddings_data[idx * 2 + 1];
+
+    // Bounds check: padding values must be non-negative
+    if (pad_params.left_padding[idx] < 0 || pad_params.right_padding[idx] < 0)
+    {
+      return IndexError;
+    }
   }
 
   switch (input1->type())


### PR DESCRIPTION
- Added IndexError enum and bounds checks in GatherND, Slice, Pad, and dimension product calculation to prevent out-of-bounds accesses and negative indices.

- Fixes security vulnerabilities related to index validation.

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>