### PR TITLE
[CI] Refactore copyright-check script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,4 +65,14 @@ repos:
         id: copyright-check
         entry: 'nnas copyright-check' # Use trick to use nnas command
         language: script
-        pass_filenames: false
+        pass_filenames: true
+        types: [file]
+        files: \.(c[cl]?|cpp|h(pp)?)$
+        # Ignore 3rd-party code
+        exclude:
+          (?x)^(
+            compiler/ann-api/.*|
+            onert-micro/externals/.*|
+            runtime/3rdparty/.*|
+            runtime/tests/nnapi/.*
+          )

--- a/infra/command/copyright-check
+++ b/infra/command/copyright-check
@@ -1,39 +1,21 @@
 #!/bin/bash
 
-INVALID_EXIT=0
+CORRECT_COPYRIGHT="Copyright \(c\) [0-9\-]+ Samsung Electronics Co\., Ltd\. All Rights Reserved"
 
-# Files to check copyright headers
-# TODO Check python files as well
-FILE_PATTERNS=(*.h *.hpp *.cpp *.cc *.c *.cl)
+if [ $# -eq 0 ]; then
+  echo "Please pass file(s) to check copyright"
+  exit 1
+fi
 
-# Manually ignore checking - 3rd party, generated files
-# Pattern should start with ':!' to exclude pattern
-FILE_EXCLUDE_PATTERN=(
-  :!compiler/ann-api
-  :!onert-micro/externals
-  :!runtime/3rdparty
-  :!runtime/tests/nnapi
-)
-
-check_copyright() {
-  CORRECT_COPYRIGHT="Copyright \(c\) [0-9\-]+ Samsung Electronics Co\., Ltd\. All Rights Reserved"
-  FILES_TO_CHECK_COPYRIGHTS=$(git ls-files -c --exclude-standard -- ${FILE_PATTERNS[@]} ${FILE_EXCLUDE_PATTERN[@]})
-
-  if [[ ${#FILES_TO_CHECK_COPYRIGHTS} -ne 0 ]]; then
-    for f in ${FILES_TO_CHECK_COPYRIGHTS[@]}; do
-      if ! grep -qE "$CORRECT_COPYRIGHT" $f; then
-        CREATED_YEAR=$(git log --follow --format=%aD $f | tail -1 | awk '{print $4}')
-        EXAMPLE_COPYRIGHT="Copyright (c) $CREATED_YEAR Samsung Electronics Co., Ltd. All Rights Reserved"
-        echo "Copyright format of $f is incorrect: recommend \"$EXAMPLE_COPYRIGHT\""
-        INVALID_EXIT=1
-      fi
-    done
+for f in "$@"; do
+  if ! grep -qE "$CORRECT_COPYRIGHT" "$f"; then
+    CREATED_YEAR=$(git log --follow --format=%aD "$f" | tail -1 | awk '{print $4}')
+    EXAMPLE_COPYRIGHT="Copyright (c) $CREATED_YEAR Samsung Electronics Co., Ltd. All Rights Reserved"
+    echo "Copyright format of $f is incorrect: recommend \"$EXAMPLE_COPYRIGHT\""
+    INVALID_EXIT=1
   fi
-}
-
-check_copyright
+done
 
 if [[ $INVALID_EXIT -ne 0 ]]; then
-    echo "[FAILED] Invalid copyright check exit."
     exit 1
 fi


### PR DESCRIPTION
This commit refactores copyright-check script to accept files as command-line arguments instead of searching for files internally. 
The pre-commit hook now handles file pattern matching and exclusion logic for C/C++ source files (*.c, *.cc, *.cpp, *.cl, *.h, *.hpp), filtering out 3rd-party code. 
It will reduce commit creation time by removing pre-commit's duplicated copyright check.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>