### PR TITLE
[github] Fix circle-interpreter publishing workflow

### DIFF
--- a/.github/workflows/pub-circle-int-launchpad.yml
+++ b/.github/workflows/pub-circle-int-launchpad.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           CIR_INTP_ITEMS="angkor;cwrap;pepper-str;pepper-strcast;pepper-csv2vec;pp"
           CIR_INTP_ITEMS="${CIR_INTP_ITEMS};oops;loco;logo-core;logo;locop"
-          CIR_INTP_ITEMS="${CIR_INTP_ITEMS};hermes;hermes-std;safemain;mio-circle08"
+          CIR_INTP_ITEMS="${CIR_INTP_ITEMS};hermes;hermes-std;safemain;mio-circle"
           CIR_INTP_ITEMS="${CIR_INTP_ITEMS};luci-compute;luci;luci-interpreter"
           CIR_INTP_ITEMS="${CIR_INTP_ITEMS};foder;arser;vconone;circle-interpreter"
           echo ${CIR_INTP_ITEMS}


### PR DESCRIPTION
This fixes the `pub-circle-int-launchpad.yml` workflow to use `mio-circle` instead of `mio-circle08`.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>