### PR TITLE
[circle-mlir/infra] Discard output from the `cd` command

### DIFF
--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -34,7 +34,7 @@ fi
 
 set -e
 
-DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 if [[ -z "$VENV_NAME" ]]; then
   VENV_NAME="venv"
 fi

--- a/circle-mlir/infra/tools/gen-coverage-report
+++ b/circle-mlir/infra/tools/gen-coverage-report
@@ -6,7 +6,7 @@
 #   COVERAGE_PATH  : path where coverage report is generated,
 #                    default is ${PROJECT_PATH}/${COVERAGE_RPATH}
 
-PROJECT_PATH="$(cd $(dirname ${BASH_SOURCE[0]})/../.. && pwd)"
+PROJECT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)"
 
 # Set BUILD_WORKSPACE_RPATH with default 'build/coverage' if not set
 BUILD_WORKSPACE_RPATH="${BUILD_WORKSPACE_RPATH:-build/coverage}"


### PR DESCRIPTION
This commit fixes the issue when `cd` is followed by the `pwd` in a bash one-liner for getting the location of the script. The `cd` command can print the destination directory in case when one has the `CDPATH` environmental variable set which breaks the one-liner functionality.