### PR TITLE
[circle-mlir] Build without installing test dependencies

### DIFF
--- a/circle-mlir/CMakeLists.txt
+++ b/circle-mlir/CMakeLists.txt
@@ -23,16 +23,16 @@ endif()
 # configuration flags
 include(CfgOptionFlags)
 
-# enable test coverage
+# setup test coverage
 include(TestCoverage)
 
-# enable ctest
-include(CTest)
-
-# enable googletest but do not install
-set(INSTALL_GTEST OFF)
-include(GTestHelper)
-include(GoogleTest)
+if(ENABLE_TEST)
+  include(CTest)
+  # enable googletest but do not install
+  set(INSTALL_GTEST OFF)
+  include(GTestHelper)
+  include(GoogleTest)
+endif()
 
 # to override externals install
 if(DEFINED ENV{CIRCLE_MLIR_LOCALINST})

--- a/circle-mlir/circle-mlir/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/CMakeLists.txt
@@ -3,4 +3,6 @@ include(UseAbseil)
 
 add_subdirectory(lib)
 add_subdirectory(tools)
-add_subdirectory(tools-test)
+if(ENABLE_TEST)
+  add_subdirectory(tools-test)
+endif()


### PR DESCRIPTION
This commit wraps GoogleTest installation with `ENABLE_TEST` which adds possibility to build `onnx2circle` without test dependencies.

#### Testing

Verified that build with `-DENABLE_TEST=OFF -DENABLE_COVERAGE=OFF` works as expected.