### PR TITLE
[infra/debian] Update changelog for circle-interpreter

### DIFF
--- a/infra/debian/circle-interpreter/changelog
+++ b/infra/debian/circle-interpreter/changelog
@@ -1,3 +1,9 @@
+circle-interpreter (1.30.1~202602260919~jammy) jammy; urgency=medium
+
+  * Support the Sign operation.
+
+ -- On-device AI developers <nnfw@samsung.com>  Thu, 26 Feb 2026 09:30:53 +0000
+
 circle-interpreter (1.30.0~202506190655~jammy) jammy; urgency=medium
 
   * Enable publish for noble


### PR DESCRIPTION
This updates the changelog for circle-interpreter_1.30.1~202602260919.
This PR includes updated changelog after successful debian build.
It is auto-generated PR from github workflow.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>