### PR TITLE
[compiler] Fix exception throw in the deprecated code

### DIFF
--- a/compiler/_deprecated/mir2loco/src/mir2loco.cpp
+++ b/compiler/_deprecated/mir2loco/src/mir2loco.cpp
@@ -395,7 +395,7 @@ void Transformer::visit(mir::ops::ConstantOp &op)
       break;
     }
     default:
-      std::runtime_error("Unsupported data type");
+      throw std::runtime_error("Unsupported data type");
   }
   // Add to map
   _mir2loco_map.emplace(op.getOutput(0), const_node);


### PR DESCRIPTION
This commit fixes a typo causing the exception not being thrown.

It is the last PR in a series to fix all occurrences of missing `throw` when runtime exception should be thrown: `git grep '  std::runtime_error'`.