### PR TITLE
[onnx2circle] Add option to list supported operators

### DIFF
--- a/compiler/mir/include/mir_onnx_importer/ONNXImporterImpl.h
+++ b/compiler/mir/include/mir_onnx_importer/ONNXImporterImpl.h
@@ -21,10 +21,12 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace mir_onnx
 {
 
+std::vector<std::string> getSupportedOperators();
 std::unique_ptr<mir::Graph> importModelFromBinaryFile(const std::string &filename);
 std::unique_ptr<mir::Graph> importModelFromTextFile(const std::string &filename);
 // TODO Remove after changing all uses.

--- a/compiler/mir/src/mir_onnx_importer/ONNXImporterImpl.cpp
+++ b/compiler/mir/src/mir_onnx_importer/ONNXImporterImpl.cpp
@@ -17,6 +17,7 @@
 #include "ONNXImporterImpl.h"
 #include "ONNXHelpers.h"
 #include "ONNXOpRegistration.h"
+#include "ONNXNodeConverterRegistry.h"
 #include "onnx/onnx.pb.h"
 
 #include "mir/Shape.h"
@@ -32,7 +33,9 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace mir_onnx
 {
@@ -45,6 +48,7 @@ class ONNXImporterImpl final
 public:
   ONNXImporterImpl();
   ~ONNXImporterImpl();
+  std::vector<std::string> getSupportedOps() const;
   /// @brief Load the model and convert it into a MIR Graph.
   std::unique_ptr<mir::Graph> importModelFromBinaryFile(const std::string &filename);
   std::unique_ptr<mir::Graph> importModelFromTextFile(const std::string &filename);
@@ -104,6 +108,16 @@ void loadModelFromTextFile(const std::string &filename, onnx::ModelProto *model)
     throw std::runtime_error("Couldn't parse file \"" + filename + "\".");
 }
 
+std::vector<std::string> ONNXImporterImpl::getSupportedOps() const
+{
+  std::vector<std::string> ops;
+  for (const auto &op : NodeConverterRegistry::getInstance().getSupportedOperators())
+  {
+    ops.push_back(op.first + "-" + std::to_string(op.second));
+  }
+  return ops;
+}
+
 std::unique_ptr<mir::Graph> ONNXImporterImpl::importModelFromBinaryFile(const std::string &filename)
 {
   _model = std::make_unique<onnx::ModelProto>();
@@ -124,7 +138,7 @@ std::unique_ptr<mir::Graph> ONNXImporterImpl::importModelFromTextFile(const std:
 
 void ONNXImporterImpl::collectUnsupportedOps()
 {
-  std::set<std::pair<std::string, int64_t>> problems_op_set;
+  std::set<NodeConverterRegistry::Operator> unsupported_ops;
 
   for (int i = 0; i < _model->graph().node_size(); i++)
   {
@@ -134,16 +148,16 @@ void ONNXImporterImpl::collectUnsupportedOps()
     auto opset = _modelCtx->getDomainOpsetVersion(onnx_node.domain());
 
     NodeConverterRegistry::ConverterFunc converter =
-      NodeConverterRegistry::getInstance().lookup(op_type, opset);
+      NodeConverterRegistry::getInstance().lookup({op_type, opset});
 
     if (converter == nullptr)
-      problems_op_set.emplace(op_type, opset);
+      unsupported_ops.emplace(op_type, opset);
   }
-  if (!problems_op_set.empty())
+  if (!unsupported_ops.empty())
   {
     std::cerr << "The following operators are not supported:\n";
-    for (const auto &op : problems_op_set)
-      std::cerr << op.first << " opset " << op.second << std::endl;
+    for (const auto &op : unsupported_ops)
+      std::cerr << op.first << "-" << op.second << std::endl;
     throw std::runtime_error("Unsupported operators found");
   }
 }
@@ -199,7 +213,7 @@ std::unique_ptr<mir::Graph> ONNXImporterImpl::createIR()
     auto opset = _modelCtx->getDomainOpsetVersion(onnx_node.domain());
     // Get converter
     NodeConverterRegistry::ConverterFunc converter =
-      NodeConverterRegistry::getInstance().lookup(op_type, opset);
+      NodeConverterRegistry::getInstance().lookup({op_type, opset});
     assert(converter != nullptr);
     converter(onnx_node, _converterCtx.get());
   }
@@ -219,6 +233,12 @@ std::unique_ptr<mir::Graph> ONNXImporterImpl::createIR()
 }
 
 } // namespace
+
+std::vector<std::string> getSupportedOperators()
+{
+  ONNXImporterImpl importer;
+  return importer.getSupportedOps();
+}
 
 std::unique_ptr<mir::Graph> importModelFromBinaryFile(const std::string &filename)
 {

--- a/compiler/mir/src/mir_onnx_importer/ONNXNodeConverterRegistry.cpp
+++ b/compiler/mir/src/mir_onnx_importer/ONNXNodeConverterRegistry.cpp
@@ -105,10 +105,10 @@ void ConverterContext::setNodeOutputs(const onnx::NodeProto &onnx_node,
 
 // NodeConverterRegistry
 
-NodeConverterRegistry::ConverterFunc NodeConverterRegistry::lookup(const std::string &optype,
-                                                                   int64_t opset) const
+NodeConverterRegistry::ConverterFunc
+NodeConverterRegistry::lookup(const NodeConverterRegistry::Operator &op) const
 {
-  auto it = _converter_map.find(optype);
+  auto it = _converter_map.find(op.first);
   if (it == _converter_map.end())
   {
     return nullptr;
@@ -117,8 +117,8 @@ NodeConverterRegistry::ConverterFunc NodeConverterRegistry::lookup(const std::st
   const VersionMap &conv_map = it->second;
 
   auto res = std::lower_bound(
-    conv_map.crbegin(), conv_map.crend(), opset,
-    [](const VersionMap::value_type &pair, int64_t opset) { return pair.first > opset; });
+    conv_map.crbegin(), conv_map.crend(), op.second,
+    [](const VersionMap::value_type &pair, unsigned int opset) { return pair.first > opset; });
 
   if (res == conv_map.crend())
   {
@@ -133,10 +133,34 @@ NodeConverterRegistry &NodeConverterRegistry::getInstance()
   return instance;
 }
 
-void NodeConverterRegistry::registerConverter(const std::string &op_type, int64_t opset,
+void NodeConverterRegistry::registerConverter(const NodeConverterRegistry::Operator &op,
                                               NodeConverterRegistry::ConverterFunc conv)
 {
-  _converter_map[op_type].emplace(opset, conv);
+  _converter_map[op.first].emplace(op.second, conv);
+}
+
+std::vector<NodeConverterRegistry::Operator> NodeConverterRegistry::getSupportedOperators() const
+{
+  std::vector<Operator> ops;
+
+  for (const auto &op : _converter_map)
+  {
+    for (const auto &version : op.second)
+    {
+      // Get only supported operators
+      if (version.second != nullptr)
+      {
+        ops.push_back({op.first, version.first});
+      }
+    }
+  }
+
+  // Sort operators alphabetically for consistent output
+  std::sort(ops.begin(), ops.end(), [](const auto &op1, const auto &op2) {
+    return (op1.first == op2.first) ? (op1.second < op2.second) : (op1.first < op2.first);
+  });
+
+  return ops;
 }
 
 } // namespace mir_onnx

--- a/compiler/mir/src/mir_onnx_importer/ONNXNodeConverterRegistry.h
+++ b/compiler/mir/src/mir_onnx_importer/ONNXNodeConverterRegistry.h
@@ -60,17 +60,20 @@ private:
 class NodeConverterRegistry
 {
 public:
+  // @brief ONNX operator defined by its name and opset number.
+  using Operator = std::pair<std::string, unsigned int>;
   using ConverterFunc = void (*)(const onnx::NodeProto &onnx_node, ConverterContext *context);
 
   NodeConverterRegistry() = default;
 
-  ConverterFunc lookup(const std::string &optype, int64_t opset) const;
-  void registerConverter(const std::string &op_type, int64_t opset, ConverterFunc conv);
+  ConverterFunc lookup(const Operator &op) const;
+  void registerConverter(const Operator &op, ConverterFunc conv);
+  std::vector<Operator> getSupportedOperators() const;
 
   static NodeConverterRegistry &getInstance();
 
 private:
-  using VersionMap = std::map<int64_t, ConverterFunc>;
+  using VersionMap = std::map<unsigned int, ConverterFunc>;
 
   std::unordered_map<std::string, VersionMap> _converter_map;
 };

--- a/compiler/mir/src/mir_onnx_importer/ONNXNodeConverterRegistry.test.cpp
+++ b/compiler/mir/src/mir_onnx_importer/ONNXNodeConverterRegistry.test.cpp
@@ -30,10 +30,10 @@ class NodeConverterRegsitryTest : public ::testing::Test
 protected:
   void SetUp() override
   {
-    registry.registerConverter("dummy", 1, converterV1);
-    registry.registerConverter("dummy", 3, converterV3);
-    registry.registerConverter("dummy", 7, converterV7);
-    registry.registerConverter("dummy", firstUnknownOpset, nullptr);
+    registry.registerConverter({"dummy", 1}, converterV1);
+    registry.registerConverter({"dummy", 3}, converterV3);
+    registry.registerConverter({"dummy", 7}, converterV7);
+    registry.registerConverter({"dummy", firstUnknownOpset}, nullptr);
   }
 
   NodeConverterRegistry registry;
@@ -41,24 +41,31 @@ protected:
 
 TEST_F(NodeConverterRegsitryTest, existing_lookup_works)
 {
-  auto res = registry.lookup("dummy", 1);
+  auto res = registry.lookup({"dummy", 1});
   ASSERT_EQ(res, &converterV1);
 }
 
 TEST_F(NodeConverterRegsitryTest, skipped_lookup_works)
 {
-  auto res = registry.lookup("dummy", 2);
+  auto res = registry.lookup({"dummy", 2});
   ASSERT_EQ(res, &converterV1);
 }
 
 TEST_F(NodeConverterRegsitryTest, first_unknown_version_works)
 {
-  auto res = registry.lookup("dummy", 14);
+  auto res = registry.lookup({"dummy", 14});
   ASSERT_EQ(res, nullptr);
 }
 
 TEST_F(NodeConverterRegsitryTest, lower_than_first_version)
 {
-  auto res = registry.lookup("dummy", 0);
+  auto res = registry.lookup({"dummy", 0});
   ASSERT_EQ(res, nullptr);
+}
+
+TEST_F(NodeConverterRegsitryTest, registered_ops)
+{
+  auto res = registry.getSupportedOperators();
+  ASSERT_EQ(
+    res, std::vector<NodeConverterRegistry::Operator>({{"dummy", 1}, {"dummy", 3}, {"dummy", 7}}));
 }

--- a/compiler/mir/src/mir_onnx_importer/ONNXOpRegistration.h
+++ b/compiler/mir/src/mir_onnx_importer/ONNXOpRegistration.h
@@ -65,7 +65,7 @@ inline void registerSupportedOps()
 {
   auto &registry = NodeConverterRegistry::getInstance();
 
-#define REG_CONVERTER(name, version, function) registry.registerConverter(name, version, function)
+#define REG_CONVERTER(name, version, function) registry.registerConverter({name, version}, function)
 #define REG(name, version) REG_CONVERTER(#name, version, convert##name##V##version)
 #define UNSUPPORTED(name, version) REG_CONVERTER(#name, version, nullptr)
 

--- a/compiler/onnx2circle/src/onnx2circle.cpp
+++ b/compiler/onnx2circle/src/onnx2circle.cpp
@@ -65,6 +65,7 @@ struct LoggingContext
 void print_help()
 {
   std::cerr << "Usage: onnx2circle <path/to/onnx> <path/to/circle/model> " << std::endl;
+  std::cerr << "       onnx2circle --list-operators" << std::endl;
 }
 
 } // namespace
@@ -82,6 +83,13 @@ int main(int argc, char **argv)
   exo::LoggingContext::get()->config(std::make_unique<EnvConfig>("ONNX2CIRCLE_Log_Backend"));
 
   LOGGER(l);
+
+  if (argc == 2 && std::string(argv[1]) == "--list-operators")
+  {
+    for (const auto &op : mir_onnx::getSupportedOperators())
+      std::cout << op << std::endl;
+    return 0;
+  }
 
   // TODO We need better args parsing in future
   if (!(argc == 3))


### PR DESCRIPTION
This commit adds `--list-operators` option to the `onnx2circle` tool which lists all supported ONNX operators with their opset numbers. Such list should help in ONNX model operators conversion in case when converted model uses not supported operators versions.

```console
$ onnx2circle --list-operators
AveragePool-1
AveragePool-7
AveragePool-10
Conv-1
...
MaxPool-1
MaxPool-8
MaxPool-10
...
```

```console
$ onnx2circle model.onnx model.circle
The following operators are not supported:
Conv-11
MaxPool-11
Resize-11
```