### PR TITLE
[infra] Update actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/build-dev-docker.yml
+++ b/.github/workflows/build-dev-docker.yml
@@ -50,7 +50,7 @@ jobs:
         version: ${{ fromJSON(needs.filtering.outputs.ubuntu-target) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build Docker Image
         run: |
@@ -87,7 +87,7 @@ jobs:
     runs-on: one-x64-linux
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/build-pub-dev-docker.yml
+++ b/.github/workflows/build-pub-dev-docker.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore onecc external cache
         uses: actions/cache/restore@v4
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore onecc external cache
         uses: actions/cache/restore@v4
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore onecc external cache
         uses: actions/cache/restore@v4
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore onecc external cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history and branch (default: 1)
           # Require all history to get file creation date

--- a/.github/workflows/check-pr-commit.yml
+++ b/.github/workflows/check-pr-commit.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Checkout PR head commit
           # Checkout Action use merge commit as default

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Generate HTML'
         uses: mattnotmitt/doxygen-action@v1.9
         with:

--- a/.github/workflows/generate-rootfs.yml
+++ b/.github/workflows/generate-rootfs.yml
@@ -44,7 +44,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y debootstrap
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate RootFS
         run: |

--- a/.github/workflows/pub-circle-int-launchpad.yml
+++ b/.github/workflows/pub-circle-int-launchpad.yml
@@ -98,7 +98,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build without test
         run: |
@@ -221,7 +221,7 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Git
         run: |

--- a/.github/workflows/pub-onert-pypi.yml
+++ b/.github/workflows/pub-onert-pypi.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore externals cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/pub-onnx2circle-launchpad.yml
+++ b/.github/workflows/pub-onnx2circle-launchpad.yml
@@ -101,7 +101,7 @@ jobs:
           apt install circle-interpreter
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # NOTE Docker image has pre-installed submodules in /workdir
       # NOTE Docker image has pre-installed python packages
@@ -226,7 +226,7 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Git
         run: |

--- a/.github/workflows/pub-tools-mec-pypi.yml
+++ b/.github/workflows/pub-tools-mec-pypi.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/run-circle-mlir-build.yml
+++ b/.github/workflows/run-circle-mlir-build.yml
@@ -79,7 +79,7 @@ jobs:
           apt install circle-interpreter
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # NOTE Docker image has pre-installed submodules in /workdir
       # NOTE Docker image has pre-installed python packages

--- a/.github/workflows/run-onecc-build.yml
+++ b/.github/workflows/run-onecc-build.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install onnx2circle
         run: |

--- a/.github/workflows/run-onert-android-build.yml
+++ b/.github/workflows/run-onert-android-build.yml
@@ -53,7 +53,7 @@ jobs:
       BUILD_TYPE: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore onecc external cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/run-onert-cross-build.yml
+++ b/.github/workflows/run-onert-cross-build.yml
@@ -62,7 +62,7 @@ jobs:
       OPTIONS: "-DBUILD_ARMCOMPUTE=OFF" # Disable arm compute library
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore onecc external cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/run-onert-gbs-build.yml
+++ b/.github/workflows/run-onert-gbs-build.yml
@@ -66,7 +66,7 @@ jobs:
           sudo apt-get update && sudo apt-get -qqy install gbs
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Caching GBS repository
         uses: actions/cache@v4

--- a/.github/workflows/run-onert-micro-unit-tests.yml
+++ b/.github/workflows/run-onert-micro-unit-tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Checkout PR head commit
           # Checkout Action use merge commit as default

--- a/.github/workflows/run-onert-native-build.yml
+++ b/.github/workflows/run-onert-native-build.yml
@@ -64,7 +64,7 @@ jobs:
       OPTIONS: "-DBUILD_ARMCOMPUTE=OFF" # Disable arm compute library
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore onecc external cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/run-tools-mec-build.yml
+++ b/.github/workflows/run-tools-mec-build.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5

--- a/.github/workflows/run-tools-onnx-subgr-build.yml
+++ b/.github/workflows/run-tools-onnx-subgr-build.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure
         run: |


### PR DESCRIPTION
This commit updates actions/checkout across all GitHub Actions workflow files to use the latest v6 version.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>