### PR TITLE
[infra] Use github-hosted runner for onecc

### DIFF
--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -48,9 +48,9 @@ jobs:
         # TODO enable focal when possible
         #      refer https://github.com/Samsung/ONE/issues/16196
         ubuntu_code: ['jammy', 'noble']
-    runs-on: one-x64-linux
+    runs-on: ubuntu-latest
     container:
-      image: samsungonedev.azurecr.io/nnfw/one-devtools:${{ matrix.ubuntu_code }}
+      image: nnfw/one-devtools:${{ matrix.ubuntu_code }}
       options: --user root
     env:
       NNCC_WORKSPACE : build


### PR DESCRIPTION
This commit uses github-hosted runner instead of self-hosted runner for onecc build test.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>