### PR TITLE
[circle-mlir/infra] Bump h5py to 3.12.1 for Python 3.13 support

### DIFF
--- a/circle-mlir/infra/docker/focal/Dockerfile
+++ b/circle-mlir/infra/docker/focal/Dockerfile
@@ -32,6 +32,7 @@ ARG VER_TORCH=2.7.0+cpu
 ARG VER_ONNX=1.18.0
 ARG VER_ONNXRUNTIME=1.21.1
 ARG VER_NUMPY=1.26.4
+ARG VER_H5PY=3.12.1
 
 # Clean archives (to reduce image size)
 RUN apt-get clean -y
@@ -60,7 +61,7 @@ RUN ${WORK_DIR}/venv/bin/python3 -m pip install --upgrade pip setuptools
 RUN ${WORK_DIR}/venv/bin/python3 -m pip install numpy==${VER_NUMPY} torch==${VER_TORCH} \
     -f https://download.pytorch.org/whl/torch
 RUN ${WORK_DIR}/venv/bin/python3 -m pip install onnx==${VER_ONNX} onnxruntime==${VER_ONNXRUNTIME} \
-    h5py==3.8.0 einops
+    h5py==${VER_H5PY} einops
 
 # Download experimental patch file for onnx-mlir
 

--- a/circle-mlir/infra/docker/jammy/Dockerfile
+++ b/circle-mlir/infra/docker/jammy/Dockerfile
@@ -29,6 +29,7 @@ ARG VER_TORCH=2.7.0+cpu
 ARG VER_ONNX=1.18.0
 ARG VER_ONNXRUNTIME=1.21.1
 ARG VER_NUMPY=1.26.4
+ARG VER_H5PY=3.12.1
 
 # Clean archives (to reduce image size)
 RUN apt-get clean -y
@@ -52,7 +53,7 @@ RUN ${WORK_DIR}/venv/bin/python3 -m pip install --upgrade pip setuptools
 RUN ${WORK_DIR}/venv/bin/python3 -m pip install numpy==${VER_NUMPY} torch==${VER_TORCH} \
     -f https://download.pytorch.org/whl/torch
 RUN ${WORK_DIR}/venv/bin/python3 -m pip install onnx==${VER_ONNX} onnxruntime==${VER_ONNXRUNTIME} \
-    h5py==3.8.0 einops
+    h5py==${VER_H5PY} einops
 
 # Download experimental patch file for onnx-mlir
 

--- a/circle-mlir/infra/docker/noble/Dockerfile
+++ b/circle-mlir/infra/docker/noble/Dockerfile
@@ -29,6 +29,7 @@ ARG VER_TORCH=2.7.0+cpu
 ARG VER_ONNX=1.18.0
 ARG VER_ONNXRUNTIME=1.21.1
 ARG VER_NUMPY=1.26.4
+ARG VER_H5PY=3.12.1
 
 # Clean archives (to reduce image size)
 RUN apt-get clean -y
@@ -52,7 +53,7 @@ RUN ${WORK_DIR}/venv/bin/python3 -m pip install --upgrade pip setuptools
 RUN ${WORK_DIR}/venv/bin/python3 -m pip install numpy==${VER_NUMPY} torch==${VER_TORCH} \
     -f https://download.pytorch.org/whl/torch
 RUN ${WORK_DIR}/venv/bin/python3 -m pip install onnx==${VER_ONNX} onnxruntime==${VER_ONNXRUNTIME} \
-    h5py==3.8.0 einops
+    h5py==${VER_H5PY} einops
 
 # Download experimental patch file for onnx-mlir
 

--- a/circle-mlir/infra/overlay/prepare-venv
+++ b/circle-mlir/infra/overlay/prepare-venv
@@ -20,7 +20,7 @@
 # use +e as python3.10 may not exist in the system and 'command' will return error.
 set +e
 
-PYTHON_CANDIDATES=("python3.12" "python3.10" "python3")
+PYTHON_CANDIDATES=("python3.13" "python3.12" "python3.10" "python3")
 for py in "${PYTHON_CANDIDATES[@]}"; do
   PYTHON3_EXEC=$(command -v "$py")
   if [[ -n "${PYTHON3_EXEC}" ]]; then
@@ -56,6 +56,7 @@ VER_TORCH=2.7.0+cpu
 VER_ONNX=1.18.0
 VER_ONNXRUNTIME=1.21.1
 VER_NUMPY=1.26.4
+VER_H5PY=3.12.1
 
 PYTHON_VERSION=$($VENV_PYTHON -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
 echo "python3 version is $PYTHON_VERSION"
@@ -65,6 +66,9 @@ if [[ "$PYTHON_VERSION" == "3.10" ]]; then
   : # use as is
 elif [[ "$PYTHON_VERSION" == "3.12" ]]; then
   # Ubuntu 24.04 is python3.12
+  : # use as is
+elif [[ "$PYTHON_VERSION" == "3.13" ]]; then
+  # Ubuntu 25.04 is python3.13
   : # use as is
 else
   echo "Error prepare-venv: Unsupported python version: $PYTHON_VERSION"
@@ -90,7 +94,7 @@ fi
 PYTHON_PACKAGES="torch==${VER_TORCH} "
 PYTHON_PACKAGES+="onnx==${VER_ONNX} "
 PYTHON_PACKAGES+="onnxruntime==${VER_ONNXRUNTIME} "
-PYTHON_PACKAGES+="h5py==3.8.0 "
+PYTHON_PACKAGES+="h5py==${VER_H5PY} "
 PYTHON_PACKAGES+="einops "
 PYTHON_PACKAGES+="numpy==${VER_NUMPY} "
 


### PR DESCRIPTION
This commit bumps h5py package to version 3.12.1. This is the first version which supports Python 3.13.

Changes has been tested with upgraded ONNX-MLIR and LLVM in order to compile with GCC 15.2.0 which is the default compiler on Ubuntu 25.04. Used tags for these projects:

GIT_TAG_ONNXMLIR: 8524104871c9a5c23973753e0f99ea8b42e3c943
GIT_TAG_LLVMPROJ: 0c2701fe7fa002e1befc5f86c268a7964f96d286

Also, I've verified that it is possible to setup `circle-mlir/infra/docker/{jammy,noble}` Docker images. The `focal` seems to be broken in the current master (the step `apt-get -qqy install python3.10 python3.10-venv python3.10-dev dh-python` does not work), so I was not able to test it, but considering that jammy and noble are OK, it should also be OK.