### PR TITLE
[circle-mlir] Bump circle schema to 0.10

### DIFF
--- a/circle-mlir/circle-mlir/lib/schema/CMakeLists.txt
+++ b/circle-mlir/circle-mlir/lib/schema/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(UseFlatbuffers)
 
-set(SCHEMA_FILE "${RES_CIRCLE_SCHEMA}/0.9/circle_schema.fbs")
+set(SCHEMA_FILE "${RES_CIRCLE_SCHEMA}/0.10/circle_schema.fbs")
 set(SCHEMA_TARGET "${CMAKE_CURRENT_BINARY_DIR}/schema.fbs")
 
 add_custom_command(OUTPUT "${SCHEMA_TARGET}"


### PR DESCRIPTION
This commit bumps used circle schema to 0.10 which is based on TF Lite 2.20.0 and adds ATTENTION and RUN_MODEL operators.