### PR TITLE
[nnkit] Clean up requires.cmake

### DIFF
--- a/compiler/nnkit/requires.cmake
+++ b/compiler/nnkit/requires.cmake
@@ -1,8 +1,3 @@
 require("angkor")
 require("nnkit-intf")
 require("nnkit-misc")
-require("nnkit-caffe")
-require("nnkit-tflite")
-require("nnkit-tf")
-require("nnkit-mocotf")
-require("nnkit-onnxrt")


### PR DESCRIPTION
This commit removes backend dependencies (caffe, tflite, tf, mocotf, onnxrt) from the nnkit requires.cmake configuration.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>