### PR TITLE
[circledump] Fix compilation on GCC 15.2.0

### DIFF
--- a/compiler/circledump/src/MetadataPrinter.h
+++ b/compiler/circledump/src/MetadataPrinter.h
@@ -17,6 +17,7 @@
 #ifndef __CIRCLEDUMP_METADATA_PRINTER_H__
 #define __CIRCLEDUMP_METADATA_PRINTER_H__
 
+#include <cstdint>
 #include <ostream>
 #include <string>
 #include <map>


### PR DESCRIPTION
This commit adds <cstdint> to fix compilation error on GCC 15.2.0 on Ubuntu 25.10:

> In file included from ../../../compiler/circledump/src/MetadataPrinter.cpp:17:
> ../../../compiler/circledump/src/MetadataPrinter.h:32:28: error: ‘uint8_t’ does not name a type
>   32 |   virtual void print(const uint8_t * /* buffer */, std::ostream &) const = 0;