### PR TITLE
[github] Use month-based key for ccache cache

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -92,12 +92,16 @@ jobs:
           path: ${{ env.NNCC_WORKSPACE }}/overlay
           key: overlay-onecc-${{ matrix.ubuntu_code }}-${{ hashFiles('compiler/common-artifacts/CMakeLists.txt') }}-${{ hashFiles('infra/cmake/packages/**/*.cmake') }}
 
+      - name: Get month for ccache cache key
+        id: get-month
+        run: echo "key_month=$(date +%y%m)" >> "$GITHUB_OUTPUT"
+
       - name: Restore ccache cache
         uses: actions/cache/restore@v4
         id: ccache-cache
         with:
           path: ~/.cache/ccache
-          key: ccache-onecc-${{ matrix.ubuntu_code }}-${{ matrix.type }}-${{ github.sha }}
+          key: ccache-onecc-${{ matrix.ubuntu_code }}-${{ matrix.type }}-${{ steps.get-month.outputs.key_month }}
           restore-keys: |
             ccache-onecc-${{ matrix.ubuntu_code }}-${{ matrix.type }}
 

--- a/.github/workflows/run-onert-android-build.yml
+++ b/.github/workflows/run-onert-android-build.yml
@@ -72,12 +72,16 @@ jobs:
           restore-keys: |
             external-onert-ndk-
 
+      - name: Get month for ccache cache key
+        id: get-month
+        run: echo "key_month=$(date +%y%m)" >> "$GITHUB_OUTPUT"
+
       - name: Restore ccache cache
         uses: actions/cache/restore@v4
         id: cache-ccache
         with:
           path: ~/.cache/ccache
-          key: ccache-onert-android-${{ github.sha }}
+          key: ccache-onert-android-${{ steps.get-month.outputs.key_month }}
           restore-keys: |
             ccache-onert-android
 

--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -80,12 +80,16 @@ jobs:
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
 
+      - name: Get month for ccache cache key
+        id: get-month
+        run: echo "key_month=$(date +%y%m)" >> "$GITHUB_OUTPUT"
+
       - name: Restore ccache cache
         uses: actions/cache/restore@v4
         id: ccache-cache
         with:
           path: ~/.cache/ccache
-          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}-${{ github.sha }}
+          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}-${{ steps.get-month.outputs.key_month }}
           restore-keys: |
             ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}
 

--- a/.github/workflows/run-onert-native-build.yml
+++ b/.github/workflows/run-onert-native-build.yml
@@ -83,12 +83,16 @@ jobs:
           restore-keys: |
             external-onert-${{ matrix.ubuntu_code }}-
 
+      - name: Get month for ccache cache key
+        id: get-month
+        run: echo "key_month=$(date +%y%m)" >> "$GITHUB_OUTPUT"
+
       - name: Restore ccache cache
         uses: actions/cache/restore@v4
         id: ccache-cache
         with:
           path: ~/.cache/ccache
-          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}-${{ github.sha }}
+          key: ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}-${{ steps.get-month.outputs.key_month }}
           restore-keys: |
             ccache-onert-${{ matrix.ubuntu_code }}-${{ matrix.arch }}-${{ matrix.type }}
 


### PR DESCRIPTION
This commit updates gitHub workflow ccache cache keys to use month-based (YYMM) identifiers instead of unique commit SHA. 
This will reduce cache updates to montly and remove duplicated cache storages for same workflow.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>